### PR TITLE
efi: Export screen_info

### DIFF
--- a/drivers/firmware/efi/efi-init.c
+++ b/drivers/firmware/efi/efi-init.c
@@ -62,7 +62,7 @@ extern __weak const efi_config_table_type_t efi_arch_tables[];
  */
 #if !defined(CONFIG_X86) && (defined(CONFIG_SYSFB) || defined(CONFIG_EFI_EARLYCON))
 struct screen_info screen_info __section(".data");
-EXPORT_SYMBOL_GPL(screen_info);
+EXPORT_SYMBOL(screen_info);
 #endif
 
 static void __init init_screen_info(void)


### PR DESCRIPTION
The NVIDIA driver requires access to the screen_info data to restore the console, so you need to export the screen_info data.