### PR TITLE
[linux-nvidia-6.18] Backport NVIDIA: VR: SAUCE: soc/tegra: misc: Use SMCCC to get chipid

### DIFF
--- a/drivers/soc/tegra/fuse/tegra-apbmisc.c
+++ b/drivers/soc/tegra/fuse/tegra-apbmisc.c
@@ -4,6 +4,7 @@
  */
 
 #include <linux/acpi.h>
+#include <linux/arm-smccc.h>
 #include <linux/export.h>
 #include <linux/io.h>
 #include <linux/kernel.h>
@@ -27,6 +28,11 @@
 #define PMC_STRAPPING_OPT_A_RAM_CODE_MASK_SHORT	\
 	(0x3 << PMC_STRAPPING_OPT_A_RAM_CODE_SHIFT)
 
+#define TEGRA_SMCCC_PLATFORM(x)		((x >> 8) & 0xff)
+#define TEGRA_SMCCC_CHIP_ID(x)		((x >> 4) & 0xff)
+#define TEGRA_SMCCC_MAJOR_REV(x)	(x & 0xf)
+#define TEGRA_SMCCC_MINOR_REV(x)	(x & 0xf)
+
 static void __iomem *apbmisc_base;
 static bool long_ram_code;
 static u32 strapping;
@@ -41,21 +47,46 @@ u32 tegra_read_chipid(void)
 
 u8 tegra_get_chip_id(void)
 {
+#ifdef CONFIG_HAVE_ARM_SMCCC_DISCOVERY
+	s32 soc_id = arm_smccc_get_soc_id_version();
+
+	if (soc_id >= 0)
+		return TEGRA_SMCCC_CHIP_ID(soc_id);
+#endif
 	return (tegra_read_chipid() >> 8) & 0xff;
 }
 
 u8 tegra_get_major_rev(void)
 {
+#ifdef CONFIG_HAVE_ARM_SMCCC_DISCOVERY
+	s32 soc_id = arm_smccc_get_soc_id_version();
+
+	if (soc_id >= 0)
+		return TEGRA_SMCCC_MAJOR_REV(soc_id);
+#endif
 	return (tegra_read_chipid() >> 4) & 0xf;
 }
 
 u8 tegra_get_minor_rev(void)
 {
+#ifdef CONFIG_HAVE_ARM_SMCCC_DISCOVERY
+	s32 revision = arm_smccc_get_soc_id_revision();
+
+	if (revision >= 0)
+		return TEGRA_SMCCC_MINOR_REV(revision);
+#endif
 	return (tegra_read_chipid() >> 16) & 0xf;
+
 }
 
 u8 tegra_get_platform(void)
 {
+#ifdef CONFIG_HAVE_ARM_SMCCC_DISCOVERY
+	s32 revision = arm_smccc_get_soc_id_revision();
+
+	if (revision >= 0)
+		return TEGRA_SMCCC_PLATFORM(revision);
+#endif
 	return (tegra_read_chipid() >> 20) & 0xf;
 }
 


### PR DESCRIPTION
Tegra410 and Tegra241 have deprecated HIDREV register. It is recommended to use ARM SMCCC calls to get chip_id, major and minor revisions.

Use ARM SMCCC to get chip_id, major and minor revision.

<hr>

This OOT patch is needed for the VR platform to avoid these warnings:
```
[   14.860697] Tegra APB MISC not yet available
[   14.860741] WARNING: CPU: 5 PID: 1 at drivers/soc/tegra/fuse/tegra-apbmisc.c:37 tegra_get_chip_id+0x58/0x88
[   14.863038] Modules linked in:
[   14.988004] Freeing initrd memory: 78908K
[   25.193803] CPU: 5 UID: 0 PID: 1 Comm: swapper/0 Not tainted 6.18.2+ #2 PREEMPT(none) 
[   25.201529] Hardware name: NVIDIA VR200 NVL72/P3809-BMC, BIOS 00.01.00.08 2026-01-03T21:17:31+00:00
[   25.210378] pstate: 61000009 (nZCv daif -PAN -UAO -TCO +DIT -SSBS BTYPE=--)
[   25.217252] pc : tegra_get_chip_id+0x58/0x88
[   25.221720] lr : tegra_get_chip_id+0x58/0x88
[   25.225931] sp : ffff800080b3ba90
[   25.229110] x29: ffff800080b3ba90 x28: ffff080019014780 x27: ffffb72a42e72520
[   25.236156] x26: ffffb72a42fcb000 x25: 000000000000010b x24: 0000000000000000
[   25.243202] x23: ffffb72a44caf000 x22: ffff08002638f800 x21: ffff08002638f810
[   25.250248] x20: ffffb72a44caf1e8 x19: ffffb72a44caf310 x18: ffff800080b1b080
[   25.257294] x17: 0000000000000000 x16: 0000000000000000 x15: 0000000000000000
[   25.264340] x14: ffffffffffffffff x13: 0a656c62616c6961 x12: 7661207465792074
[   25.271385] x11: 6f6e204353494d20 x10: 4250412061726765 x9 : 0000000000000000
[   25.278431] x8 : 0000000000000000 x7 : 0000000000000000 x6 : 0000000000000000
[   25.285477] x5 : 0000000000000000 x4 : 0000000000000000 x3 : 0000000000000000
[   25.292523] x2 : 0000000000000000 x1 : 0000000000000000 x0 : 0000000000000000
[   25.299570] Call trace:
[   25.301805]  tegra_get_chip_id+0x58/0x88 (P)
[   25.306272]  tegra_fuse_probe+0x26c/0x430
[   25.310138]  platform_probe+0x74/0x100
[   25.313747]  really_probe+0xd8/0x3e8
[   25.317442]  __driver_probe_device+0x94/0x1c8
[   25.321653]  driver_probe_device+0x48/0x188
[   25.325605]  __driver_attach+0x14c/0x2c8
[   25.329729]  bus_for_each_dev+0x88/0x110
[   25.333596]  driver_attach+0x30/0x60
[   25.337119]  bus_add_driver+0x17c/0x2e8
[   25.340642]  driver_register+0x68/0x178
[   25.344422]  __platform_driver_register+0x30/0x60
[   25.349234]  tegra_fuse_driver_init+0x28/0x50
[   25.353531]  do_one_initcall+0x64/0x378
[   25.357140]  kernel_init_freeable+0x23c/0x500
[   25.361608]  kernel_init+0x3c/0x258
[   25.364873]  ret_from_fork+0x10/0x20
[   25.368654] ---[ end trace 0000000000000000 ]---
[   25.373229] tegra-fuse NVDA200F:00: error -EINVAL: Unsupported SoC: 00
[   25.373248] tegra-fuse NVDA200F:00: probe with driver tegra-fuse failed with error -22
[   25.373801] ------------[ cut here ]------------
```

This patch will be posted to LKML in the near future.

After building the kernel with this patch, I verified that the warnings are no longer present on a VR system.