### PR TITLE
[linux-nvidia-6.17-next] Add two more Spark IDs for the iommu quirk

### DIFF
--- a/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c
+++ b/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c
@@ -3671,7 +3671,9 @@ static int arm_smmu_def_domain_type(struct device *dev)
 		if (IS_HISI_PTT_DEVICE(pdev))
 			return IOMMU_DOMAIN_IDENTITY;
 
-		if (pdev->vendor == PCI_VENDOR_ID_NVIDIA && pdev->device == 0x2E12)
+		if (pdev->vendor == PCI_VENDOR_ID_NVIDIA &&
+		    (pdev->device == 0x2E12 || pdev->device == 0x2E2A ||
+		     pdev->device == 0x2E2B))
 			return IOMMU_DOMAIN_DMA;
 	}
 


### PR DESCRIPTION
Add two more Spark IDs for the iommu quirk
https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-6.14/+bug/2132033
https://nvbugspro.nvidia.com/bug/5649700/34