### PR TITLE
UBUNTU: SAUCE: security/apparmor: Fix AA_DEBUG_PROFILE define

### DIFF
--- a/security/apparmor/include/lib.h
+++ b/security/apparmor/include/lib.h
@@ -54,9 +54,9 @@ extern struct aa_dfa *stacksplitdfa;
 #define AA_DEBUG_LABEL(LAB, X, fmt, args...)				\
 do {									\
 	if ((LAB)->flags & FLAG_DEBUG1)					\
-		AA_DEBUG(X, fmt);					\
+		AA_DEBUG(X, fmt, ## args);			\
 } while (0)
-#define AA_DEBUG_PROFILE(PROF, X, fmt...) AA_DEBUG_LABEL(&(PROF)->label, X, fmt)
+#define AA_DEBUG_PROFILE(PROF, X, fmt, args...) AA_DEBUG_LABEL(&(PROF)->label, X, fmt, ## args)
 
 #define AA_WARN(X) WARN((X), "APPARMOR WARN %s: %s\n", __func__, #X)
 


### PR DESCRIPTION
BugLink: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia/+bug/2138131

Properly pass the variadic arguments so it can be called with or without them depending on the format.