### PR TITLE
vfio/nvgrace-gpu: Avoid resmem pfn unregistration (6.11-adv)

### DIFF
--- a/drivers/vfio/pci/nvgrace-gpu/main.c
+++ b/drivers/vfio/pci/nvgrace-gpu/main.c
@@ -239,7 +239,8 @@ static void nvgrace_gpu_close_device(struct vfio_device *core_vdev)
 	mutex_destroy(&nvdev->remap_lock);
 
 #ifdef CONFIG_MEMORY_FAILURE
-	unregister_pfn_address_space(&nvdev->resmem.pfn_address_space);
+	if (nvdev->resmem.memlength)
+		unregister_pfn_address_space(&nvdev->resmem.pfn_address_space);
 	unregister_pfn_address_space(&nvdev->usemem.pfn_address_space);
 #endif
 	vfio_pci_core_close_device(core_vdev);
@@ -320,9 +321,10 @@ static int nvgrace_gpu_mmap(struct vfio_device *core_vdev,
 #ifdef CONFIG_MEMORY_FAILURE
 	vma->vm_ops = &nvgrace_gpu_vfio_pci_mmap_ops;
 
-	if (index == VFIO_PCI_BAR2_REGION_INDEX)
+	if (index == VFIO_PCI_BAR2_REGION_INDEX) {
+		WARN_ON_ONCE(!nvdev->has_mig_hw_bug);
 		ret = nvgrace_gpu_vfio_pci_register_pfn_range(&nvdev->resmem, vma);
-	else
+	} else
 		ret = nvgrace_gpu_vfio_pci_register_pfn_range(&nvdev->usemem, vma);
 #endif
 


### PR DESCRIPTION
When porting the ECC/EGM series, to this branch, some logic that avoids the “resmem” region for systems that do not use it (i.e. Grace-Blackwell) was dropped. This was due to the Grace-Blackwell support implementation changing during the upstreaming process. The 6.8 branches have the pre-upstream version, and therefore their ECC/EGM patches did not take into account some of the changes that went into the upstream version.

This patch adds a check to only unregister the resmem pfnmap when it was created. It also adds a sanity check in the mmap handler to call out a potential bug (trying to register resmem pfnmap on systems where it is not required).

Tested on GH and GB by passing through a GPU to a VM:
- While running a [bpftrace](https://drive.google.com/file/d/1MZVqWtwINPG-9WBSMX7MpHc1nzMkQ-oe/view?usp=drive_link) on the host to evaluate pfnmap registrations on boot/shutdown
- Evaluating the kernel log after VM shutdown to ensure the print mentioned in the commit is no longer present.