### PR TITLE
 UBUNTU: [Packaging] Enable coresight in Perf if arm64

### DIFF
--- a/debian/rules.d/2-binary-arch.mk
+++ b/debian/rules.d/2-binary-arch.mk
@@ -622,7 +622,7 @@ ifeq ($(do_tools_cpupower),true)
 endif
 ifeq ($(do_tools_perf),true)
 	cd $(builddirpa)/tools/perf && \
-		$(kmake) prefix=/usr HAVE_CPLUS_DEMANGLE_SUPPORT=1 CROSS_COMPILE=$(CROSS_COMPILE) NO_LIBPERL=1 WERROR=0
+		$(kmake) prefix=/usr HAVE_CPLUS_DEMANGLE_SUPPORT=1 CROSS_COMPILE=$(CROSS_COMPILE) NO_LIBPERL=1 WERROR=0 $(if $(filter arm64,$(build_arch)),CORESIGHT=1)
 endif
 ifeq ($(do_tools_bpftool),true)
 	$(kmake) CROSS_COMPILE=$(CROSS_COMPILE) -C $(builddirpa)/tools/bpf/bpftool


### PR DESCRIPTION
It's https://github.com/NVIDIA/NV-Kernels/pull/38/commits/12081223b11a93ffb4bfc4369a80372edc8fe0ca on 6.8 (6.8 build log: https://launchpadlibrarian.net/845166918/buildlog_ubuntu-noble-arm64.linux-nvidia_6.8.0-1046.49_BUILDING.txt.gz )

but it's missing from 6.17 (build log: https://launchpadlibrarian.net/832073467/buildlog_ubuntu-noble-arm64.linux-nvidia-6.17_6.17.0-1004.4_GATHERING.txt.gz)

which causes bench of coresight test case didn't see on 6.17 kernel.

```
$ uname -r
6.17.0-1008-nvidia-64k
$ sudo perf test list 'arm coresight'
$
```

<hr>

LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia/+bug/2093957 (re-using the same LP from when this change was made in 6.8-LTS)