### PR TITLE
[nvidia-6.14-next] Set CONFIG_IOMMU_DEFAULT_PASSTHROUGH for kernel above 6.11

### DIFF
--- a/debian.nvidia-6.14/config/annotations
+++ b/debian.nvidia-6.14/config/annotations
@@ -117,11 +117,14 @@ CONFIG_ETM4X_IMPDEF_FEATURE                     note<'Required for Grace enablem
 CONFIG_GPIO_AAEON                               policy<{'amd64': '-'}>
 CONFIG_GPIO_AAEON                               note<'Disable all Ubuntu ODM drivers'>
 
-CONFIG_IOMMU_DEFAULT_DMA_LAZY                   policy<{'amd64': 'y', 'arm64': 'y'}>
-CONFIG_IOMMU_DEFAULT_DMA_LAZY                   note<'Nvidia CPU SMMU supports passthrough and lazy IOMMU mode so set lazy mode as default for better performance'>
+CONFIG_IOMMU_DEFAULT_PASSTHROUGH                policy<{'arm64': 'y'}>
+CONFIG_IOMMU_DEFAULT_PASSTHROUGH                note<'On Nvidia CPU passthrough mode is recommend so set passthrough mode as default for better performance'>
 
-CONFIG_IOMMU_DEFAULT_DMA_STRICT                 policy<{'amd64': 'n', 'arm64': 'n'}>
-CONFIG_IOMMU_DEFAULT_DMA_STRICT                 note<'Nvidia CPU SMMU supports passthrough and lazy IOMMU mode so set lazy mode as default for better performance'>
+CONFIG_IOMMU_DEFAULT_DMA_LAZY                   policy<{'arm64': 'n'}>
+CONFIG_IOMMU_DEFAULT_DMA_LAZY                   note<'On Nvidia CPU passthrough mode is recommend so set passthrough mode as default for better performance'>
+
+CONFIG_IOMMU_DEFAULT_DMA_STRICT                 policy<{'arm64': 'n'}>
+CONFIG_IOMMU_DEFAULT_DMA_STRICT                 note<'On Nvidia CPU passthrough mode is recommend so set passthrough mode as default for better performance'>
 
 CONFIG_LEDS_AAEON                               policy<{'amd64': '-'}>
 CONFIG_LEDS_AAEON                               note<'Disable all Ubuntu ODM drivers'>

--- a/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c
+++ b/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c
@@ -3653,6 +3653,9 @@ static int arm_smmu_def_domain_type(struct device *dev)
 
 		if (IS_HISI_PTT_DEVICE(pdev))
 			return IOMMU_DOMAIN_IDENTITY;
+
+		if (pdev->vendor == PCI_VENDOR_ID_NVIDIA && pdev->device == 0x2E12)
+			return IOMMU_DOMAIN_DMA;
 	}
 
 	return 0;


### PR DESCRIPTION
As suggested by perf team set CONFIG_IOMMU_DEFAULT_PASSTHROUGH=1 for kernel above 6.11

Ref:
https://docs.nvidia.com/grace-perf-tuning-guide/os-settings.html#input-output-memory-management-unit-passthrough
https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-6.14/+bug/2129776
https://nvbugspro.nvidia.com/bug/5469888