### PR TITLE
NVIDIA: SAUCE: perf: arm_cspmu: Fix duplicate sysfs filename for NVIDIA PMU devices

### DIFF
--- a/drivers/perf/arm_cspmu/nvidia_cspmu.c
+++ b/drivers/perf/arm_cspmu/nvidia_cspmu.c
@@ -286,16 +286,54 @@ static char *nv_cspmu_format_name(const struct arm_cspmu *cspmu,
 {
 	char *name;
 	struct device *dev = cspmu->dev;
-
+	u32 prodid;
 	static atomic_t pmu_generic_idx = {0};
+	/* Per-prodid counters to ensure unique names */
+	static atomic_t pmu_pcie_idx = {0};
+	static atomic_t pmu_nvlink_c2c1_idx = {0};
+	static atomic_t pmu_nvlink_c2c0_idx = {0};
+	static atomic_t pmu_cnvlink_idx = {0};
+	static atomic_t pmu_scf_idx = {0};
+
+	prodid = FIELD_GET(ARM_CSPMU_PMIIDR_PRODUCTID, cspmu->impl.pmiidr);
 
 	switch (match->name_fmt) {
 	case NAME_FMT_SOCKET: {
-		const int cpu = cpumask_first(&cspmu->associated_cpus);
-		const int socket = cpu_to_node(cpu);
+		atomic_t *idx_ptr = NULL;
 
-		name = devm_kasprintf(dev, GFP_KERNEL, match->name_pattern,
-				       socket);
+		/* Select the appropriate counter based on product ID */
+		switch (prodid & NV_PRODID_MASK) {
+		case 0x103:
+			idx_ptr = &pmu_pcie_idx;
+			break;
+		case 0x104:
+			idx_ptr = &pmu_nvlink_c2c1_idx;
+			break;
+		case 0x105:
+			idx_ptr = &pmu_nvlink_c2c0_idx;
+			break;
+		case 0x106:
+			idx_ptr = &pmu_cnvlink_idx;
+			break;
+		case 0x2CF:
+			idx_ptr = &pmu_scf_idx;
+			break;
+		default:
+			break;
+		}
+
+		/* Use per-prodid index to ensure uniqueness across all sockets */
+		if (idx_ptr) {
+			unsigned int idx = atomic_fetch_inc(idx_ptr);
+			name = devm_kasprintf(dev, GFP_KERNEL, match->name_pattern,
+					       idx);
+		} else {
+			/* Fallback to socket-based naming if prodid not recognized */
+			const int cpu = cpumask_first(&cspmu->associated_cpus);
+			const int socket = cpu_to_node(cpu);
+			name = devm_kasprintf(dev, GFP_KERNEL, match->name_pattern,
+					       socket);
+		}
 		break;
 	}
 	case NAME_FMT_GENERIC:


### PR DESCRIPTION
Multiple NVIDIA PMU devices of the same type on the same socket were using socket-based naming (e.g., nvidia_pcie_pmu_0), causing duplicate sysfs filename errors when registering multiple devices.

Example dmesg warning:
  sysfs: cannot create duplicate filename '/bus/event_source/devices/nvidia_pcie_pmu_0'
  CPU: 176 UID: 0 PID: 2338 Comm: modprobe Tainted: G        W           6.17.1+ #24 PREEMPT(none)
  Call trace:
    show_stack+0x24/0x50 (C)
    dump_stack_lvl+0x80/0x140
    dump_stack+0x1c/0x38
    sysfs_warn_dup+0xa4/0xe8
    sysfs_do_create_link_sd+0x140/0x150
    sysfs_create_link+0x2c/0x80
    bus_add_device+0x144/0x1a8
    device_add+0x3e0/0x8a0
    pmu_dev_alloc+0x110/0x188
    perf_pmu_register+0x468/0x548
    arm_cspmu_device_probe+0x7a4/0xa80 [arm_cspmu_module]

Fix this by using per-PMU-type atomic counters to assign unique sequential indices to each PMU device, regardless of socket topology. This ensures each PMU device gets a unique name (nvidia_pcie_pmu_0, nvidia_pcie_pmu_1, etc.) and prevents sysfs duplicate filename errors.

After this patch: 
```
ls -l /sys/bus/event_source/devices/|grep nvidia
lrwxrwxrwx 1 root root 0 Nov  6 13:04 nvidia_pcie_pmu_0 -> ../../../devices/platform/arm-cs-arch-pmu.3.auto/nvidia_pcie_pmu_0
lrwxrwxrwx 1 root root 0 Nov  6 13:04 nvidia_pcie_pmu_1 -> ../../../devices/platform/arm-cs-arch-pmu.1.auto/nvidia_pcie_pmu_1
lrwxrwxrwx 1 root root 0 Nov  6 13:04 nvidia_pcie_pmu_2 -> ../../../devices/platform/arm-cs-arch-pmu.2.auto/nvidia_pcie_pmu_2
lrwxrwxrwx 1 root root 0 Nov  6 13:04 nvidia_pcie_pmu_3 -> ../../../devices/platform/arm-cs-arch-pmu.5.auto/nvidia_pcie_pmu_3
lrwxrwxrwx 1 root root 0 Nov  6 13:04 nvidia_pcie_pmu_4 -> ../../../devices/platform/arm-cs-arch-pmu.4.auto/nvidia_pcie_pmu_4
lrwxrwxrwx 1 root root 0 Nov  6 13:04 nvidia_pcie_pmu_5 -> ../../../devices/platform/arm-cs-arch-pmu.6.auto/nvidia_pcie_pmu_5
lrwxrwxrwx 1 root root 0 Nov  6 13:04 nvidia_scf_pmu_0 -> ../../../devices/platform/arm-cs-arch-pmu.0.auto/nvidia_scf_pmu_0
lrwxrwxrwx 1 root root 0 Nov  6 13:04 nvidia_uncore_pmu_0 -> ../../../devices/platform/arm-cs-arch-pmu.9.auto/nvidia_uncore_pmu_0
lrwxrwxrwx 1 root root 0 Nov  6 13:04 nvidia_uncore_pmu_1 -> ../../../devices/platform/arm-cs-arch-pmu.10.auto/nvidia_uncore_pmu_1
lrwxrwxrwx 1 root root 0 Nov  6 13:04 nvidia_uncore_pmu_2 -> ../../../devices/platform/arm-cs-arch-pmu.11.auto/nvidia_uncore_pmu_2
lrwxrwxrwx 1 root root 0 Nov  6 13:04 nvidia_uncore_pmu_3 -> ../../../devices/platform/arm-cs-arch-pmu.12.auto/nvidia_uncore_pmu_3
lrwxrwxrwx 1 root root 0 Nov  6 13:04 nvidia_uncore_pmu_4 -> ../../../devices/platform/arm-cs-arch-pmu.7.auto/nvidia_uncore_pmu_4
lrwxrwxrwx 1 root root 0 Nov  6 13:04 nvidia_uncore_pmu_5 -> ../../../devices/platform/arm-cs-arch-pmu.8.auto/nvidia_uncore_pmu_5
```