### PR TITLE
efi/libstub: Bump up EFI_MMAP_NR_SLACK_SLOTS to 32 (for 6.11 adv)

### DIFF
--- a/drivers/firmware/efi/libstub/efistub.h
+++ b/drivers/firmware/efi/libstub/efistub.h
@@ -171,7 +171,7 @@ void efi_set_u64_split(u64 data, u32 *lo, u32 *hi)
  * the EFI memory map. Other related structures, e.g. x86 e820ext, need
  * to factor in this headroom requirement as well.
  */
-#define EFI_MMAP_NR_SLACK_SLOTS	8
+#define EFI_MMAP_NR_SLACK_SLOTS	32
 
 typedef struct efi_generic_dev_path efi_device_path_protocol_t;
 

--- a/drivers/firmware/efi/libstub/efistub.h
+++ b/drivers/firmware/efi/libstub/efistub.h
@@ -171,7 +171,7 @@ void efi_set_u64_split(u64 data, u32 *lo, u32 *hi)
  * the EFI memory map. Other related structures, e.g. x86 e820ext, need
  * to factor in this headroom requirement as well.
  */
-#define EFI_MMAP_NR_SLACK_SLOTS	16
+#define EFI_MMAP_NR_SLACK_SLOTS	8
 
 typedef struct efi_generic_dev_path efi_device_path_protocol_t;
 


### PR DESCRIPTION
Customer is seeing this:
we still see Linux EFI stub failed to boot with this error:

EFI stub: Booting Linux Kernel...
EFI stub: Using DTB from configuration table
EFI stub: Exiting boot services...
EFI stub: ERROR: Exit boot services failed.

This failure won't occur when we add the kernel commandline parameter efi=disable_early_pci_dma

The linux-nvidia kernel has a SAUCE patch to increment this value from 8 to 16 but 16 is not enough for this customer. There is an official upstream patch that will bump this value to 32.

From ec46969 Mon Sep 17 00:00:00 2001
From: Hamza Mahfooz hamzamahfooz@linux.microsoft.com
Date: Mon, 9 Dec 2024 13:20:39 -0500
Subject: efi/libstub: Bump up EFI_MMAP_NR_SLACK_SLOTS to 32

LaunchPad:https://bugs.launchpad.net/ubuntu/+source/linux-nvidia/+bug/2102674
Nvbug:https://nvbugspro.nvidia.com/bug/5156028
