### PR TITLE
UBUNTU: SAUCE: Add nvidia-kmemleak and nvidia-64k-kmemleak kernel flavors

### DIFF
--- a/debian.nvidia-6.17/config/annotations
+++ b/debian.nvidia-6.17/config/annotations
@@ -1,8 +1,8 @@
 # Menu: HEADER
 # FORMAT: 4
 # ARCH: amd64 arm64
-# FLAVOUR: amd64-nvidia arm64-nvidia arm64-nvidia-64k
-# FLAVOUR_DEP: {'amd64-nvidia': 'amd64-generic', 'arm64-nvidia': 'arm64-generic', 'arm64-nvidia-64k': 'arm64-generic-64k'}
+# FLAVOUR: amd64-nvidia arm64-nvidia arm64-nvidia-64k arm64-nvidia-kmemleak arm64-nvidia-64k-kmemleak
+# FLAVOUR_DEP: {'amd64-nvidia': 'amd64-generic', 'arm64-nvidia': 'arm64-generic', 'arm64-nvidia-64k': 'arm64-generic-64k', 'arm64-nvidia-kmemleak': 'arm64-nvidia', 'arm64-nvidia-64k-kmemleak': 'arm64-nvidia-64k'}
 
 include "../../debian.master/config/annotations"
 
@@ -261,3 +261,20 @@ CONFIG_TOOLS_SUPPORT_RELR                       policy<{'amd64': 'y', 'arm64': '
 CONFIG_UCSI_HUAWEI_GAOKUN                       policy<{'arm64': '-'}>
 CONFIG_VFIO_CONTAINER                           policy<{'amd64': 'y', 'arm64': 'n'}>
 CONFIG_VFIO_IOMMU_TYPE1                         policy<{'amd64': 'm', 'arm64': '-'}>
+
+# ---- Kmemleak debug flavors ----
+
+CONFIG_DEBUG_KMEMLEAK                           policy<{'arm64-nvidia-kmemleak': 'y', 'arm64-nvidia-64k-kmemleak': 'y'}>
+CONFIG_DEBUG_KMEMLEAK                           note<'Enable kernel memory leak detector for debug flavors'>
+
+CONFIG_DEBUG_KMEMLEAK_MEM_POOL_SIZE             policy<{'arm64-nvidia-kmemleak': '16000', 'arm64-nvidia-64k-kmemleak': '16000'}>
+CONFIG_DEBUG_KMEMLEAK_MEM_POOL_SIZE             note<'Kmemleak memory pool size'>
+
+CONFIG_DEBUG_KMEMLEAK_DEFAULT_OFF               policy<{'arm64-nvidia-kmemleak': 'n', 'arm64-nvidia-64k-kmemleak': 'n'}>
+CONFIG_DEBUG_KMEMLEAK_DEFAULT_OFF               note<'Enable kmemleak by default on boot'>
+
+CONFIG_DEBUG_KMEMLEAK_AUTO_SCAN                 policy<{'arm64-nvidia-kmemleak': 'y', 'arm64-nvidia-64k-kmemleak': 'y'}>
+CONFIG_DEBUG_KMEMLEAK_AUTO_SCAN                 note<'Enable automatic kmemleak scanning'>
+
+CONFIG_SAMPLE_KMEMLEAK                          policy<{'arm64-nvidia-kmemleak': 'n', 'arm64-nvidia-64k-kmemleak': 'n'}>
+CONFIG_SAMPLE_KMEMLEAK                          note<'Disable kmemleak sample/test module'>

--- a/debian.nvidia-6.17/control.d/vars.nvidia-64k-kmemleak
+++ b/debian.nvidia-6.17/control.d/vars.nvidia-64k-kmemleak
@@ -1,0 +1,5 @@
+arch="arm64"
+supported="NVIDIA 64K pages with kmemleak"
+target="Intended for NVIDIA platforms with 64K pages and kmemleak enabled for debugging"
+bootloader="grub-efi-arm64 [arm64] | flash-kernel [arm64]"
+provides="kvm-api-4, redhat-cluster-modules, ivtv-modules"

--- a/debian.nvidia-6.17/control.d/vars.nvidia-kmemleak
+++ b/debian.nvidia-6.17/control.d/vars.nvidia-kmemleak
@@ -1,0 +1,5 @@
+arch="arm64"
+supported="NVIDIA with kmemleak"
+target="Intended for NVIDIA platforms with kmemleak enabled for debugging"
+bootloader="grub-efi-arm64 [arm64] | flash-kernel [arm64]"
+provides="kvm-api-4, redhat-cluster-modules, ivtv-modules"

--- a/debian.nvidia-6.17/rules.d/arm64.mk
+++ b/debian.nvidia-6.17/rules.d/arm64.mk
@@ -1,6 +1,6 @@
 build_arch	= arm64
 defconfig	= defconfig
-flavours	= nvidia nvidia-64k
+flavours	= nvidia nvidia-64k nvidia-kmemleak nvidia-64k-kmemleak
 build_image	= Image.gz
 kernel_file	= arch/$(build_arch)/boot/Image.gz
 install_file	= vmlinuz


### PR DESCRIPTION
Add new arm64 kernel flavors with kmemleak enabled for memory leak debugging:
- nvidia-kmemleak: inherits from nvidia, adds kmemleak support
- nvidia-64k-kmemleak: inherits from nvidia-64k, adds kmemleak support

Kmemleak configuration:
- CONFIG_DEBUG_KMEMLEAK=y
- CONFIG_DEBUG_KMEMLEAK_MEM_POOL_SIZE=16000
- CONFIG_DEBUG_KMEMLEAK_DEFAULT_OFF=n (enabled by default on boot)
- CONFIG_DEBUG_KMEMLEAK_AUTO_SCAN=y
- CONFIG_SAMPLE_KMEMLEAK=n