### PR TITLE
[linux-nvidia-6.14-next] Make perf counters accessible from sched_ext schedulers

### DIFF
--- a/include/linux/bpf.h
+++ b/include/linux/bpf.h
@@ -2039,6 +2039,8 @@ int bpf_prog_calc_tag(struct bpf_prog *fp);
 const struct bpf_func_proto *bpf_get_trace_printk_proto(void);
 const struct bpf_func_proto *bpf_get_trace_vprintk_proto(void);
 
+const struct bpf_func_proto *bpf_get_perf_event_read_value_proto(void);
+
 typedef unsigned long (*bpf_ctx_copy_t)(void *dst, const void *src,
 					unsigned long off, unsigned long len);
 typedef u32 (*bpf_convert_ctx_access_t)(enum bpf_access_type type,

--- a/kernel/bpf/core.c
+++ b/kernel/bpf/core.c
@@ -2925,6 +2925,11 @@ const struct bpf_func_proto * __weak bpf_get_trace_vprintk_proto(void)
 	return NULL;
 }
 
+const struct bpf_func_proto * __weak bpf_get_perf_event_read_value_proto(void)
+{
+	return NULL;
+}
+
 u64 __weak
 bpf_event_output(struct bpf_map *map, u64 flags, void *meta, u64 meta_size,
 		 void *ctx, u64 ctx_size, bpf_ctx_copy_t ctx_copy)

--- a/kernel/bpf/helpers.c
+++ b/kernel/bpf/helpers.c
@@ -2050,6 +2050,8 @@ bpf_base_func_proto(enum bpf_func_id func_id, const struct bpf_prog *prog)
 		return &bpf_task_pt_regs_proto;
 	case BPF_FUNC_trace_vprintk:
 		return bpf_get_trace_vprintk_proto();
+	case BPF_FUNC_perf_event_read_value:
+		return bpf_get_perf_event_read_value_proto();
 	default:
 		return NULL;
 	}

--- a/kernel/trace/bpf_trace.c
+++ b/kernel/trace/bpf_trace.c
@@ -607,6 +607,11 @@ static const struct bpf_func_proto bpf_perf_event_read_value_proto = {
 	.arg4_type	= ARG_CONST_SIZE,
 };
 
+const struct bpf_func_proto *bpf_get_perf_event_read_value_proto(void)
+{
+	return &bpf_perf_event_read_value_proto;
+}
+
 static __always_inline u64
 __bpf_perf_event_output(struct pt_regs *regs, struct bpf_map *map,
 			u64 flags, struct perf_raw_record *raw,


### PR DESCRIPTION
There is a growing need to design sched_ext schedulers that can monitor specific PMU hardware events (e.g., branch-prediction misses, cache misses, CPU cycles, etc.) either to mitigate potential hardware-related regressions or implement more informed scheduling policies that can improve performance.

Unfortunately, the 6.14 kernel does not provide access to PMU counters from BPF, which makes it impossible to run such schedulers on linux-nvidia-6.14. Exposing `perf_event_read_output()` to all BPF program types would enable these schedulers to work on linux-nvidia-6.14 as well.

The required change is a clean cherry pick of a single upstream commit (`bpf: Make perf_event_read_output accessible in all program types.`) which makes a kfunc usable from multiple contexts and it's pretty self contained in the BPF subsystem, therefore regression potential is minimal.