### PR TITLE
[nvidia-6.14-next] wifi mt7925 patches backport #150

### DIFF
--- a/drivers/net/wireless/mediatek/mt76/mt7925/mcu.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7925/mcu.c
@@ -1924,14 +1924,14 @@ mt7925_mcu_sta_cmd(struct mt76_phy *phy,
 			mt7925_mcu_sta_mld_tlv(skb, info->vif, info->link_sta->sta);
 			mt7925_mcu_sta_eht_mld_tlv(skb, info->vif, info->link_sta->sta);
 		}
-
-		mt7925_mcu_sta_hdr_trans_tlv(skb, info->vif, info->link_sta);
 	}
 
 	if (!info->enable) {
 		mt7925_mcu_sta_remove_tlv(skb);
 		mt76_connac_mcu_add_tlv(skb, STA_REC_MLD_OFF,
 					sizeof(struct tlv));
+	} else {
+		mt7925_mcu_sta_hdr_trans_tlv(skb, info->vif, info->link_sta);
 	}
 
 	return mt76_mcu_skb_send_msg(dev, skb, info->cmd, true);

--- a/drivers/net/wireless/mediatek/mt76/mt7925/mcu.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7925/mcu.c
@@ -1962,11 +1962,7 @@ int mt7925_mcu_sta_update(struct mt792x_dev *dev,
 		mlink = mt792x_sta_to_link(msta, link_sta->link_id);
 	}
 	info.wcid = link_sta ? &mlink->wcid : &mvif->sta.deflink.wcid;
-
-	if (link_sta)
-		info.newly = state != MT76_STA_INFO_STATE_ASSOC;
-	else
-		info.newly = state == MT76_STA_INFO_STATE_ASSOC ? false : true;
+	info.newly = state != MT76_STA_INFO_STATE_ASSOC;
 
 	return mt7925_mcu_sta_cmd(&dev->mphy, &info);
 }


### PR DESCRIPTION
This PR is for 24.04_linux-nvidia-6.14-next branch of https://github.com/NVIDIA/NV-Kernels/pull/150.
The original PR contains 8 commits. 

The starting 2 commits are merged in v6.14 kernel.

https://github.com/NVIDIA/NV-Kernels/commit/8aa2f59260eb66fc80378c158922ccb741ccc491
https://github.com/NVIDIA/NV-Kernels/commit/bf18f7172aa429ec6a68852984a2e9468560c066

Then the next 4 commits have already been cherry-picked and part of 24.04_linux-nvidia-6.14-next

https://github.com/NVIDIA/NV-Kernels/commit/ae5cc8b58151ca83bb504146db0309d508e8fa6d
https://github.com/NVIDIA/NV-Kernels/commit/c7b49c5705d3d5a6bb6d7cac16a29e8cabc9cc4c
https://github.com/NVIDIA/NV-Kernels/commit/b03eb2a3f4556f43315aaf093720069f1d8bf3e3
https://github.com/NVIDIA/NV-Kernels/commit/ac7becc8dc089611683e723a1daf7a46b4374263

This PR contains the remaining 2 commits which is clean cherry-picked.