### PR TITLE
UBUNTU: [Config] nvidia-6.11: Update annotations to set CONFIG_IOMMU_DEFAULT_DMA_LAZY

### DIFF
--- a/debian.nvidia-6.11/config/annotations
+++ b/debian.nvidia-6.11/config/annotations
@@ -114,6 +114,10 @@ CONFIG_ETM4X_IMPDEF_FEATURE                     note<'Required for Grace enablem
 CONFIG_GPIO_AAEON                               policy<{'amd64': '-'}>
 CONFIG_GPIO_AAEON                               note<'Disable all Ubuntu ODM drivers'>
 
+CONFIG_IOMMU_DEFAULT_DMA_STRICT                 policy<{'arm64': 'n'}>
+CONFIG_IOMMU_DEFAULT_DMA_LAZY                   policy<{'arm64': 'y'}>
+CONFIG_IOMMU_DEFAULT_DMA_LAZY                   note<'Nvidia CPU SMMU supports passthrough and lazy IOMMU mode so set lazy mode as default for better performance'>
+
 CONFIG_LEDS_AAEON                               policy<{'amd64': '-'}>
 CONFIG_LEDS_AAEON                               note<'Disable all Ubuntu ODM drivers'>
 


### PR DESCRIPTION
Nvidia CPU SMMU supports passthrough and lazy IOMMU mode so set lazy mode as default for better performance.

nvbug: #[5432475](https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/5432475)
BugLink: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-6.11/+bug/2119661

perf numbers from the bug:

2 Grace sockets, 4 SSDs per socket. All 4 SSDs in a socket connected to the same PCIe root port.
SSD model: SAMSUNG MZTL63T8HFLT-00AW7
4KiB random read performance per disk: 1.7-2M IOPs (the spec says 1.7, but we are able to hit 2M)

IOMMU config IOPs (M)
passthrough 16.5
lazy invalidations 16.4
strict invalidations 2.8