### PR TITLE
drm/ast: Use msleep instead of mdelay for edid read

### DIFF
--- a/drivers/gpu/drm/ast/ast_dp.c
+++ b/drivers/gpu/drm/ast/ast_dp.c
@@ -62,7 +62,7 @@ int ast_astdp_read_edid(struct drm_device *dev, u8 *ediddata)
 			 *	  of right-click of mouse.
 			 * 2. The Delays are often longer a lot when system resume from S3/S4.
 			 */
-			mdelay(j+1);
+			msleep(j+1);
 
 			if (!(ast_get_index_reg_mask(ast, AST_IO_VGACRI, 0xD1,
 							ASTDP_MCU_FW_EXECUTING) &&


### PR DESCRIPTION
The busy-waiting in mdelay() can cause CPU stalls and kernel timeouts during boot.

https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-6.14/+bug/2125667
https://nvbugspro.nvidia.com/bug/5541552 