### PR TITLE
[linux-nvidia-6.14-next] vfio/nvgrace-egm: Prevent double-unregister of pfn_address_space

### DIFF
--- a/drivers/vfio/pci/nvgrace-gpu/egm.c
+++ b/drivers/vfio/pci/nvgrace-gpu/egm.c
@@ -33,6 +33,7 @@ struct egm_region {
 	DECLARE_HASHTABLE(htbl, 0x10);
 #ifdef CONFIG_MEMORY_FAILURE
 	struct pfn_address_space pfn_address_space;
+	bool pfn_space_registered;
 #endif
 };
 
@@ -140,7 +141,10 @@ static int nvgrace_egm_release(struct inode *inode, struct file *file)
 
 	if (atomic_dec_and_test(&region->open_count)) {
 #ifdef CONFIG_MEMORY_FAILURE
-		unregister_pfn_address_space(&region->pfn_address_space);
+		if (region->pfn_space_registered) {
+			unregister_pfn_address_space(&region->pfn_address_space);
+			region->pfn_space_registered = false;
+		}
 #endif
 		file->private_data = NULL;
 	}
@@ -169,7 +173,10 @@ static int nvgrace_egm_mmap(struct file *file, struct vm_area_struct *vma)
 	vma->vm_ops = &nvgrace_egm_mmap_ops;
 
 	ret = nvgrace_egm_register_pfn_range(region, vma);
+	if (ret == 0)
+		region->pfn_space_registered = true;
 #endif
+
 	return ret;
 }
 
@@ -458,6 +465,9 @@ int register_egm_node(struct pci_dev *pdev)
 	region->egmpxm = egmpxm;
 
 	hash_init(region->htbl);
+#ifdef CONFIG_MEMORY_FAILURE
+	region->pfn_space_registered = false;
+#endif
 	INIT_LIST_HEAD(&region->gpus);
 
 	atomic_set(&region->open_count, 0);


### PR DESCRIPTION
Check for the registration state of egm_region's pfn_address_space, preventing double-unregisters that can occur when using an external management app such as Libvirt to launch VMs with vEGM enabled. This addresses a null pointer dereference in __rb_erase_color when using shutting down a Libvirt VM with vEGM enabled.

LP bug: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-6.14/+bug/2131582 

Testing:
Launch a libvirt-qemu VM with vEGM and then shut it down.

Upstream plans:
N/A as Ankit's vEGM RFC series does not follow the same unregister logic.