### PR TITLE
[linux-nvidia-6.17] Backport arm64: cpufeature: Add Olympus MIDR to BBML2 allow list

### DIFF
--- a/arch/arm64/kernel/cpufeature.c
+++ b/arch/arm64/kernel/cpufeature.c
@@ -2235,6 +2235,7 @@ static bool has_bbml2_noabort(const struct arm64_cpu_capabilities *caps, int sco
 	static const struct midr_range supports_bbml2_noabort_list[] = {
 		MIDR_REV_RANGE(MIDR_CORTEX_X4, 0, 3, 0xf),
 		MIDR_REV_RANGE(MIDR_NEOVERSE_V3, 0, 2, 0xf),
+		MIDR_ALL_VERSIONS(MIDR_NVIDIA_OLYMPUS),
 		{}
 	};
 


### PR DESCRIPTION
Backport this upstream patch to linux-nvidia-6.17.
v6.18 patch: https://web.git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=cc80537caaa789e097f35b2032ddc693a4e136f9

LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia/+bug/2131047