### PR TITLE
Integrate vCMDQ 4k kernel fixes

### DIFF
--- a/drivers/iommu/arm/arm-smmu-v3/tegra241-cmdqv.c
+++ b/drivers/iommu/arm/arm-smmu-v3/tegra241-cmdqv.c
@@ -559,7 +559,8 @@ static int tegra241_vcmdq_alloc_smmu_cmdq(struct tegra241_vcmdq *vcmdq)
 
 	snprintf(name, 16, "vcmdq%u", vcmdq->idx);
 
-	q->llq.max_n_shift = VCMDQ_LOG2SIZE_MAX;
+	/* Queue size, capped to ensure natural alignment */
+	q->llq.max_n_shift = min_t(u32, CMDQ_MAX_SZ_SHIFT, VCMDQ_LOG2SIZE_MAX);
 
 	/* Use the common helper to init the VCMDQ, and then... */
 	ret = arm_smmu_init_one_queue(smmu, q, vcmdq->page0,

--- a/drivers/iommu/iommufd/main.c
+++ b/drivers/iommu/iommufd/main.c
@@ -417,9 +417,6 @@ static int iommufd_fops_mmap(struct file *filp, struct vm_area_struct *vma)
 	unsigned long pfn;
 	int rc;
 
-	if (size > PAGE_SIZE)
-		return -EINVAL;
-
 	viommu = container_of(iommufd_get_object(ictx, viommu_id,
 						 IOMMUFD_OBJ_VIOMMU),
 			      struct iommufd_viommu, obj);


### PR DESCRIPTION
Small series of patches to support Grace I/O virtualization. Tested on CG1 and CG4.

To test the 4k vCMDQ patches, I booted the host with the 4k tech preview kernel + both patches, reserved 16 1G hugepages and launched a VM backed by the hugepages (required for vCMDQ) with a Hopper GPU passed through and vCMDQ active. The guest VM tech preview kernel included the alignment patch and I tested with both the 4k and 64k page size. The actual test was to run nvidia-smi, Gflops, texture_simple, and ats_malloc_host with nvidia-persistenced on and off. The success criteria is for all of these to execute successfully without any errors or unknown kernel log messages. All tests passed.