### PR TITLE
[linux-nvidia-6.17] kexec warning

### DIFF
--- a/include/linux/kexec.h
+++ b/include/linux/kexec.h
@@ -527,7 +527,7 @@ extern bool kexec_file_dbg_print;
 #define kexec_dprintk(fmt, arg...) \
         do { if (kexec_file_dbg_print) pr_info(fmt, ##arg); } while (0)
 
-extern void *kimage_map_segment(struct kimage *image, unsigned long addr, unsigned long size);
+extern void *kimage_map_segment(struct kimage *image, int idx);
 extern void kimage_unmap_segment(void *buffer);
 #else /* !CONFIG_KEXEC_CORE */
 struct pt_regs;
@@ -537,7 +537,7 @@ static inline void __crash_kexec(struct pt_regs *regs) { }
 static inline void crash_kexec(struct pt_regs *regs) { }
 static inline int kexec_should_crash(struct task_struct *p) { return 0; }
 static inline int kexec_crash_loaded(void) { return 0; }
-static inline void *kimage_map_segment(struct kimage *image, unsigned long addr, unsigned long size)
+static inline void *kimage_map_segment(struct kimage *image, int idx)
 { return NULL; }
 static inline void kimage_unmap_segment(void *buffer) { }
 #define kexec_in_progress false

--- a/kernel/kexec_core.c
+++ b/kernel/kexec_core.c
@@ -961,16 +961,19 @@ int kimage_load_segment(struct kimage *image, int idx)
 	return result;
 }
 
-void *kimage_map_segment(struct kimage *image,
-			 unsigned long addr, unsigned long size)
+void *kimage_map_segment(struct kimage *image, int idx)
 {
+	unsigned long addr, size, eaddr;
 	unsigned long src_page_addr, dest_page_addr = 0;
-	unsigned long eaddr = addr + size;
 	kimage_entry_t *ptr, entry;
 	struct page **src_pages;
 	unsigned int npages;
 	void *vaddr = NULL;
 	int i;
+
+	addr = image->segment[idx].mem;
+	size = image->segment[idx].memsz;
+	eaddr = addr + size;
 
 	/*
 	 * Collect the source pages and map them in a contiguous VA range.

--- a/kernel/kexec_core.c
+++ b/kernel/kexec_core.c
@@ -968,13 +968,17 @@ void *kimage_map_segment(struct kimage *image, int idx)
 	kimage_entry_t *ptr, entry;
 	struct page **src_pages;
 	unsigned int npages;
+	struct page *cma;
 	void *vaddr = NULL;
 	int i;
+
+	cma = image->segment_cma[idx];
+	if (cma)
+		return page_address(cma);
 
 	addr = image->segment[idx].mem;
 	size = image->segment[idx].memsz;
 	eaddr = addr + size;
-
 	/*
 	 * Collect the source pages and map them in a contiguous VA range.
 	 */
@@ -1015,7 +1019,8 @@ void *kimage_map_segment(struct kimage *image, int idx)
 
 void kimage_unmap_segment(void *segment_buffer)
 {
-	vunmap(segment_buffer);
+	if (is_vmalloc_addr(segment_buffer))
+		vunmap(segment_buffer);
 }
 
 struct kexec_load_limit {

--- a/security/integrity/ima/ima_kexec.c
+++ b/security/integrity/ima/ima_kexec.c
@@ -250,9 +250,7 @@ void ima_kexec_post_load(struct kimage *image)
 	if (!image->ima_buffer_addr)
 		return;
 
-	ima_kexec_buffer = kimage_map_segment(image,
-					      image->ima_buffer_addr,
-					      image->ima_buffer_size);
+	ima_kexec_buffer = kimage_map_segment(image, image->ima_segment_index);
 	if (!ima_kexec_buffer) {
 		pr_err("Could not map measurements buffer.\n");
 		return;


### PR DESCRIPTION
when doing kexec -a -l /boot/vmlinuz-6.17.0-1008-nvidia-64k --initrd=/boot/initrd.img-6.17.0-1008-nvidia-64k --reuse-cmdline
we see this warning 
​​​​​​[  265.233332] ------------[ cut here ]------------
[  265.233342] WARNING: CPU: 39 PID: 3409 at kernel/kexec_core.c:1002 kimage_map_segment+0x1e8/0x230
[  265.233366] Modules linked in: xt_conntrack xt_MASQUERADE bridge stp llc xt_set ip_set nft_chain_nat nf_nat nf_conntrack nf_defrag_ipv6 nf_defrag_ipv4 xt_addrtype nft_compat nf_tables xfrm_user xfrm_algo nvidia_uvm(OE) qrtr overlay cfg80211 nvidia_drm(OE) sunrpc binfmt_misc nls_iso8859_1 onboard_usb_dev dax_hmem cxl_acpi cppc_cpufreq cxl_port ast cxl_core i2c_algo_bit ipmi_ssif sbsa_gwdt einj spi_nor nvidia_modeset(OE) nvidia_cspmu video acpi_power_meter drm_ttm_helper coresight_tmc coresight_stm coresight_funnel coresight_trbe arm_cspmu_module arm_spe_pmu mlx5_fwctl ttm acpi_ipmi arm_smmuv3_pmu ipmi_devintf stm_p_basic fwctl coresight stm_core ipmi_msghandler uio_pdrv_genirq sch_fq_codel uio ib_umad nvidia_fs(O) nvidia(OE) dm_multipath nvme_fabrics efi_pstore nfnetlink dmi_sysfs ip_tables x_tables autofs4 btrfs blake2b_generic raid10 raid456 async_raid6_recov async_memcpy async_pq async_xor async_tx xor xor_neon raid6_pq raid1 raid0 linear mlx5_ib ib_uverbs macsec ib_core mlx5_dpll polyval_ce ghash_ce sm4_ce_gcm
[  265.233478]  sm4_ce_ccm mlx5_core sm4_ce nvme mlxfw sm4_ce_cipher i2c_smbus nvme_core sm4 psample sm3_ce nvme_keyring tls sha3_ce arm_smccc_trng xhci_pci_renesas nvme_auth pci_hyperv_intf i2c_tegra aes_neon_bs aes_neon_blk aes_ce_blk aes_ce_cipher
[  265.233510] CPU: 39 UID: 0 PID: 3409 Comm: kexec Tainted: G           OE       6.17.0-1008-nvidia-64k #8-Ubuntu PREEMPT(none)
[  265.233515] Tainted: [O]=OOT_MODULE, [E]=UNSIGNED_MODULE
[  265.233517] Hardware name:  Grace CPU P5041, BIOS 02.03.25 20250326
[  265.233520] pstate: 83400009 (Nzcv daif +PAN -UAO +TCO +DIT -SSBS BTYPE=--)
[  265.233523] pc : kimage_map_segment+0x1e8/0x230
[  265.233527] lr : kimage_map_segment+0x54/0x230
[  265.233529] sp : ffff80011ceef9a0
[  265.233531] x29: ffff80011ceef9a0 x28: 0000000000000004 x27: 0000000000000004
[  265.233535] x26: ffffa0318c2297e8 x25: ffff100045e70c00 x24: 0000000000000000
[  265.233539] x23: 00000000ba510000 x22: 00000000ba500000 x21: ffff100013d86168
[  265.233543] x20: 0000000000000001 x19: ffff100045e70c00 x18: ffff80011cf20040
[  265.233546] x17: 0000000000000000 x16: 0000000000000000 x15: 646565732d676e72
[  265.233550] x14: 00646e652d647274 x13: 636578656b2d6d6f x12: 72662d6465746f6f
[  265.233553] x11: 007265666675622d x10: 636578656b2d616d x9 : ffffa0318a6755b8
[  265.233557] x8 : 0000000000000000 x7 : 0000000080000000 x6 : 0000000000000000
[  265.233560] x5 : ffff100045e70c00 x4 : 0000000000000000 x3 : 0000000000000004
[  265.233564] x2 : 0000000000000000 x1 : ffffffdfc0000000 x0 : 0001000000000000
[  265.233569] Call trace:
[  265.233571]  kimage_map_segment+0x1e8/0x230 (P)
[  265.233575]  ima_kexec_post_load+0x74/0x100
[  265.233584]  __do_sys_kexec_file_load+0x314/0x428
[  265.233586]  __arm64_sys_kexec_file_load+0x30/0x60
[  265.233588]  invoke_syscall.constprop.0+0x7c/0xf8
[  265.233593]  do_el0_svc+0x4c/0x100
[  265.233595]  el0_svc+0x48/0x200
[  265.233603]  el0t_64_sync_handler+0xc0/0x108
[  265.233605]  el0t_64_sync+0x1b8/0x1c0
[  265.233608] ---[ end trace 0000000000000000 ]---
[  265.233632] ------------[ cut here ]------------
[  265.233635] WARNING: CPU: 39 PID: 3409 at mm/vmalloc.c:542 vmap_pages_pte_range+0x27c/0x550
[  265.233644] Modules linked in: xt_conntrack xt_MASQUERADE bridge stp llc xt_set ip_set nft_chain_nat nf_nat nf_conntrack nf_defrag_ipv6 nf_defrag_ipv4 xt_addrtype nft_compat nf_tables xfrm_user xfrm_algo nvidia_uvm(OE) qrtr overlay cfg80211 nvidia_drm(OE) sunrpc binfmt_misc nls_iso8859_1 onboard_usb_dev dax_hmem cxl_acpi cppc_cpufreq cxl_port ast cxl_core i2c_algo_bit ipmi_ssif sbsa_gwdt einj spi_nor nvidia_modeset(OE) nvidia_cspmu video acpi_power_meter drm_ttm_helper coresight_tmc coresight_stm coresight_funnel coresight_trbe arm_cspmu_module arm_spe_pmu mlx5_fwctl ttm acpi_ipmi arm_smmuv3_pmu ipmi_devintf stm_p_basic fwctl coresight stm_core ipmi_msghandler uio_pdrv_genirq sch_fq_codel uio ib_umad nvidia_fs(O) nvidia(OE) dm_multipath nvme_fabrics efi_pstore nfnetlink dmi_sysfs ip_tables x_tables autofs4 btrfs blake2b_generic raid10 raid456 async_raid6_recov async_memcpy async_pq async_xor async_tx xor xor_neon raid6_pq raid1 raid0 linear mlx5_ib ib_uverbs macsec ib_core mlx5_dpll polyval_ce ghash_ce sm4_ce_gcm
[  265.233725]  sm4_ce_ccm mlx5_core sm4_ce nvme mlxfw sm4_ce_cipher i2c_smbus nvme_core sm4 psample sm3_ce nvme_keyring tls sha3_ce arm_smccc_trng xhci_pci_renesas nvme_auth pci_hyperv_intf i2c_tegra aes_neon_bs aes_neon_blk aes_ce_blk aes_ce_cipher
[  265.233747] CPU: 39 UID: 0 PID: 3409 Comm: kexec Tainted: G        W  OE       6.17.0-1008-nvidia-64k #8-Ubuntu PREEMPT(none)
[  265.233750] Tainted: [W]=WARN, [O]=OOT_MODULE, [E]=UNSIGNED_MODULE
[  265.233752] Hardware name:  Grace CPU P5041, BIOS 02.03.25 20250326
[  265.233754] pstate: 23400009 (nzCv daif +PAN -UAO +TCO +DIT -SSBS BTYPE=--)
[  265.233755] pc : vmap_pages_pte_range+0x27c/0x550
[  265.233757] lr : vmap_small_pages_range_noflush+0x130/0x1f0
[  265.233759] sp : ffff80011ceef860
[  265.233760] x29: ffff80011ceef860 x28: 0010000000000001 x27: ffffa0318c43a000
[  265.233765] x26: ffff80011ceef8e0 x25: ffff80011e140000 x24: ffff0000957bf0a0
[  265.233769] x23: ffffffdfc0000000 x22: ffff80011ceef8e4 x21: 0068000000000703
[  265.233773] x20: ffff80011e150000 x19: 5d0752412f6f21b8 x18: ffff80011cf20058
[  265.233777] x17: 0000000000000000 x16: 0000000000000000 x15: 646565732d676e72
[  265.233781] x14: 00646e652d647274 x13: 636578656b2d6d6f x12: 72662d6465746f6f
[  265.233785] x11: 0000000000000000 x10: 0000000000000000 x9 : ffffa0318a63e440
[  265.233789] x8 : 0000000000000000 x7 : 0040000000000001 x6 : 0040000000000041
[  265.233793] x5 : ffff80011ceef8e0 x4 : ffff100013d86168 x3 : 0068000000000703
[  265.233797] x2 : 0000000000000000 x1 : 003fffffffffffc0 x0 : 5d0752616f8f21b8
[  265.233801] Call trace:
[  265.233803]  vmap_pages_pte_range+0x27c/0x550 (P)
[  265.233805]  vmap_small_pages_range_noflush+0x130/0x1f0
[  265.233807]  vmap+0xb8/0x180
[  265.233811]  kimage_map_segment+0xf0/0x230[  265.233332] 

kexec will still work fine but with system with CMA enabled will see this warning. 

Lore discussion: https://lore.kernel.org/all/20251216014852.8737-1-piliu@redhat.com/T/#mecdfe3e65f7f6ba31335e4240cc16b51a495caea
Nvbug:https://nvbugspro.nvidia.com/bug/5895597
Launchpad:https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-6.17/+bug/2141705