### PR TITLE
[nvidia-6.8] Fix "KVM: arm64: Don't eagerly teardown the vgic on init error"

### DIFF
--- a/tools/testing/selftests/kvm/lib/kvm_util.c
+++ b/tools/testing/selftests/kvm/lib/kvm_util.c
@@ -659,9 +659,6 @@ static void __vm_mem_region_delete(struct kvm_vm *vm,
 	rb_erase(&region->hva_node, &vm->regions.hva_tree);
 	hash_del(&region->slot_node);
 
-	region->region.memory_size = 0;
-	vm_ioctl(vm, KVM_SET_USER_MEMORY_REGION2, &region->region);
-
 	sparsebit_free(&region->unused_phy_pages);
 	ret = munmap(region->mmap_start, region->mmap_size);
 	TEST_ASSERT(!ret, __KVM_SYSCALL_ERROR("munmap()", ret));
@@ -1195,7 +1192,12 @@ void vm_mem_region_move(struct kvm_vm *vm, uint32_t slot, uint64_t new_gpa)
  */
 void vm_mem_region_delete(struct kvm_vm *vm, uint32_t slot)
 {
-	__vm_mem_region_delete(vm, memslot2region(vm, slot));
+	struct userspace_mem_region *region = memslot2region(vm, slot);
+
+	region->region.memory_size = 0;
+	vm_ioctl(vm, KVM_SET_USER_MEMORY_REGION2, &region->region);
+
+	__vm_mem_region_delete(vm, region);
 }
 
 void vm_guest_mem_fallocate(struct kvm_vm *vm, uint64_t base, uint64_t size,

--- a/tools/testing/selftests/kvm/lib/kvm_util.c
+++ b/tools/testing/selftests/kvm/lib/kvm_util.c
@@ -651,16 +651,13 @@ void kvm_vm_release(struct kvm_vm *vmp)
 }
 
 static void __vm_mem_region_delete(struct kvm_vm *vm,
-				   struct userspace_mem_region *region,
-				   bool unlink)
+				   struct userspace_mem_region *region)
 {
 	int ret;
 
-	if (unlink) {
-		rb_erase(&region->gpa_node, &vm->regions.gpa_tree);
-		rb_erase(&region->hva_node, &vm->regions.hva_tree);
-		hash_del(&region->slot_node);
-	}
+	rb_erase(&region->gpa_node, &vm->regions.gpa_tree);
+	rb_erase(&region->hva_node, &vm->regions.hva_tree);
+	hash_del(&region->slot_node);
 
 	region->region.memory_size = 0;
 	vm_ioctl(vm, KVM_SET_USER_MEMORY_REGION2, &region->region);
@@ -700,7 +697,7 @@ void kvm_vm_free(struct kvm_vm *vmp)
 
 	/* Free userspace_mem_regions. */
 	hash_for_each_safe(vmp->regions.slot_hash, ctr, node, region, slot_node)
-		__vm_mem_region_delete(vmp, region, false);
+		__vm_mem_region_delete(vmp, region);
 
 	/* Free sparsebit arrays. */
 	sparsebit_free(&vmp->vpages_valid);
@@ -1198,7 +1195,7 @@ void vm_mem_region_move(struct kvm_vm *vm, uint32_t slot, uint64_t new_gpa)
  */
 void vm_mem_region_delete(struct kvm_vm *vm, uint32_t slot)
 {
-	__vm_mem_region_delete(vm, memslot2region(vm, slot), true);
+	__vm_mem_region_delete(vm, memslot2region(vm, slot));
 }
 
 void vm_guest_mem_fallocate(struct kvm_vm *vm, uint64_t base, uint64_t size,


### PR DESCRIPTION
### Problem Introduced
Commit df5fd75ee305 ("KVM: arm64: Don't eagerly teardown the vgic on init error") introduced a regression in KVM selftests, specifically causing the `vgic_init` test to fail with I/O errors during VM cleanup:

```
# ==== Test Assertion Failure ====
#   lib/kvm_util.c:666: false
#   pid=4528 tid=4528 errno=5 - Input/output error
#      1        0x0000000000404eb7: __vm_mem_region_delete at kvm_util.c:666
```

### Root Cause
The original commit changed KVM's behavior to mark VMs as "dead" (returning -EIO) instead of properly tearing down the vGIC when initialization fails. While this fixed race conditions during vGIC initialization, it created a new problem:

1. **Dead VM state persists** - When vGIC initialization fails, the VM is marked as dead but resources aren't immediately cleaned up
2. **Selftest cleanup fails** - The test framework tries to delete memory regions from the dead VM during cleanup
3. **KVM rejects operations** - Since the VM is marked dead, KVM returns -EIO for memory region operations
4. **Test assertion failure** - The selftest framework doesn't expect I/O errors during cleanup and fails

### Impact
- Breaks KVM selftests that exercise vGIC initialization error paths
- Affects test automation and CI systems
- Makes it difficult to test edge cases and error handling

### Solution Options
1. **Revert this commit** - Go back to the previous behavior (but reintroduces the race condition)
2. **Apply follow-up fix** - Modify selftest framework to handle dead VMs gracefully during cleanup (recommended)

The follow-up fix (commit 5afe18dfa47d) addresses this by modifying the selftest framework to avoid calling into KVM to delete memslots during VM cleanup, since KVM will clean up resources when the VM fd is closed anyway.

### Recommendation
Apply the follow-up fix rather than reverting, as it:
- Preserves the race condition fix for vGIC initialization
- Makes the selftest framework more robust
- Improves cleanup performance by avoiding unnecessary KVM calls
- Handles both live and dead VMs correctly

This issue demonstrates the importance of testing not just the happy path, but also error conditions and cleanup scenarios in kernel selftests.
