### PR TITLE
i2c: tegra: check msg length in SMBUS block read (6.11 adv)

### DIFF
--- a/drivers/i2c/busses/i2c-tegra.c
+++ b/drivers/i2c/busses/i2c-tegra.c
@@ -1395,6 +1395,11 @@ static int tegra_i2c_xfer(struct i2c_adapter *adap, struct i2c_msg msgs[],
 			ret = tegra_i2c_xfer_msg(i2c_dev, &msgs[i], MSG_END_CONTINUE);
 			if (ret)
 				break;
+
+			/* Validate message length before proceeding */
+			if (msgs[i].buf[0] == 0 || msgs[i].buf[0] > I2C_SMBUS_BLOCK_MAX)
+				break;
+
 			/* Set the msg length from first byte */
 			msgs[i].len += msgs[i].buf[0];
 			dev_dbg(i2c_dev->dev, "reading %d bytes\n", msgs[i].len);


### PR DESCRIPTION
For SMBUS block read, do not continue to read if the message length passed from the device is '0' or greater than the maximum allowed bytes.


Acked-by: Thierry Reding <treding@nvidia.com>
Link: https://lore.kernel.org/r/20250424053320.19211-1-akhilrajeev@nvidia.com

(cherry picked from commit 17ffd5154a03fcec9ce1ff4ff5e604235a91f985 linux-next)

Launchpad:https://bugs.launchpad.net/ubuntu/+source/linux-nvidia/+bug/2109750
Nvbug: https://nvbugspro.nvidia.com/bug/5115227