### PR TITLE
NVIDIA: SAUCE: PCI: Use downstream bridges for distributing resources 24.04_linux-nvidia-internal-6.11-next

### DIFF
--- a/drivers/pci/setup-bus.c
+++ b/drivers/pci/setup-bus.c
@@ -2105,8 +2105,7 @@ pci_root_bus_distribute_available_resources(struct pci_bus *bus,
 		 * in case of root bus.
 		 */
 		if (bridge && pci_bridge_resources_not_assigned(dev))
-			pci_bridge_distribute_available_resources(bridge,
-								  add_list);
+			pci_bridge_distribute_available_resources(dev, add_list);
 		else
 			pci_root_bus_distribute_available_resources(b, add_list);
 	}


### PR DESCRIPTION
NVBUG: https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/4868471
BugLink: https://bugs.launchpad.net/bugs/2094821

Systems with BF3 switch will hit error where some BAR are not getting assigned.

Lore discussion: https://lore.kernel.org/all/20241204022457.51322-1-kaihengf@nvidia.com/
Without patch we need to use kernel parameter pci=realloc to workaround the issue.

Patch needed for internal tech preview