### PR TITLE
Integrate EGM fixes + sysfs linkage required for libvirt

### DIFF
--- a/drivers/vfio/pci/nvgrace-gpu/egm.c
+++ b/drivers/vfio/pci/nvgrace-gpu/egm.c
@@ -295,11 +295,13 @@ nvgrace_gpu_fetch_egm_property(struct pci_dev *pdev, u64 *pegmphys,
 
 	ret = device_property_read_u64(&pdev->dev, "nvidia,egm-pxm",
 				       pegmpxm);
+	if (ret)
+		return ret;
 
 	if (overflows_type(*pegmpxm, int))
 		return -EOVERFLOW;
 
-	return ret;
+	return 0;
 }
 
 static void nvgrace_egm_fetch_bad_pages(struct pci_dev *pdev,

--- a/drivers/vfio/pci/nvgrace-gpu/egm.c
+++ b/drivers/vfio/pci/nvgrace-gpu/egm.c
@@ -359,6 +359,9 @@ int register_egm_node(struct pci_dev *pdev)
 	}
 
 	region = kvzalloc(sizeof(*region), GFP_KERNEL);
+	if (!region)
+		return -ENOMEM;
+
 	region->egmphys = egmphys;
 	region->egmlength = egmlength;
 	region->egmpxm = egmpxm;
@@ -368,11 +371,16 @@ int register_egm_node(struct pci_dev *pdev)
 
 	nvgrace_egm_fetch_bad_pages(pdev, region);
 
+	ret = setup_egm_chardev(region);
+	if (ret)
+		goto err;
+
 	list_add_tail(&region->list, &egm_list);
 
-	setup_egm_chardev(region);
-
 	return 0;
+err:
+	kfree(region);
+	return ret;
 }
 EXPORT_SYMBOL_GPL(register_egm_node);
 

--- a/drivers/vfio/pci/nvgrace-gpu/egm.c
+++ b/drivers/vfio/pci/nvgrace-gpu/egm.c
@@ -324,8 +324,6 @@ static void nvgrace_egm_fetch_bad_pages(struct pci_dev *pdev,
 
 	count = *(u64 *)memaddr;
 
-	hash_init(region->htbl);
-
 	for (index = 0; index < count; index++) {
 		struct h_node *retired_page;
 
@@ -365,6 +363,7 @@ int register_egm_node(struct pci_dev *pdev)
 	region->egmlength = egmlength;
 	region->egmpxm = egmpxm;
 
+	hash_init(region->htbl);
 	atomic_set(&region->open_count, 0);
 
 	nvgrace_egm_fetch_bad_pages(pdev, region);

--- a/drivers/vfio/pci/nvgrace-gpu/egm.c
+++ b/drivers/vfio/pci/nvgrace-gpu/egm.c
@@ -398,6 +398,7 @@ void unregister_egm_node(int egm_node)
 
 			destroy_egm_chardev(region);
 			list_del(&region->list);
+			kfree(region);
 		}
 	}
 }

--- a/drivers/vfio/pci/nvgrace-gpu/egm.c
+++ b/drivers/vfio/pci/nvgrace-gpu/egm.c
@@ -316,6 +316,10 @@ static void nvgrace_egm_fetch_bad_pages(struct pci_dev *pdev,
 				     &retiredpagesphys))
 		return;
 
+	/* Catch firmware bug and avoid a crash */
+	if (WARN_ON_ONCE(retiredpagesphys == 0))
+		return;
+
 	memaddr = memremap(retiredpagesphys, PAGE_SIZE, MEMREMAP_WB);
 	if (!memaddr)
 		return;

--- a/drivers/vfio/pci/nvgrace-gpu/egm.c
+++ b/drivers/vfio/pci/nvgrace-gpu/egm.c
@@ -188,6 +188,7 @@ static long nvgrace_egm_ioctl(struct file *file, unsigned int cmd, unsigned long
 
 	switch (cmd) {
 	case EGM_BAD_PAGES_LIST:
+	{
 		int ret;
 		unsigned long bad_page_struct_size = sizeof(struct egm_bad_pages_info);
 		struct egm_bad_pages_info tmp;
@@ -230,6 +231,7 @@ static long nvgrace_egm_ioctl(struct file *file, unsigned int cmd, unsigned long
 			info.count = index;
 		}
 		break;
+	}
 	default:
 		return -EINVAL;
 	}

--- a/drivers/vfio/pci/nvgrace-gpu/main.c
+++ b/drivers/vfio/pci/nvgrace-gpu/main.c
@@ -1121,6 +1121,7 @@ static void nvgrace_gpu_remove(struct pci_dev *pdev)
 	struct h_node *cur;
 	unsigned long bkt;
 	struct hlist_node *tmp_node;
+
 	hash_for_each_safe(nvdev->resmem.htbl, bkt, tmp_node, cur, node) {
 		hash_del(&cur->node);
 		vfree(cur);

--- a/drivers/vfio/pci/nvgrace-gpu/main.c
+++ b/drivers/vfio/pci/nvgrace-gpu/main.c
@@ -874,7 +874,7 @@ nvgrace_gpu_fetch_memory_property(struct pci_dev *pdev,
 	if (ret)
 		return ret;
 
-	if (*pmemphys > type_max(phys_addr_t))
+	if (overflows_type(*pmemphys, phys_addr_t))
 		return -EOVERFLOW;
 
 	ret = device_property_read_u64(&pdev->dev, "nvidia,gpu-mem-size",
@@ -882,7 +882,7 @@ nvgrace_gpu_fetch_memory_property(struct pci_dev *pdev,
 	if (ret)
 		return ret;
 
-	if (*pmemlength > type_max(size_t))
+	if (overflows_type(*pmemlength, size_t))
 		return -EOVERFLOW;
 
 	/*


### PR DESCRIPTION
Small series of patches to support vEGM with libvirt. Tested on CG1 and CG4.

To regression test the EGM patches, I booted the host with the 4k and 64k tech preview kernel + patches, and launched a VM backed by the EGM character device. The guest VM ran the same tech preview kernel used for the vCMDQ tests in [PR 32](https://github.com/NVIDIA/NV-Kernels/pull/32) and I tested with both 4k/64k and the same tests and success criteria. All tests passed.

To test the sysfs linkage patch, with EGM configured on the host, I verified the presence of the PCI dev -> EGM chardev and EGM chardev -> PCI dev links, their removal upon unconfiguring the device, and their recreation when configuring the device again.

The memory free, registration error handling, and invalid retired pages base patches were unit tested with scaffolding while being developed. Specifically, the retired pages base patch was added because I happened to initially be using a system that had an invalid firmware image that was presenting that node but without an address.