### PR TITLE
cpufreq/cppc: Don't compare desired_perf in target()

### DIFF
--- a/drivers/cpufreq/cppc_cpufreq.c
+++ b/drivers/cpufreq/cppc_cpufreq.c
@@ -291,15 +291,10 @@ static int cppc_cpufreq_set_target(struct cpufreq_policy *policy,
 	struct cppc_cpudata *cpu_data = policy->driver_data;
 	unsigned int cpu = policy->cpu;
 	struct cpufreq_freqs freqs;
-	u32 desired_perf;
 	int ret = 0;
 
-	desired_perf = cppc_khz_to_perf(&cpu_data->perf_caps, target_freq);
-	/* Return if it is exactly the same perf */
-	if (desired_perf == cpu_data->perf_ctrls.desired_perf)
-		return ret;
-
-	cpu_data->perf_ctrls.desired_perf = desired_perf;
+	cpu_data->perf_ctrls.desired_perf =
+			cppc_khz_to_perf(&cpu_data->perf_caps, target_freq);
 	freqs.old = policy->cur;
 	freqs.new = target_freq;
 


### PR DESCRIPTION
There is a corner case where the desired_perf is exactly same as the old perf, but the actual current freq is not.

This happens during S3 while the cpufreq governor is set to powersave. During cpufreq resume process, the booting CPU's new_freq obtained via .get() is the highest frequency, while the policy->cur and cpu->perf_ctrls.desired_perf are set to the lowest level (powersave governor). This causes the warning: "CPU frequency out of sync:", and the cpufreq core sets policy->cur to new_freq.

Then the governor->limits() calls cppc_cpufreq_set_target() to configures the CPU frequency and returns directly because the desired_perf converted from target_freq is same as the cpu->perf_ctrls.desired_perf and both are the lowest_perf.

Since target_freq and policy->cur have been already compared in __cpufreq_driver_target(), there's no need to compare them again here.

Drop the comparison.


[ Viresh: Updated commit message / subject ]

(cherry picked from commit 90e4ed6bb02ad93663f17411d17e8e714a765a6b)