### PR TITLE
[nvidia-6.11-next]Backport: PCI/ACPI: Fix pci_acpi_preserve_config() memory leak

### DIFF
--- a/drivers/pci/pci-acpi.c
+++ b/drivers/pci/pci-acpi.c
@@ -121,6 +121,8 @@ phys_addr_t acpi_pci_root_get_mcfg_addr(acpi_handle handle)
 
 bool pci_acpi_preserve_config(struct pci_host_bridge *host_bridge)
 {
+	bool ret = false;
+
 	if (ACPI_HANDLE(&host_bridge->dev)) {
 		union acpi_object *obj;
 
@@ -134,11 +136,11 @@ bool pci_acpi_preserve_config(struct pci_host_bridge *host_bridge)
 					      1, DSM_PCI_PRESERVE_BOOT_CONFIG,
 					      NULL, ACPI_TYPE_INTEGER);
 		if (obj && obj->integer.value == 0)
-			return true;
+			ret = true;
 		ACPI_FREE(obj);
 	}
 
-	return false;
+	return ret;
 }
 
 /* _HPX PCI Setting Record (Type 0); same as _HPP */


### PR DESCRIPTION
kmemleak found a leak in acpi code: https://nvbugspro.nvidia.com/bug/5460890. The fix is in pci repo: git.kernel.org/pub/scm/linux/kernel/git/pci/pci.git
Launchpad : https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-6.11/+bug/2121451