### PR TITLE
NVIDIA: SAUCE: mm: correctly identify pfn without struct pages

### DIFF
--- a/mm/memory-failure.c
+++ b/mm/memory-failure.c
@@ -473,7 +473,7 @@ static void __add_to_kill(struct task_struct *tsk, const struct page *p,
 	}
 
 	/* Check for pgoff not backed by struct page */
-	if (!(pfn_valid(pgoff)) && (vma->vm_flags | PFN_MAP)) {
+	if (!(pfn_valid(pgoff)) && (vma->vm_flags & VM_PFNMAP)) {
 		tk->addr = vma_address(vma, pgoff, 1);
 		tk->size_shift = PAGE_SHIFT;
 	} else {


### PR DESCRIPTION
Correct the logic used to identify the absence of struct page during memory_failure().

Fixes: a3fe67d7fa13 ("NVIDIA: SAUCE: mm: handle poisoning of pfn without struct pages")

<hr>

Canonical encountered this [bug](https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-6.14/+bug/2125434) while running some Linux Test Project (LTP) workloads against the linux-azure-nvidia kernel, which is based on the linux-nvidia kernel. Looking at the code, there is an obvious bitwise error in the conditional that detects the absence of a struct page during memory_failure().

Verified by running the testcase again that previously failed:

```
# PATH=$PATH:$PWD ./madvise07
tst_test.c:2008: TINFO: LTP version: 20250530-206-g514dd3b48
tst_test.c:2011: TINFO: Tested kernel: 6.14.11+ #14 SMP PREEMPT_DYNAMIC Mon Sep 22 14:18:30 PDT 2025 aarch64
tst_kconfig.c:88: TINFO: Parsing kernel config '/lib/modules/6.14.11+/build/.config'
tst_test.c:1829: TINFO: Overall timeout per run is 0h 00m 30s
madvise07.c:43: TINFO: mmap(0, 65536, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0)
madvise07.c:54: TINFO: madvise(0xf7d7aa350000, 65536, MADV_HWPOISON)
madvise07.c:83: TPASS: Received SIGBUS after accessing poisoned page

Summary:
passed   1
failed   0
broken   0
skipped  0
warnings 0
```

LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-6.14/+bug/2125434