### PR TITLE
UBUNTU: [Config] nvidia-6.11: Update annotations to set CONFIG_DRM_CLIENT_SELECTION

### DIFF
--- a/debian.nvidia-6.11/config/annotations
+++ b/debian.nvidia-6.11/config/annotations
@@ -93,6 +93,12 @@ CONFIG_CPU_FREQ_DEFAULT_GOV_ONDEMAND            note<'Required for NVIDIA worklo
 CONFIG_CPU_FREQ_DEFAULT_GOV_PERFORMANCE         policy<{'amd64': 'n', 'arm64': 'y'}>
 CONFIG_CPU_FREQ_DEFAULT_GOV_PERFORMANCE         note<'Required for NVIDIA workloads'>
 
+CONFIG_DRM_CLIENT_SELECTION                     policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_DRM_CLIENT_SELECTION                     note<'Required for nvidia-drm framebuffer console support'>
+
+CONFIG_DRM_CLIENT_SETUP                         policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_DRM_CLIENT_SETUP                         note<'Required for nvidia-drm framebuffer console support'>
+
 CONFIG_DRM_NOUVEAU                              policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_DRM_NOUVEAU                              note<'Disable nouveau for NVIDIA kernels'>
 

--- a/drivers/gpu/drm/Kconfig
+++ b/drivers/gpu/drm/Kconfig
@@ -180,9 +180,10 @@ config DRM_DEBUG_MODESET_LOCK
 	  If in doubt, say "N".
 
 config DRM_CLIENT_SELECTION
-	bool
+	bool "Enable in-kernel DRM clients"
 	depends on DRM
 	select DRM_CLIENT_SETUP if DRM_FBDEV_EMULATION
+	default n
 	help
 	  Drivers that support in-kernel DRM clients have to select this
 	  option.


### PR DESCRIPTION
Commit 8781125d424c backported a change to add the `drm_client_setup()` function and the `DRM_CLIENT_SELECTION` configuration option, but didn't backport any of the changes to make in-kernel DRM clients actually use that function or select the config option. Thus, enabling the option isn't possible and `drm_client_setup()` is always compiled to a stub function that does nothing.

At compile time, nvidia-drm checks for the presence of `drm_client_setup()` and calls that instead of `drm_fbdev_ttm_setup()` if it's loaded with the `modeset=1` and `fbdev=1` parameters, which results in a blank screen if `CONFIG_DRM_CLIENT_SELECTION=n`.

Update the option to make it selectable and select it in the nvidia-6.11 annotations file.

Fixes: 8781125d424c ("drm: Add client-agnostic setup helper")
Fixes: https://github.com/NVIDIA/NV-Kernels/issues/176