### PR TITLE
NVIDIA: [Packaging] Take out the sbsa_gwdt from the blacklist

### DIFF
--- a/debian/rules.d/2-binary-arch.mk
+++ b/debian/rules.d/2-binary-arch.mk
@@ -184,6 +184,7 @@ endif
 		>>$(pkgdir)/lib/modprobe.d/blacklist_$(src_pkg_name)_$(abi_release)-$*.conf
 	ls -1 $(pkgdir)/lib/modules/$(abi_release)-$*/kernel/drivers/watchdog/ | \
 		grep -v '^bcm2835_wdt$$' | \
+		grep -v '^sbsa_gwdt*' | \
 		sed -e 's/^/blacklist /' -e 's/.ko$$//' | \
 		sort -u \
 		>>$(pkgdir)/lib/modprobe.d/blacklist_$(src_pkg_name)_$(abi_release)-$*.conf


### PR DESCRIPTION
BugLink: https://bugs.launchpad.net/bugs/2109635

Take out the sbsa_gwdt from the blacklist for nvidia kernel.

grep sbsa_gwdt /lib/modprobe.d/*
/lib/modprobe.d/blacklist_linux_6.8.0-58-generic.conf:blacklist sbsa_gwdt
/lib/modprobe.d/blacklist_linux-nvidia-6.11_6.11.0-1006-nvidia-64k.conf:blacklist sbsa_gwdt
/lib/modprobe.d/blacklist_linux-nvidia_6.8.0-1026-nvidia-64k.conf:blacklist sbsa_gwdt

Jira: https://jirasw.nvidia.com/browse/DGX-12485
Nvbugs: https://nvbugspro.nvidia.com/bug/5180162
 https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/5245152