### PR TITLE
KVM initialization hitting exception at boot time with kernel 6.17

### DIFF
--- a/arch/arm64/kvm/debug.c
+++ b/arch/arm64/kvm/debug.c
@@ -15,6 +15,12 @@
 #include <asm/kvm_arm.h>
 #include <asm/kvm_emulate.h>
 
+static int cpu_has_spe(u64 dfr0)
+{
+	return cpuid_feature_extract_unsigned_field(dfr0, ID_AA64DFR0_EL1_PMSVer_SHIFT) &&
+	       !(read_sysreg_s(SYS_PMBIDR_EL1) & PMBIDR_EL1_P);
+}
+
 /**
  * kvm_arm_setup_mdcr_el2 - configure vcpu mdcr_el2 value
  *
@@ -74,12 +80,11 @@ void kvm_init_host_debug_data(void)
 	*host_data_ptr(debug_brps) = SYS_FIELD_GET(ID_AA64DFR0_EL1, BRPs, dfr0);
 	*host_data_ptr(debug_wrps) = SYS_FIELD_GET(ID_AA64DFR0_EL1, WRPs, dfr0);
 
+	if (cpu_has_spe(dfr0))
+		host_data_set_flag(HAS_SPE);
+
 	if (has_vhe())
 		return;
-
-	if (cpuid_feature_extract_unsigned_field(dfr0, ID_AA64DFR0_EL1_PMSVer_SHIFT) &&
-	    !(read_sysreg_s(SYS_PMBIDR_EL1) & PMBIDR_EL1_P))
-		host_data_set_flag(HAS_SPE);
 
 	/* Check if we have BRBE implemented and available at the host */
 	if (cpuid_feature_extract_unsigned_field(dfr0, ID_AA64DFR0_EL1_BRBE_SHIFT))
@@ -99,7 +104,7 @@ void kvm_init_host_debug_data(void)
 void kvm_debug_init_vhe(void)
 {
 	/* Clear PMSCR_EL1.E{0,1}SPE which reset to UNKNOWN values. */
-	if (SYS_FIELD_GET(ID_AA64DFR0_EL1, PMSVer, read_sysreg(id_aa64dfr0_el1)))
+	if (host_data_test_flag(HAS_SPE))
 		write_sysreg_el1(0, SYS_PMSCR);
 }
 


### PR DESCRIPTION
Canonical is hitting an exception when booting with 6.17 kernel. 
It looked like this (during KVM initialization):
[    6.307762] pci 0008:05:00.0: quirk_usb_early_handoff+0x0/0x290 took 46611 usecs
[    6.307781] PCI: CLS 64 bytes, default 64
[    6.307795] ARM FF-A: Driver version 1.2
[    6.307796] ARM FF-A: Firmware version 1.1 found
[    6.307846] GICv3: [Firmware Bug]: Illegal GSI5 translation request
[    6.307847] ARM FF-A: Failed to create IRQ mapping!
[    6.307929] Trying to unpack rootfs image as initramfs...
Unhandled Exception from EL2
x0             = 0x000011f210305619
x1             = 0x0000000000000000
x2             = 0x0000000000000000
x3             = 0x0000000000000000
x4             = 0x0000000000000000
x5             = 0x0000000000000000
x6             = 0x0000000000000000
x7             = 0x0000000000000000
x8             = 0xffff000085c0c000
x9             = 0xffff9f883fa7ce9c
x10            = 0x000000000000000a

The commit that was causing this is exception: 
efad60e46057 ("KVM: arm64: Initialize PMSCR_EL1 when in VHE")

We found an upstream commit that fix this issue:
c35dd838666d KVM: arm64: Guard PMSCR_EL1 initialization with SPE presence check

Launchpad:https://bugs.launchpad.net/ubuntu/+source/linux-nvidia/+bug/2130289