### PR TITLE
Revert "eth: bnxt: remove most dependencies on RTNL"

### DIFF
--- a/drivers/net/ethernet/mellanox/mlx5/core/en_main.c
+++ b/drivers/net/ethernet/mellanox/mlx5/core/en_main.c
@@ -685,7 +685,7 @@ static void mlx5e_rq_timeout_work(struct work_struct *timeout_work)
 	 * channels are closing for another reason, making this work no longer
 	 * necessary.
 	 */
-	while (!netdev_trylock(rq->netdev)) {
+	while (!mutex_trylock(&rq->netdev->lock)) {
 		if (!test_bit(MLX5E_STATE_CHANNELS_ACTIVE, &rq->priv->state))
 			return;
 		msleep(20);

--- a/include/linux/netdevice.h
+++ b/include/linux/netdevice.h
@@ -2710,11 +2710,6 @@ static inline void netdev_lock(struct net_device *dev)
 	mutex_lock(&dev->lock);
 }
 
-static inline bool netdev_trylock(struct net_device *dev)
-{
-	return mutex_trylock(&dev->lock);
-}
-
 static inline void netdev_unlock(struct net_device *dev)
 {
 	mutex_unlock(&dev->lock);


### PR DESCRIPTION
Fixes a build failure of DOCA's mlnx-ofed-kernel 25.10.OFED.25.10.1.2.2.1 with linux-nvidia 6.14.0-1014.14.
Please see patch changelog for more details.