### PR TITLE
[nvidia-6.14-next] Backport: iommu/arm-smmu-v3: Fix smmu_domain->nr_ats_masters decrement

### DIFF
--- a/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c
+++ b/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c
@@ -2927,9 +2927,9 @@ void arm_smmu_attach_commit(struct arm_smmu_attach_state *state)
 		/* ATS is being switched off, invalidate the entire ATC */
 		arm_smmu_atc_inv_master(master, IOMMU_NO_PASID);
 	}
-	master->ats_enabled = state->ats_enabled;
 
 	arm_smmu_remove_master_domain(master, state->old_domain, state->ssid);
+	master->ats_enabled = state->ats_enabled;
 }
 
 static int arm_smmu_attach_dev(struct iommu_domain *domain, struct device *dev)


### PR DESCRIPTION
This upstream (v6.17-rc3) fix addresses an issue where the ats master tracking can become corrupted during a SMMU attachment when the state changes. This can lead to odd side effects as the count does not represent the actual state of the hardware. Backport fix to 6.14-HWE.

Lore discussion: https://lore.kernel.org/r/20250801030127.2006979-1-nicolinc@nvidia.com
Upstream SHA: 685ca577b408 iommu/arm-smmu-v3: Fix smmu_domain->nr_ats_masters decrement
Launchpad: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-6.14/+bug/2121415

Tested with host and guest kernels using GPU passthrough. This commit picked cleanly to 24.04_linux-nvidia-6.14-next.