### PR TITLE
NVIDIA: SAUCE: vfio: Remove vfio_device_from_file() declaration

### DIFF
--- a/include/linux/vfio.h
+++ b/include/linux/vfio.h
@@ -331,7 +331,6 @@ static inline bool vfio_file_has_dev(struct file *file, struct vfio_device *devi
 	return false;
 }
 #endif
-struct vfio_device *vfio_device_from_file(struct file *file);
 bool vfio_file_is_valid(struct file *file);
 bool vfio_file_enforced_coherent(struct file *file);
 void vfio_file_set_kvm(struct file *file, struct kvm *kvm);


### PR DESCRIPTION
Remove this declaration which is now used within the file after merging upstream "vfio/nvgrace-gpu: register device memory for poison handling".

Fixes: 
```
drivers/vfio/vfio_main.c:1369:28: error: static declaration of ‘vfio_device_from_file’ follows non-static declaration
 1369 | static struct vfio_device *vfio_device_from_file(struct file *file)
      |                            ^~~~~~~~~~~~~~~~~~~~~
In file included from drivers/vfio/vfio_main.c:35:
./include/linux/vfio.h:334:21: note: previous declaration of ‘vfio_device_from_file’ with type ‘struct vfio_device *(struct file *)’
  334 | struct vfio_device *vfio_device_from_file(struct file *file);
      |                     ^~~~~~~~~~~~~~~~~~~~~
  LD [M]  drivers/vfio/platform/vfio-platform.o
```