### PR TITLE
[6.11-next]: (Redo commit messages from PR#188) Set DRM_CLIENT configs

### DIFF
--- a/debian.nvidia-6.11/config/annotations
+++ b/debian.nvidia-6.11/config/annotations
@@ -93,6 +93,12 @@ CONFIG_CPU_FREQ_DEFAULT_GOV_ONDEMAND            note<'Required for NVIDIA worklo
 CONFIG_CPU_FREQ_DEFAULT_GOV_PERFORMANCE         policy<{'amd64': 'n', 'arm64': 'y'}>
 CONFIG_CPU_FREQ_DEFAULT_GOV_PERFORMANCE         note<'Required for NVIDIA workloads'>
 
+CONFIG_DRM_CLIENT_SELECTION                     policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_DRM_CLIENT_SELECTION                     note<'Required for nvidia-drm framebuffer console support'>
+
+CONFIG_DRM_CLIENT_SETUP                         policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_DRM_CLIENT_SETUP                         note<'Required for nvidia-drm framebuffer console support'>
+
 CONFIG_DRM_NOUVEAU                              policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_DRM_NOUVEAU                              note<'Disable nouveau for NVIDIA kernels'>
 

--- a/drivers/gpu/drm/Kconfig
+++ b/drivers/gpu/drm/Kconfig
@@ -180,9 +180,10 @@ config DRM_DEBUG_MODESET_LOCK
 	  If in doubt, say "N".
 
 config DRM_CLIENT_SELECTION
-	bool
+	bool "Enable in-kernel DRM clients"
 	depends on DRM
 	select DRM_CLIENT_SETUP if DRM_FBDEV_EMULATION
+	default n
 	help
 	  Drivers that support in-kernel DRM clients have to select this
 	  option.


### PR DESCRIPTION
PR#188 was NAK'd with:

```
The subject of commit "NVIDIA: SAUCE: [Config] nvidia-6.11: Update
annotations to set CONFIG_DRM_CLIENT_SELECTION" isn't clear that it is
also changing Kconfig behavior. Ideally we'd have one NVIDIA: SAUCE:
commit for this Kconfig change and another NVIDIA: [Config] commit
specifically for the annotations change.
```

Split this series into separate commits in the way Canonical asked.