### PR TITLE
[linux-nvidia-6.14-next] iommufd: Avoid including VM_PFNMAP memory from RLIMIT_MEMLOCK

### DIFF
--- a/drivers/iommu/iommufd/pages.c
+++ b/drivers/iommu/iommufd/pages.c
@@ -1410,6 +1410,18 @@ struct iopt_pages *iopt_alloc_user_pages(void __user *uptr,
 		return pages;
 	pages->uptr = uptr_down;
 	pages->type = IOPT_ADDRESS_USER;
+
+	if (pages->account_mode == IOPT_PAGES_ACCOUNT_USER) {
+		struct vm_area_struct *vma;
+
+		mmap_read_lock(pages->source_mm);
+		vma = find_vma(pages->source_mm, (unsigned long)uptr_down);
+		if (vma && (vma->vm_flags & VM_PFNMAP)) {
+			pages->account_mode = IOPT_PAGES_ACCOUNT_NONE;
+		}
+		mmap_read_unlock(pages->source_mm);
+	}
+	
 	return pages;
 }
 


### PR DESCRIPTION
Device memory regions such as I/O device BARs do not consume host RAM and should not count against the RLIMIT_MEMLOCK limit for how much memory can be locked/pinned.

When a VM with device passthrough is launched by an unprivileged process (e.g., Libvirt launches qemu process as an unprivileged user), IOMMUFD's unified memory accounting causes ENOMEM errors for large device BARs that exceed the process memlock limit. VFIO without IOMMUFD does not check device memory against the limit and therefore does not show the same behavior.

This commit sets device memory account_mode to IOPT_PAGES_ACCOUNT_NONE, bypassing the RLIMIT_MEMLOCK limit to restore the behavior of VFIO without IOMMUFD for device memory.

LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia/+bug/2131970

Testing:
Launch a GPU passthrough Libvirt-qemu VM with iommufd backing and observe ENOMEM from GPU BAR mapping operations. Subsequent VM launches fail. Add CAP_IPC_LOCK capability to the qemu binary and observe successful BAR mappings + multiple VM launch.

Upstream plans:
Working on different implementation for upstream memory accounting infrastructure that differs from what we carry here.