### PR TITLE
[nvidia-6.14-next] SW WAR for USB SuperSpeed Plus Gen 2x1 incorrect lane count 

### DIFF
--- a/drivers/usb/host/xhci-hub.c
+++ b/drivers/usb/host/xhci-hub.c
@@ -1291,6 +1291,17 @@ int xhci_hub_control(struct usb_hcd *hcd, u16 typeReq, u16 wValue,
 			}
 			port_li = readl(port->addr + PORTLI);
 			status = xhci_get_ext_port_status(temp, port_li);
+
+			/*
+			 * In MT8901 USB host controller, the lane count can be wrongly set
+			 * to 2 instead of 1 for USB Gen2x1 devices due to a HW Bug. As a SW
+			 * WAR, check if port speed is 0x5 (SuperSpeedPlus Gen2x1) in
+			 * PORTSC register and update the lane count as 1.
+			 */
+			if ((xhci->quirks & XHCI_NVIDIA_MT8901_HOST) &&
+			    DEV_SUPERSPEEDPLUS(temp))
+				status &= ~0xff00;
+
 			put_unaligned_le32(status, &buf[4]);
 		}
 		break;


### PR DESCRIPTION
This PR adds a SW WAR to fix a HW issue where USB SuperSpeed Plus Gen 2x1 device lane count is being reported as 2 instead of 1.

usb 4-1: new SuperSpeed Plus Gen 2x2 USB device number 2 using xhci-hcd

Expected:
usb 4-1: new SuperSpeed Plus Gen 2x1 USB device number 2 using xhci-hcd

This is tracked with internal Bug 5422673