### PR TITLE
[linux-nvidia-6.17] Backport perf: Fix 0 count issue of cpu-clock

### DIFF
--- a/kernel/events/core.c
+++ b/kernel/events/core.c
@@ -11890,7 +11890,7 @@ static int cpu_clock_event_add(struct perf_event *event, int flags)
 
 static void cpu_clock_event_del(struct perf_event *event, int flags)
 {
-	cpu_clock_event_stop(event, flags);
+	cpu_clock_event_stop(event, PERF_EF_UPDATE);
 }
 
 static void cpu_clock_event_read(struct perf_event *event)


### PR DESCRIPTION
Currently cpu-clock event always returns 0 count, e.g.,

perf stat -e cpu-clock -- sleep 1

 Performance counter stats for 'sleep 1':
                 0      cpu-clock                        #    0.000 CPUs utilized
       1.002308394 seconds time elapsed

The root cause is the commit 'bc4394e5e79c ("perf: Fix the throttle
 error of some clock events")' adds PERF_EF_UPDATE flag check before
calling cpu_clock_event_update() to update the count, however the PERF_EF_UPDATE flag is never set when the cpu-clock event is stopped in counting mode (pmu->dev() -> cpu_clock_event_del() -> cpu_clock_event_stop()). This leads to the cpu-clock event count is never updated.

To fix this issue, force to set PERF_EF_UPDATE flag for cpu-clock event just like what task-clock does.

Fixes: bc4394e5e79c ("perf: Fix the throttle error of some clock events")


Reviewed-by: Ian Rogers <irogers@google.com>
Acked-by: Namhyung Kim <namhyung@kernel.org>
Link: https://patch.msgid.link/20251112080526.3971392-1-dapeng1.mi@linux.intel.com (cherry picked from commit f1f96511b1c4c33e53f05909dd267878e0643a9a)

<hr>

LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia/+bug/2139648