### PR TITLE
NVIDIA: SAUCE: Downgrade "xhci_endpoint_init rsv" message level

### DIFF
--- a/drivers/usb/host/xhci-mem.c
+++ b/drivers/usb/host/xhci-mem.c
@@ -1480,7 +1480,7 @@ int xhci_endpoint_init(struct xhci_hcd *xhci,
 	ep_ctx->tx_info = cpu_to_le32(EP_MAX_ESIT_PAYLOAD_LO(max_esit_payload) |
 				      EP_AVG_TRB_LENGTH(avg_trb_len));
 	ep_ctx->reserved[0] = cpu_to_le32(0x1 | (0x1 << 11)); //mtk's bpks & bm
-		pr_err("%s rsv %#x\n", __func__, ep_ctx->reserved[0]);
+		pr_debug("%s rsv %#x\n", __func__, ep_ctx->reserved[0]);
 
 	return 0;
 }


### PR DESCRIPTION
The message should use pr_debug() instead of pr_err().