### PR TITLE
MPAM: Pull Request: CPU-less feature, numa id as domain id, performance fix

### DIFF
--- a/drivers/resctrl/mpam_devices.c
+++ b/drivers/resctrl/mpam_devices.c
@@ -1552,15 +1552,15 @@ int mpam_msmon_read(struct mpam_component *comp, struct mon_cfg *ctx,
 	if (!mpam_has_feature(type, cprops))
 		return -EOPNOTSUPP;
 
+	if (type == mpam_feat_msmon_mbwu)
+		type = mpam_msmon_choose_counter(class);
+
 	arg = (struct mon_read) {
 		.ctx = ctx,
 		.type = type,
 		.val = val,
 	};
 	*val = 0;
-
-	if (type == mpam_feat_msmon_mbwu)
-		type = mpam_msmon_choose_counter(class);
 
 	err = _msmon_read(comp, &arg);
 	if (err == -EBUSY && class->nrdy_usec)

--- a/drivers/resctrl/mpam_devices.c
+++ b/drivers/resctrl/mpam_devices.c
@@ -2874,6 +2874,12 @@ static irqreturn_t __mpam_irq_handler(int irq, struct mpam_msc *msc)
 			   msc->id, mpam_errcode_names[errcode], partid, pmg,
 			   ris);
 
+	/* No action is required for the MPAM programming errors */
+	if ((errcode != MPAM_ERRCODE_REQ_PARTID_RANGE) &&
+	    (errcode != MPAM_ERRCODE_REQ_PMG_RANGE)) {
+		return IRQ_HANDLED;
+	}
+
 	/* Disable this interrupt. */
 	mpam_disable_msc_ecr(msc);
 

--- a/drivers/resctrl/mpam_devices.c
+++ b/drivers/resctrl/mpam_devices.c
@@ -1945,6 +1945,45 @@ static void mpam_wa_t241_force_mbw_min_to_one(struct mpam_config *cfg,
 	cfg->mbw_min = min_hw_granule + 1;
 }
 
+static u16 mpam_wa_t241_calc_min_from_max(struct mpam_config *cfg)
+{
+	u16 val = 0;
+
+	if (mpam_has_feature(mpam_feat_mbw_max, cfg)) {
+		u16 delta = ((5 * MPAMCFG_MBW_MAX_MAX) / 100) - 1;
+
+		if (cfg->mbw_max > delta)
+			val = cfg->mbw_max - delta;
+	}
+
+	return val;
+}
+
+/*
+ * Based on T241-MPAM-4 erratum, need to avoid to enter a throttled state
+ * when mbw_min is 0 and set mbw_min to 95% of mbw_max.
+ *
+ * The workaround of the erratum:
+ *
+ * 1. Set mbw_min to 95% of mbw_max so memory bandwidth will be used as
+ *    much as possible.
+ * 2. If for any reason, the calculation of 95% of mbw_max is smaller than 1,
+ *    mbw_min is forced to 1 to avoid to enter the throttled state.
+ */
+static void mpam_wa_t241_set_mbw_min(struct mpam_config *cfg,
+				     struct mpam_props *props)
+{
+	u16 val = 0;
+
+	/* cfg->mbw_min is fored to 1 */
+	mpam_wa_t241_force_mbw_min_to_one(cfg, props);
+	val = mpam_wa_t241_calc_min_from_max(cfg);
+
+	/* If 95% of mbw_max is bigger than 1, set mbw_min to 95% of mbw_max */
+	if (val > cfg->mbw_min)
+		cfg->mbw_min = val;
+}
+
 /*
  * Called via smp_call_on_cpu() to prevent migration, while still being
  * pre-emptible. Caller must hold mpam_srcu.
@@ -1961,7 +2000,7 @@ static int mpam_reset_ris(void *arg)
 
 	mpam_init_reset_cfg(&reset_cfg);
 	if (mpam_has_quirk(T241_FORCE_MBW_MIN_TO_ONE, msc))
-		mpam_wa_t241_force_mbw_min_to_one(&reset_cfg, &ris->props);
+		mpam_wa_t241_set_mbw_min(&reset_cfg, &ris->props);
 
 	reprogram_arg.ris = ris;
 	reprogram_arg.cfg = &reset_cfg;
@@ -3028,8 +3067,7 @@ static void mpam_reset_component_cfg(struct mpam_component *comp)
 	for (i = 0; i < mpam_partid_max + 1; i++) {
 		mpam_init_reset_cfg(&comp->cfg[i]);
 		if (mpam_has_quirk(T241_FORCE_MBW_MIN_TO_ONE, class))
-			mpam_wa_t241_force_mbw_min_to_one(&comp->cfg[i],
-							  &class->props);
+			mpam_wa_t241_set_mbw_min(&comp->cfg[i], &class->props);
 	}
 }
 

--- a/drivers/resctrl/mpam_devices.c
+++ b/drivers/resctrl/mpam_devices.c
@@ -727,7 +727,8 @@ static int mpam_ris_get_affinity(struct mpam_msc *msc, cpumask_t *affinity,
 		if (cpumask_empty(affinity)) {
 			dev_warn_once(&msc->pdev->dev, "CPU-less numa node");
 			cpumask_copy(affinity, cpu_possible_mask);
-		}
+		} else if (class->level > 3)
+			cpumask_copy(affinity, cpu_possible_mask);
 		break;
 	case MPAM_CLASS_UNKNOWN:
 		return 0;

--- a/drivers/resctrl/mpam_devices.c
+++ b/drivers/resctrl/mpam_devices.c
@@ -3455,8 +3455,8 @@ static bool mpam_update_config(struct mpam_config *cfg,
 static void mpam_extend_config(struct mpam_class *class, struct mpam_config *cfg)
 {
 	struct mpam_props *cprops = &class->props;
-	u16 min, min_hw_granule, delta;
 	u16 max_hw_value, res0_bits;
+	u16 min_hw_granule;
 
 	/*
 	 * Calculate the values the 'min' control can hold.
@@ -3469,25 +3469,6 @@ static void mpam_extend_config(struct mpam_class *class, struct mpam_config *cfg
 	res0_bits = 16 - cprops->bwa_wd;
 	max_hw_value = ((1 << cprops->bwa_wd) - 1) << res0_bits;
 	min_hw_granule = ~max_hw_value;
-
-	/*
-	 * MAX and MIN should be set together. If only one is provided,
-	 * generate a configuration for the other. If only one control
-	 * type is supported, the other value will be ignored.
-	 *
-	 * Resctrl can only configure the MAX.
-	 */
-	if (mpam_has_feature(mpam_feat_mbw_max, cfg) &&
-	    !mpam_has_feature(mpam_feat_mbw_min, cfg)) {
-		delta = ((5 * MPAMCFG_MBW_MAX_MAX) / 100) - 1;
-		if (cfg->mbw_max > delta)
-			min = cfg->mbw_max - delta;
-		else
-			min = 0;
-
-		cfg->mbw_min = max(min, min_hw_granule);
-		mpam_set_feature(mpam_feat_mbw_min, cfg);
-	}
 
 	if (mpam_has_quirk(T241_FORCE_MBW_MIN_TO_ONE, class) &&
 	    cfg->mbw_min <= min_hw_granule) {

--- a/drivers/resctrl/mpam_devices.c
+++ b/drivers/resctrl/mpam_devices.c
@@ -19,6 +19,7 @@
 #include <linux/irq.h>
 #include <linux/irqdesc.h>
 #include <linux/list.h>
+#include <linux/list_sort.h>
 #include <linux/lockdep.h>
 #include <linux/mutex.h>
 #include <linux/moduleparam.h>
@@ -2761,6 +2762,21 @@ static void mpam_enable_merge_class_features(struct mpam_component *comp)
 		__class_props_mismatch(class, vmsc);
 }
 
+
+static int mpam_component_sort_cmp(void *priv, const struct list_head *a,
+				   const struct list_head *b)
+{
+	const struct mpam_component *comp0;
+	const struct mpam_component *comp1;
+
+	lockdep_assert_held(&mpam_list_lock);
+
+	comp0 = list_entry(a, struct mpam_component, class_list);
+	comp1 = list_entry(b, struct mpam_component, class_list);
+
+	return comp0->comp_id > comp1->comp_id;
+}
+
 /*
  * Merge all the common resource features into class.
  * vmsc features are bitwise-or'd together by mpam_enable_merge_vmsc_features()
@@ -2782,6 +2798,9 @@ static void mpam_enable_merge_features(struct list_head *all_classes_list)
 	lockdep_assert_held(&mpam_list_lock);
 
 	list_for_each_entry(class, all_classes_list, classes_list) {
+
+		list_sort(NULL, &class->components, mpam_component_sort_cmp);
+
 		list_for_each_entry(comp, &class->components, class_list)
 			mpam_enable_merge_vmsc_features(comp);
 

--- a/drivers/resctrl/mpam_devices.c
+++ b/drivers/resctrl/mpam_devices.c
@@ -724,6 +724,10 @@ static int mpam_ris_get_affinity(struct mpam_msc *msc, cpumask_t *affinity,
 	case MPAM_CLASS_MEMORY:
 		get_cpumask_from_node_id(comp->comp_id, affinity);
 		/* affinity may be empty for CPU-less memory nodes */
+		if (cpumask_empty(affinity)) {
+			dev_warn_once(&msc->pdev->dev, "CPU-less numa node");
+			cpumask_copy(affinity, cpu_possible_mask);
+		}
 		break;
 	case MPAM_CLASS_UNKNOWN:
 		return 0;

--- a/drivers/resctrl/mpam_resctrl.c
+++ b/drivers/resctrl/mpam_resctrl.c
@@ -1251,9 +1251,9 @@ static void mpam_resctrl_pick_counters(void)
 					update_rmid_limits(cache_size);
 
 				counter_update_class(QOS_L3_OCCUP_EVENT_ID, class);
-				return;
+				break;
 			default:
-				return;
+				break;
 			}
 		}
 

--- a/drivers/resctrl/mpam_resctrl.c
+++ b/drivers/resctrl/mpam_resctrl.c
@@ -1522,6 +1522,9 @@ static int mpam_resctrl_pick_domain_id(int cpu, struct mpam_component *comp)
 	if (class->type == MPAM_CLASS_CACHE)
 		return comp->comp_id;
 
+	if ((class->type == MPAM_CLASS_MEMORY) && (class->level > 3))
+		return comp->comp_id;
+
 	if (topology_matches_l3(class)) {
 		/* Use the corresponding L3 component ID as the domain ID */
 		int id = get_cpu_cacheinfo_id(cpu, 3);
@@ -2146,7 +2149,8 @@ mpam_resctrl_alloc_domain_nid(int nid, struct mpam_resctrl_res *res)
 }
 
 static struct mpam_resctrl_dom *
-mpam_resctrl_get_domain_from_cpu(int cpu, struct mpam_resctrl_res *res)
+mpam_get_ctrl_domain_from_cpu(int cpu, struct mpam_resctrl_res *res,
+			      struct mpam_component *comp)
 {
 	struct mpam_resctrl_dom *dom;
 	struct rdt_ctrl_domain *ctrl_d;
@@ -2156,6 +2160,8 @@ mpam_resctrl_get_domain_from_cpu(int cpu, struct mpam_resctrl_res *res)
 
 	list_for_each_entry(ctrl_d, &r->ctrl_domains, hdr.list) {
 		dom = container_of(ctrl_d, struct mpam_resctrl_dom, resctrl_ctrl_dom);
+		if (dom->ctrl_comp != comp)
+			continue;
 
 		if (cpumask_test_cpu(cpu, &dom->ctrl_comp->affinity))
 			return dom;
@@ -2193,6 +2199,7 @@ int mpam_resctrl_online_cpu(unsigned int cpu)
 	int i, err = 0;
 	struct mpam_resctrl_dom *dom;
 	struct mpam_resctrl_res *res;
+	struct mpam_component *comp;
 
 	mutex_lock(&domain_list_lock);
 	for (i = 0; i < RDT_NUM_RESOURCES; i++) {
@@ -2200,16 +2207,19 @@ int mpam_resctrl_online_cpu(unsigned int cpu)
 		if (!res->class)
 			continue;	// dummy_resource;
 
-		dom = mpam_resctrl_get_domain_from_cpu(cpu, res);
-		if (!dom)
-			dom = mpam_resctrl_alloc_domain_cpu(cpu, res);
-		if (IS_ERR(dom)) {
-			err = PTR_ERR(dom);
-			break;
-		}
+		list_for_each_entry(comp, &res->class->components, class_list) {
+			if (!cpumask_test_cpu(cpu, &comp->affinity))
+				continue;
 
-		cpumask_set_cpu(cpu, &dom->resctrl_ctrl_dom.hdr.cpu_mask);
-		cpumask_set_cpu(cpu, &dom->resctrl_mon_dom.hdr.cpu_mask);
+			dom = mpam_get_ctrl_domain_from_cpu(cpu, res, comp);
+			if (!dom)
+				dom = mpam_resctrl_alloc_domain_cpu(cpu, res);
+			if (IS_ERR(dom))
+				return PTR_ERR(dom);
+
+			cpumask_set_cpu(cpu, &dom->resctrl_ctrl_dom.hdr.cpu_mask);
+			cpumask_set_cpu(cpu, &dom->resctrl_mon_dom.hdr.cpu_mask);
+		}
 	}
 	mutex_unlock(&domain_list_lock);
 
@@ -2227,6 +2237,7 @@ int mpam_resctrl_offline_cpu(unsigned int cpu)
 	struct rdt_mon_domain *mon_d;
 	struct rdt_ctrl_domain *ctrl_d;
 	bool ctrl_dom_empty, mon_dom_empty;
+	struct mpam_component *comp;
 
 	resctrl_offline_cpu(cpu);
 
@@ -2236,32 +2247,31 @@ int mpam_resctrl_offline_cpu(unsigned int cpu)
 		if (!res->class)
 			continue;	// dummy resource
 
-		dom = mpam_resctrl_get_domain_from_cpu(cpu, res);
-		if (WARN_ON_ONCE(!dom))
-			continue;
+		list_for_each_entry(comp, &res->class->components, class_list) {
+			if (!cpumask_test_cpu(cpu, &comp->affinity))
+				continue;
 
-		ctrl_dom_empty = true;
-		if (exposed_alloc_capable) {
+			dom = mpam_get_ctrl_domain_from_cpu(cpu, res, comp);
+			if (WARN_ON_ONCE(!dom))
+				continue;
+
 			mpam_reset_component_locked(dom->ctrl_comp);
 
 			ctrl_d = &dom->resctrl_ctrl_dom;
-			ctrl_dom_empty = mpam_resctrl_offline_domain_hdr(cpumask_of(cpu),
-									 &ctrl_d->hdr);
+			ctrl_dom_empty = mpam_resctrl_offline_domain_hdr(cpumask_of(cpu), &ctrl_d->hdr);
 			if (ctrl_dom_empty)
 				resctrl_offline_ctrl_domain(&res->resctrl_res, ctrl_d);
-		}
+			if (res->resctrl_res.mon_capable) {
+				mon_d = &dom->resctrl_mon_dom;
+				mon_dom_empty = mpam_resctrl_offline_domain_hdr(cpumask_of(cpu), &mon_d->hdr);
+				if (mon_dom_empty)
+					resctrl_offline_mon_domain(&res->resctrl_res, mon_d);
+			} else
+				mon_dom_empty = true;
 
-		mon_dom_empty = true;
-		if (exposed_mon_capable) {
-			mon_d = &dom->resctrl_mon_dom;
-			mon_dom_empty = mpam_resctrl_offline_domain_hdr(cpumask_of(cpu),
-									&mon_d->hdr);
-			if (mon_dom_empty)
-				resctrl_offline_mon_domain(&res->resctrl_res, mon_d);
+			if (ctrl_dom_empty && mon_dom_empty)
+				kfree(dom);
 		}
-
-		if (ctrl_dom_empty && mon_dom_empty)
-			kfree(dom);
 	}
 	mutex_unlock(&domain_list_lock);
 

--- a/drivers/resctrl/mpam_resctrl.c
+++ b/drivers/resctrl/mpam_resctrl.c
@@ -734,6 +734,12 @@ static bool mba_class_use_mbw_max(struct mpam_props *cprops)
 		cprops->bwa_wd);
 }
 
+static bool class_has_usable_mbw_min(struct mpam_props *cprops)
+{
+	return (mpam_has_feature(mpam_feat_mbw_min, cprops) &&
+		cprops->bwa_wd);
+}
+
 static bool class_has_usable_mba(struct mpam_props *cprops)
 {
 	return mba_class_use_mbw_part(cprops) || mba_class_use_mbw_max(cprops);
@@ -843,14 +849,7 @@ static u32 percent_to_mbw_pbm(u8 pc, struct mpam_props *cprops)
  */
 static u32 fract16_to_percent(u16 fract, u8 wd)
 {
-	u32 val = fract;
-
-	val >>= 16 - wd;
-	val += 1;
-	val *= MAX_MBA_BW;
-	val = DIV_ROUND_CLOSEST(val, 1 << wd);
-
-	return val;
+	return DIV_ROUND_CLOSEST((fract + 1) * 100, 65536);
 }
 
 /*
@@ -865,29 +864,12 @@ static u32 fract16_to_percent(u16 fract, u8 wd)
  */
 static u16 percent_to_fract16(u8 pc, u8 wd)
 {
-	u32 val = pc;
-
-	val <<= wd;
-	val = DIV_ROUND_CLOSEST(val, MAX_MBA_BW);
-	val = max(val, 1) - 1;
-	val <<= 16 - wd;
-
-	return val;
+	return pc ? (((pc * 65536) / 100) - 1) : 0;
 }
 
 static u32 mbw_max_to_percent(u16 mbw_max, struct mpam_props *cprops)
 {
 	return fract16_to_percent(mbw_max, cprops->bwa_wd);
-}
-
-static u16 percent_to_mbw_max(u8 pc, struct mpam_props *cprops)
-{
-	return percent_to_fract16(pc, cprops->bwa_wd);
-}
-
-static u16 percent_to_cmax(u8 pc, struct mpam_props *cprops)
-{
-	return percent_to_fract16(pc, cprops->cmax_wd);
 }
 
 static u32 get_mba_min(struct mpam_props *cprops)
@@ -1117,6 +1099,10 @@ static void mpam_resctrl_pick_mba(void)
 		res = &mpam_resctrl_controls[RDT_RESOURCE_MBA];
 		res->class = candidate_class;
 		exposed_alloc_capable = true;
+		if (class_has_usable_mbw_min(&candidate_class->props)) {
+			res = &mpam_resctrl_controls[RDT_RESOURCE_MBA_MIN];
+			res->class = candidate_class;
+		}
 	}
 }
 
@@ -1501,6 +1487,28 @@ static int mpam_resctrl_control_init(struct mpam_resctrl_res *res,
 
 		r->name = "MB";
 
+		/* Round up to at least 1% */
+		if (!r->membw.bw_gran)
+			r->membw.bw_gran = 1;
+
+		break;
+	case RDT_RESOURCE_MBA_MIN:
+		r->alloc_capable = true;
+		r->schema_fmt = RESCTRL_SCHEMA_PERCENT;
+		r->ctrl_scope = RESCTRL_L3_CACHE;
+
+		r->mba.delay_linear = true;
+		r->mba.throttle_mode = THREAD_THROTTLE_UNDEFINED;
+		r->membw.min_bw = get_mba_granularity(cprops);
+		r->membw.max_bw = MAX_MBA_BW;
+		r->membw.bw_gran = get_mba_granularity(cprops);
+
+		r->name = "MB_MIN";
+
+		/* Round up to at least 1% */
+		if (!r->membw.bw_gran)
+			r->membw.bw_gran = 1;
+
 		break;
 	default:
 		break;
@@ -1724,6 +1732,12 @@ u32 resctrl_arch_get_config(struct rdt_resource *r, struct rdt_ctrl_domain *d,
 	case RDT_RESOURCE_L3_MAX:
 		configured_by = mpam_feat_cmax_cmax;
 		break;
+	case RDT_RESOURCE_MBA_MIN:
+		if (mpam_has_feature(mpam_feat_mbw_min, cprops)) {
+			configured_by = mpam_feat_mbw_min;
+			break;
+		}
+		return -EINVAL;
 	case RDT_RESOURCE_MBA:
 		if (mba_class_use_mbw_part(cprops)) {
 			configured_by = mpam_feat_mbw_part;
@@ -1738,8 +1752,11 @@ u32 resctrl_arch_get_config(struct rdt_resource *r, struct rdt_ctrl_domain *d,
 	}
 
 	if (!r->alloc_capable || partid >= resctrl_arch_get_num_closid(r) ||
-	    !mpam_has_feature(configured_by, cfg))
-		goto err;
+	    !mpam_has_feature(configured_by, cfg)) {
+		if (configured_by == mpam_feat_mbw_min)
+			return 0;
+		return resctrl_get_resource_default_ctrl(r);
+	}
 
 	switch (configured_by) {
 	case mpam_feat_cpor_part:
@@ -1752,6 +1769,8 @@ u32 resctrl_arch_get_config(struct rdt_resource *r, struct rdt_ctrl_domain *d,
 		return mbw_pbm_to_percent(cfg->mbw_pbm, cprops);
 	case mpam_feat_mbw_max:
 		return mbw_max_to_percent(cfg->mbw_max, cprops);
+	case mpam_feat_mbw_min:
+		return fract16_to_percent(cfg->mbw_min, cprops->bwa_wd);
 	default:
 		goto err;
 	}
@@ -1805,8 +1824,12 @@ int resctrl_arch_update_one(struct rdt_resource *r, struct rdt_ctrl_domain *d,
 		break;
 	case RDT_RESOURCE_L2_MAX:
 	case RDT_RESOURCE_L3_MAX:
-		cfg.cmax = percent_to_cmax(cfg_val, cprops);
+		cfg.cmax = percent_to_fract16(cfg_val, cprops->bwa_wd);
 		mpam_set_feature(mpam_feat_cmax_cmax, &cfg);
+		break;
+	case RDT_RESOURCE_MBA_MIN:
+		cfg.mbw_min = percent_to_fract16(cfg_val, cprops->bwa_wd);
+		mpam_set_feature(mpam_feat_mbw_min, &cfg);
 		break;
 	case RDT_RESOURCE_MBA:
 		if (mba_class_use_mbw_part(cprops)) {
@@ -1814,7 +1837,7 @@ int resctrl_arch_update_one(struct rdt_resource *r, struct rdt_ctrl_domain *d,
 			mpam_set_feature(mpam_feat_mbw_part, &cfg);
 			break;
 		} else if (mpam_has_feature(mpam_feat_mbw_max, cprops)) {
-			cfg.mbw_max = percent_to_mbw_max(cfg_val, cprops);
+			cfg.mbw_max = percent_to_fract16(cfg_val, cprops->bwa_wd);
 			mpam_set_feature(mpam_feat_mbw_max, &cfg);
 			break;
 		}

--- a/drivers/resctrl/mpam_resctrl.c
+++ b/drivers/resctrl/mpam_resctrl.c
@@ -1056,7 +1056,12 @@ static void mpam_resctrl_pick_mba(void)
 			continue;
 		}
 
-		if (!cpumask_equal(&class->affinity, cpu_possible_mask)) {
+		/*
+		 * For memory classes, allow CPU-less components (memory-only NUMA nodes).
+		 * For other classes, require all CPUs to be covered.
+		 */
+		if (class->type != MPAM_CLASS_MEMORY &&
+		    !cpumask_equal(&class->affinity, cpu_possible_mask)) {
 			pr_debug("class %u has missing CPUs\n", class->level);
 			continue;
 		}
@@ -1095,7 +1100,9 @@ static void mpam_resctrl_pick_mba(void)
 	}
 
 	if (candidate_class) {
-		pr_debug("selected class %u to back MBA\n", candidate_class->level);
+		pr_info("MPAM: selected class %u type %u to back MBA (l3_id=%d, numa_nid=%d)\n",
+			candidate_class->level, candidate_class->type,
+			mb_l3_cache_id_possible, mb_numa_nid_possible);
 		res = &mpam_resctrl_controls[RDT_RESOURCE_MBA];
 		res->class = candidate_class;
 		exposed_alloc_capable = true;
@@ -1597,8 +1604,12 @@ bool resctrl_arch_get_mb_uses_numa_nid(void)
 	return mb_uses_numa_nid;
 }
 
+static int mpam_resctrl_online_node(unsigned int nid);
+static int mpam_resctrl_offline_node(unsigned int nid);
+
 int resctrl_arch_set_mb_uses_numa_nid(bool enabled)
 {
+	int nid;
 	struct rdt_resource *r;
 	struct mpam_resctrl_res *res;
 	struct mpam_resctrl_dom *dom;
@@ -1628,7 +1639,38 @@ int resctrl_arch_set_mb_uses_numa_nid(bool enabled)
 		ctrl_d->hdr.id = mpam_resctrl_pick_domain_id(cpu, dom->ctrl_comp);
 	}
 
-	/* monitor domains are unaffected and should continue to use the L3 */
+	/*
+	 * Create domains for CPU-less NUMA nodes when enabling NUMA node IDs.
+	 * Nodes with CPUs already have domains created via CPU online callbacks.
+	 * Iterate over memory class components since hot-pluggable memory nodes
+	 * might not be in N_MEMORY state yet.
+	 *
+	 * When disabling (unmount path), do NOT call mpam_resctrl_offline_node()
+	 * because rdt_kill_sb() already handles domain cleanup while holding
+	 * rdtgroup_mutex. Calling resctrl_offline_ctrl_domain() here would
+	 * cause a deadlock.
+	 */
+	if (enabled && res->class->type == MPAM_CLASS_MEMORY) {
+		struct mpam_component *comp;
+		int idx;
+
+		pr_info("MPAM: mb_uses_numa_nid=%d, iterating memory class components\n", enabled);
+		idx = srcu_read_lock(&mpam_srcu);
+		list_for_each_entry_srcu(comp, &res->class->components, class_list,
+					 srcu_read_lock_held(&mpam_srcu)) {
+			nid = comp->comp_id;
+			pr_info("MPAM: component nid=%d cpumask_empty=%d\n", nid,
+				cpumask_empty(cpumask_of_node(nid)));
+			if (!cpumask_empty(cpumask_of_node(nid)))
+				continue;  /* Skip nodes with CPUs */
+
+			{
+				int ret = mpam_resctrl_online_node(nid);
+				pr_info("MPAM: online_node(%d) returned %d\n", nid, ret);
+			}
+		}
+		srcu_read_unlock(&mpam_srcu, idx);
+	}
 
 	if (!enabled && mb_l3_cache_id_possible)
 		r->alloc_capable = true;
@@ -2001,6 +2043,26 @@ static struct mpam_component *find_component(struct mpam_class *victim,
 	return NULL;
 }
 
+/*
+ * Find a component in @victim class that has the same affinity as @ref_comp.
+ * This is used to find the equivalent monitor component for a control component.
+ */
+static struct mpam_component *
+find_equivalent_component(struct mpam_component *ref_comp,
+			  struct mpam_class *victim)
+{
+	struct mpam_component *victim_comp;
+
+	guard(srcu)(&mpam_srcu);
+	list_for_each_entry_srcu(victim_comp, &victim->components, class_list,
+				 srcu_read_lock_held(&mpam_srcu)) {
+		if (cpumask_equal(&ref_comp->affinity, &victim_comp->affinity))
+			return victim_comp;
+	}
+
+	return NULL;
+}
+
 static void mpam_resctrl_domain_insert(struct list_head *list,
 				       struct rdt_domain_hdr *new)
 {
@@ -2051,14 +2113,13 @@ mpam_resctrl_alloc_domain(const struct cpumask *onlined_cpus, int nid,
 
 	if (exposed_mon_capable) {
 		int i;
-		struct mpam_component *mon_comp, *any_mon_comp;
+		struct mpam_component *mon_comp, *any_mon_comp = NULL;
 
 		/*
 		 * Even if the monitor domain is backed by a different component,
-		 * the L3 component IDs need to be used... only there may be no
-		 * ctrl_comp for the L3.
-		 * Search each event's class list for a component with overlapping
-		 * CPUs and set up the dom->mon_comp array.
+		 * the control component's affinity is used to find the equivalent
+		 * monitor component in each event's class.
+		 * For monitor-only platforms, fall back to CPU-based search.
 		 */
 		for (i = 0; i < QOS_NUM_EVENTS; i++) {
 			struct mpam_resctrl_mon *mon;
@@ -2067,7 +2128,21 @@ mpam_resctrl_alloc_domain(const struct cpumask *onlined_cpus, int nid,
 			if (!mon->class)
 				continue;       // dummy resource
 
-			mon_comp = find_component(mon->class, onlined_cpus);
+			/*
+			 * If we have a control component, find the equivalent
+			 * monitor component by matching affinity. This ensures
+			 * the correct component is used for each domain,
+			 * especially for CPU-less NUMA nodes.
+			 */
+			if (ctrl_comp) {
+				if (mon->class == ctrl_comp->class)
+					mon_comp = ctrl_comp;
+				else
+					mon_comp = find_equivalent_component(
+							ctrl_comp, mon->class);
+			} else {
+				mon_comp = find_component(mon->class, onlined_cpus);
+			}
 			dom->mon_comp[i] = mon_comp;
 			if (mon_comp)
 				any_mon_comp = mon_comp;
@@ -2077,7 +2152,13 @@ mpam_resctrl_alloc_domain(const struct cpumask *onlined_cpus, int nid,
 		dom->mbm_local_evt_cfg = MPAM_RESTRL_EVT_CONFIG_VALID;
 
 		mon_d = &dom->resctrl_mon_dom;
-		mpam_resctrl_domain_hdr_init(onlined_cpus, any_mon_comp,
+		/*
+		 * Use the control component for the monitor domain header
+		 * to ensure the domain ID matches. Fall back to any_mon_comp
+		 * for monitor-only platforms.
+		 */
+		mpam_resctrl_domain_hdr_init(onlined_cpus,
+					     ctrl_comp ? ctrl_comp : any_mon_comp,
 					     &mon_d->hdr);
 		mon_d->hdr.type = RESCTRL_MON_DOMAIN;
 		mpam_resctrl_domain_insert(&r->mon_domains, &mon_d->hdr);
@@ -2131,45 +2212,6 @@ static struct mpam_resctrl_dom *mpam_resctrl_get_mon_domain_from_cpu(int cpu)
 	return NULL;
 }
 
-/**
- * mpam_resctrl_get_domain_from_cpu() - find the mpam domain structure
- * @cpu:       The CPU that is going online/offline.
- * @res:       The resctrl resource the domain should belong to.
- *
- * The component structures must be used to identify the CPU may be marked
- * offline in the resctrl structures. However the resctrl domain list is
- * used to search as this is also used to determine if resctrl thinks the
- * domain is online.
- * For platforms with controls, this is easy as each resource has one control
- * component.
- * For the monitors, we need to search the list of events...
- */
-static struct mpam_resctrl_dom *
-mpam_resctrl_alloc_domain_cpu(int cpu, struct mpam_resctrl_res *res)
-{
-	struct mpam_component *comp_iter, *ctrl_comp;
-	struct mpam_class *class = res->class;
-	int idx;
-
-	ctrl_comp = NULL;
-	idx = srcu_read_lock(&mpam_srcu);
-	list_for_each_entry_srcu(comp_iter, &class->components, class_list,
-				 srcu_read_lock_held(&mpam_srcu)) {
-		if (cpumask_test_cpu(cpu, &comp_iter->affinity)) {
-			ctrl_comp = comp_iter;
-			break;
-		}
-	}
-	srcu_read_unlock(&mpam_srcu, idx);
-
-	/* cpu with unknown exported component? */
-	if (WARN_ON_ONCE(!ctrl_comp))
-		return ERR_PTR(-EINVAL);
-
-	return mpam_resctrl_alloc_domain(cpumask_of(cpu), cpu_to_node(cpu),
-					 ctrl_comp, res);
-}
-
 static struct mpam_resctrl_dom *
 mpam_resctrl_alloc_domain_nid(int nid, struct mpam_resctrl_res *res)
 {
@@ -2178,13 +2220,18 @@ mpam_resctrl_alloc_domain_nid(int nid, struct mpam_resctrl_res *res)
 	int idx;
 
 	/* Only the memory class uses comp_id as nid */
-	if (class->type != MPAM_CLASS_MEMORY)
+	if (class->type != MPAM_CLASS_MEMORY) {
+		pr_info("MPAM: alloc_domain_nid(%d): class type %u is not MEMORY\n",
+			nid, class->type);
 		return ERR_PTR(-EINVAL);
+	}
 
 	ctrl_comp = NULL;
 	idx = srcu_read_lock(&mpam_srcu);
 	list_for_each_entry_srcu(comp_iter, &class->components, class_list,
 				 srcu_read_lock_held(&mpam_srcu)) {
+		pr_info("MPAM: alloc_domain_nid(%d): checking comp_id=%u\n",
+			nid, comp_iter->comp_id);
 		if (comp_iter->comp_id == nid) {
 			ctrl_comp = comp_iter;
 			break;
@@ -2193,9 +2240,12 @@ mpam_resctrl_alloc_domain_nid(int nid, struct mpam_resctrl_res *res)
 	srcu_read_unlock(&mpam_srcu, idx);
 
 	/* cpu with unknown exported component? */
-	if (WARN_ON_ONCE(!ctrl_comp))
+	if (WARN_ON_ONCE(!ctrl_comp)) {
+		pr_info("MPAM: alloc_domain_nid(%d): no component found\n", nid);
 		return ERR_PTR(-EINVAL);
+	}
 
+	pr_info("MPAM: alloc_domain_nid(%d): found component, creating domain\n", nid);
 	return mpam_resctrl_alloc_domain(cpu_possible_mask, nid, ctrl_comp, res);
 }
 
@@ -2263,10 +2313,21 @@ int mpam_resctrl_online_cpu(unsigned int cpu)
 				continue;
 
 			dom = mpam_get_ctrl_domain_from_cpu(cpu, res, comp);
-			if (!dom)
-				dom = mpam_resctrl_alloc_domain_cpu(cpu, res);
-			if (IS_ERR(dom))
+			if (!dom) {
+				/*
+				 * Pass the component directly to ensure
+				 * correct domain creation for each component.
+				 * The domain ID is determined by the component
+				 * via mpam_resctrl_pick_domain_id().
+				 */
+				dom = mpam_resctrl_alloc_domain(cpumask_of(cpu),
+								cpu_to_node(cpu),
+								comp, res);
+			}
+			if (IS_ERR(dom)) {
+				mutex_unlock(&domain_list_lock);
 				return PTR_ERR(dom);
+			}
 
 			cpumask_set_cpu(cpu, &dom->resctrl_ctrl_dom.hdr.cpu_mask);
 			cpumask_set_cpu(cpu, &dom->resctrl_mon_dom.hdr.cpu_mask);
@@ -2333,19 +2394,33 @@ static int mpam_resctrl_online_node(unsigned int nid)
 {
 	struct mpam_resctrl_dom *dom;
 	struct mpam_resctrl_res *res;
+	int ret = 0;
 
 	/* Domain IDs as NUMA nid is only defined for MBA */
 	res = &mpam_resctrl_controls[RDT_RESOURCE_MBA];
-	if (!res->class)
+	if (!res->class) {
+		pr_info("MPAM: online_node(%u): no class for MBA\n", nid);
 		return 0;	// dummy_resource;
+	}
 
+	pr_info("MPAM: online_node(%u): MBA class type=%u level=%u\n",
+		nid, res->class->type, res->class->level);
+
+	mutex_lock(&domain_list_lock);
 	dom = mpam_get_domain_from_nid(nid, res);
-	if (!dom)
+	if (!dom) {
+		pr_info("MPAM: online_node(%u): no existing domain, allocating\n", nid);
 		dom = mpam_resctrl_alloc_domain_nid(nid, res);
-	if (IS_ERR(dom))
-		return PTR_ERR(dom);
+	}
+	if (IS_ERR(dom)) {
+		pr_info("MPAM: online_node(%u): alloc failed with %ld\n", nid, PTR_ERR(dom));
+		ret = PTR_ERR(dom);
+	} else {
+		pr_info("MPAM: online_node(%u): success\n", nid);
+	}
+	mutex_unlock(&domain_list_lock);
 
-	return 0;
+	return ret;
 }
 
 static int mpam_resctrl_offline_node(unsigned int nid)
@@ -2360,22 +2435,30 @@ static int mpam_resctrl_offline_node(unsigned int nid)
 	if (!res->class)
 		return 0;	// dummy_resource;
 
+	mutex_lock(&domain_list_lock);
 	dom = mpam_get_domain_from_nid(nid, res);
-	if (WARN_ON_ONCE(!dom))
+	if (WARN_ON_ONCE(!dom)) {
+		mutex_unlock(&domain_list_lock);
 		return 0;
+	}
 
 	ctrl_d = &dom->resctrl_ctrl_dom;
 	resctrl_offline_ctrl_domain(&res->resctrl_res, ctrl_d);
-	if (!mpam_resctrl_offline_domain_hdr(cpu_possible_mask, &ctrl_d->hdr))
+	if (!mpam_resctrl_offline_domain_hdr(cpu_possible_mask, &ctrl_d->hdr)) {
+		mutex_unlock(&domain_list_lock);
 		return 0;
+	}
 
 	// TODO: skip monitor domains if there are no monitors for this resource
 	mon_d = &dom->resctrl_mon_dom;
 	resctrl_offline_mon_domain(&res->resctrl_res, mon_d);
-	if (!mpam_resctrl_offline_domain_hdr(cpu_possible_mask, &mon_d->hdr))
+	if (!mpam_resctrl_offline_domain_hdr(cpu_possible_mask, &mon_d->hdr)) {
+		mutex_unlock(&domain_list_lock);
 		return 0;
+	}
 
 	kfree(dom);
+	mutex_unlock(&domain_list_lock);
 
 	return 0;
 }

--- a/drivers/resctrl/mpam_resctrl.c
+++ b/drivers/resctrl/mpam_resctrl.c
@@ -1258,7 +1258,8 @@ static void mpam_resctrl_pick_counters(void)
 		}
 
 		has_mbwu = class_has_usable_mbwu(class);
-		if (has_mbwu && topology_matches_l3(class)) {
+		if (has_mbwu && ((class->type == MPAM_CLASS_MEMORY) ||
+		    topology_matches_l3(class))) {
 			pr_debug("class %u has usable MBWU, and matches L3 topology", class->level);
 
 			/*
@@ -1477,7 +1478,10 @@ static int mpam_resctrl_control_init(struct mpam_resctrl_res *res,
 			r->alloc_capable = true;
 
 		r->schema_fmt = RESCTRL_SCHEMA_PERCENT;
-		r->ctrl_scope = RESCTRL_L3_CACHE;
+		if ((class->type == MPAM_CLASS_MEMORY) && (class->level > 3))
+			r->ctrl_scope = RESCTRL_NUMA_NODE;
+		else
+			r->ctrl_scope = RESCTRL_L3_CACHE;
 
 		r->mba.delay_linear = true;
 		r->mba.throttle_mode = THREAD_THROTTLE_UNDEFINED;
@@ -1495,7 +1499,10 @@ static int mpam_resctrl_control_init(struct mpam_resctrl_res *res,
 	case RDT_RESOURCE_MBA_MIN:
 		r->alloc_capable = true;
 		r->schema_fmt = RESCTRL_SCHEMA_PERCENT;
-		r->ctrl_scope = RESCTRL_L3_CACHE;
+		if ((class->type == MPAM_CLASS_MEMORY) && (class->level > 3))
+			r->ctrl_scope = RESCTRL_NUMA_NODE;
+		else
+			r->ctrl_scope = RESCTRL_L3_CACHE;
 
 		r->mba.delay_linear = true;
 		r->mba.throttle_mode = THREAD_THROTTLE_UNDEFINED;
@@ -1636,10 +1643,26 @@ int resctrl_arch_set_mb_uses_numa_nid(bool enabled)
 static void mpam_resctrl_monitor_init(struct mpam_resctrl_mon *mon,
 				      enum resctrl_event_id type)
 {
-	struct mpam_resctrl_res *res = &mpam_resctrl_controls[RDT_RESOURCE_L3];
-	struct rdt_resource *l3 = &res->resctrl_res;
+	struct mpam_class *class = mon->class;
+	struct mpam_resctrl_res *res;
+	struct rdt_resource *r;
 
 	lockdep_assert_cpus_held();
+
+	/* Did we find anything for this monitor type? */
+	if (!class)
+		return;
+
+	/*
+	 * For memory class with level > 3 (i.e., memory controllers),
+	 * use the MBA resource. Otherwise use L3.
+	 */
+	if ((class->type == MPAM_CLASS_MEMORY) && (class->level > 3))
+		res = &mpam_resctrl_controls[RDT_RESOURCE_MBA];
+	else
+		res = &mpam_resctrl_controls[RDT_RESOURCE_L3];
+
+	r = &res->resctrl_res;
 
 	/* There also needs to be an L3 cache present */
 	if (get_cpu_cacheinfo_id(smp_processor_id(), 3) == -1)
@@ -1652,16 +1675,21 @@ static void mpam_resctrl_monitor_init(struct mpam_resctrl_mon *mon,
 	 */
 	if (!res->class) {
 		pr_warn_once("Faking L3 MSC to enable counters.\n");
-		res->class = mpam_resctrl_counters[type].class;
+		res->class = class;
 	}
 
 	/* Called multiple times!, once per event type */
 	if (exposed_mon_capable) {
-		l3->mon_capable = true;
+		r->mon_capable = true;
 
 		/* Setting name is necessary on monitor only platforms */
-		l3->name = "L3";
-		l3->mon_scope = RESCTRL_L3_CACHE;
+		if ((class->type == MPAM_CLASS_MEMORY) && (class->level > 3)) {
+			r->name = "MB";
+			r->mon_scope = RESCTRL_NUMA_NODE;
+		} else {
+			r->name = "L3";
+			r->mon_scope = RESCTRL_L3_CACHE;
+		}
 
 		resctrl_enable_mon_event(type);
 
@@ -1678,13 +1706,13 @@ static void mpam_resctrl_monitor_init(struct mpam_resctrl_mon *mon,
 		 * here.  But the pmgs corresponding to the parent control
 		 * group can be allocated freely:
 		 */
-		l3->mon.num_rmid = mpam_pmg_max + 1;;
+		r->mon.num_rmid = mpam_pmg_max + 1;
 
 		switch (type) {
 		case QOS_L3_MBM_LOCAL_EVENT_ID:
 		case QOS_L3_MBM_TOTAL_EVENT_ID:
 			mpam_resctrl_monitor_init_abmc(mon);
-			l3->mon.mbm_cfg_mask = MPAM_RESTRL_EVT_CONFIG_VALID;
+			r->mon.mbm_cfg_mask = MPAM_RESTRL_EVT_CONFIG_VALID;
 
 			return;
 		default:

--- a/fs/resctrl/internal.h
+++ b/fs/resctrl/internal.h
@@ -80,6 +80,34 @@ extern struct mon_evt mon_event_all[QOS_NUM_EVENTS];
 				      mevt < &mon_event_all[QOS_NUM_EVENTS]; mevt++)
 
 /**
+ * mon_event_belongs_to_resource - Check if a monitoring event belongs to a resource
+ * @mevt:	The monitoring event to check
+ * @r:		The resource to check against
+ *
+ * Returns true if the event belongs to the resource. MBM events are moved from
+ * L3 to MBA resource when MBA uses NUMA node scope (for memory bandwidth
+ * monitoring on systems where MPAM memory controllers are enumerated separately
+ * from L3).
+ */
+static inline bool mon_event_belongs_to_resource(struct mon_evt *mevt,
+						 struct rdt_resource *r)
+{
+	struct rdt_resource *mba_r;
+
+	/* For MBM events, check if they should be moved to MBA resource */
+	if (resctrl_is_mbm_event(mevt->evtid)) {
+		mba_r = resctrl_arch_get_resource(RDT_RESOURCE_MBA);
+		if (mba_r && mba_r->mon_capable &&
+		    mba_r->mon_scope == RESCTRL_NUMA_NODE) {
+			/* MBM events belong to MBA, not L3 */
+			return r->rid == RDT_RESOURCE_MBA;
+		}
+	}
+
+	return mevt->rid == r->rid;
+}
+
+/**
  * struct mon_data - Monitoring details for each event file.
  * @list:            Member of the global @mon_data_kn_priv_list list.
  * @rid:             Resource id associated with the event file.

--- a/fs/resctrl/monitor.c
+++ b/fs/resctrl/monitor.c
@@ -1612,7 +1612,7 @@ int mbm_L3_assignments_show(struct kernfs_open_file *of, struct seq_file *s, voi
 	}
 
 	for_each_mon_event(mevt) {
-		if (mevt->rid != r->rid || !mevt->enabled || !resctrl_is_mbm_event(mevt->evtid))
+		if (!mon_event_belongs_to_resource(mevt, r) || !mevt->enabled || !resctrl_is_mbm_event(mevt->evtid))
 			continue;
 
 		sep = false;
@@ -1646,7 +1646,7 @@ static struct mon_evt *mbm_get_mon_event_by_name(struct rdt_resource *r, char *n
 	struct mon_evt *mevt;
 
 	for_each_mon_event(mevt) {
-		if (mevt->rid == r->rid && mevt->enabled &&
+		if (mon_event_belongs_to_resource(mevt, r) && mevt->enabled &&
 		    resctrl_is_mbm_event(mevt->evtid) &&
 		    !strcmp(mevt->name, name))
 			return mevt;

--- a/fs/resctrl/rdtgroup.c
+++ b/fs/resctrl/rdtgroup.c
@@ -1248,7 +1248,7 @@ static int rdt_mon_features_show(struct kernfs_open_file *of,
 	struct mon_evt *mevt;
 
 	for_each_mon_event(mevt) {
-		if (mevt->rid != r->rid || !mevt->enabled)
+		if (!mon_event_belongs_to_resource(mevt, r) || !mevt->enabled)
 			continue;
 		seq_printf(seq, "%s\n", mevt->name);
 		if (mevt->configurable &&
@@ -2489,7 +2489,7 @@ static int resctrl_mkdir_event_configs(struct rdt_resource *r, struct kernfs_nod
 		return ret;
 
 	for_each_mon_event(mevt) {
-		if (mevt->rid != r->rid || !mevt->enabled || !resctrl_is_mbm_event(mevt->evtid))
+		if (!mon_event_belongs_to_resource(mevt, r) || !mevt->enabled || !resctrl_is_mbm_event(mevt->evtid))
 			continue;
 
 		kn_subdir2 = kernfs_create_dir(kn_subdir, mevt->name, kn_subdir->mode, mevt);
@@ -3546,7 +3546,7 @@ static int mon_add_all_files(struct kernfs_node *kn, struct rdt_mon_domain *d,
 	int ret, domid;
 
 	for_each_mon_event(mevt) {
-		if (mevt->rid != r->rid || !mevt->enabled)
+		if (!mon_event_belongs_to_resource(mevt, r) || !mevt->enabled)
 			continue;
 		domid = do_sum ? d->ci_id : d->hdr.id;
 		priv = mon_get_kn_priv(r->rid, domid, mevt, do_sum);

--- a/fs/resctrl/rdtgroup.c
+++ b/fs/resctrl/rdtgroup.c
@@ -1968,6 +1968,64 @@ void resctrl_bmec_files_show(struct rdt_resource *r, struct kernfs_node *l3_mon_
 		kernfs_put(mon_kn);
 }
 
+static struct rdtgroup *find_rdtgroup(u32 closid, u32 rmid)
+{
+	struct rdtgroup *prgrp, *crgrp;
+
+	lockdep_assert_held(&rdtgroup_mutex);
+
+	list_for_each_entry(prgrp, &rdt_all_groups, rdtgroup_list) {
+		if (prgrp->closid != closid)
+			continue;
+
+		if (prgrp->mon.rmid == rmid)
+			return prgrp;
+
+		list_for_each_entry(crgrp, &prgrp->mon.crdtgrp_list,
+				    mon.crdtgrp_list)
+		{
+			if (crgrp->mon.rmid == rmid)
+				return crgrp;
+		}
+	}
+
+	return NULL;
+}
+
+int resctrl_id_decode(u64 id, u32 *closid, u32 *rmid)
+{
+	int err = 0;
+
+	__resctrl_id_decode(id, closid, rmid);
+
+	/* Check this closid/rmid is allocated */
+	mutex_lock(&rdtgroup_mutex);
+	if (!find_rdtgroup(*closid, *rmid))
+		err = -ENOENT;
+	mutex_unlock(&rdtgroup_mutex);
+
+	return err;
+}
+
+static int rdtgroup_id_show(struct kernfs_open_file *of,
+			    struct seq_file *seq, void *v)
+{
+	struct rdtgroup *rdtgrp;
+	int ret = 0;
+	u64 id;
+
+	rdtgrp = rdtgroup_kn_lock_live(of->kn);
+	if (rdtgrp) {
+		id = resctrl_id_encode(rdtgrp->closid, rdtgrp->mon.rmid);
+		seq_printf(seq, "0x%llx\n", id);
+	} else {
+		ret = -ENOENT;
+	}
+	rdtgroup_kn_unlock(of->kn);
+
+	return ret;
+}
+
 /* rdtgroup information files for one cache resource. */
 static struct rftype res_common_files[] = {
 	{
@@ -2232,7 +2290,13 @@ static struct rftype res_common_files[] = {
 		.seq_show	= resctrl_schema_format_show,
 		.fflags		= RFTYPE_CTRL_INFO,
 	},
-
+	{
+		.name		= "id",
+		.mode		= 0444,
+		.kf_ops		= &rdtgroup_kf_single_ops,
+		.seq_show	= rdtgroup_id_show,
+		.fflags		= RFTYPE_BASE,
+	},
 };
 
 static int rdtgroup_add_files(struct kernfs_node *kn, unsigned long fflags)

--- a/include/linux/resctrl.h
+++ b/include/linux/resctrl.h
@@ -273,6 +273,7 @@ enum resctrl_scope {
 	RESCTRL_L2_CACHE = 2,
 	RESCTRL_L3_CACHE = 3,
 	RESCTRL_L3_NODE,
+	RESCTRL_NUMA_NODE,
 };
 
 /**

--- a/include/linux/resctrl.h
+++ b/include/linux/resctrl.h
@@ -8,6 +8,7 @@
 #include <linux/list.h>
 #include <linux/pid.h>
 #include <linux/resctrl_types.h>
+#include <linux/bitfield.h>
 
 #ifdef CONFIG_ARCH_HAS_CPU_RESCTRL
 #include <asm/resctrl.h>
@@ -30,6 +31,10 @@ int proc_resctrl_show(struct seq_file *m,
 
 /* max value for struct rdt_domain's mbps_val */
 #define MBA_MAX_MBPS   U32_MAX
+
+/* The format for packing fields into the u64 'id' exposed to user-space */
+#define RESCTRL_ID_CLOSID      GENMASK_ULL(31, 0)
+#define RESCTRL_ID_RMID                GENMASK_ULL(63, 32)
 
 /* Walk all possible resources, with variants for only controls or monitors. */
 #define for_each_rdt_resource(_r)						\
@@ -439,6 +444,52 @@ static inline u32 resctrl_get_schema_default_ctrl(struct resctrl_schema *s)
 
 	return WARN_ON_ONCE(1);
 }
+
+/**
+ * resctrl_id_encode() - pack a closid and rmid into a u64 that can be used
+ *                      to identify a rdtgroup.
+ * @closid:    The closid to encode.
+ * @rmid:      The rmid to encode.
+ */
+static inline u64 resctrl_id_encode(u32 closid, u32 rmid)
+{
+	u64 id;
+
+	id = FIELD_PREP(RESCTRL_ID_CLOSID, closid) |
+	     FIELD_PREP(RESCTRL_ID_RMID, rmid);
+
+	return id;
+}
+
+/**
+ * __resctrl_id_decode() - unpack a known-good id that has been checked by
+ *                         resctrl_id_decode().
+ * @id:		The value originally passed by user-space.
+ * @closid:	Returned closid.
+ * @rmid:	Returned rmid.
+ *
+ * Decodes the id field with no error checking. resctrl_id_decode() must have
+ * been used to check the id produces values that are in range and are
+ * allocated at the time of first use.
+ */
+static inline void __resctrl_id_decode(u64 id, u32 *closid, u32 *rmid)
+{
+	*closid = FIELD_GET(RESCTRL_ID_CLOSID, id);
+	*rmid = FIELD_GET(RESCTRL_ID_RMID, id);
+}
+
+/**
+ * resctrl_id_decode() - unpack an id passed by user-space.
+ * @id:		The value passed by user-space.
+ * @closid:	Returned closid.
+ * @rmid:	Returned rmid.
+ *
+ * Returns -EINVAL if @id doesn't correspond to an allocated control
+ * or monitor group. Returns 0 on success.
+ *
+ * Takes a mutex, call in process context.
+ */
+int resctrl_id_decode(u64 id, u32 *closid, u32 *rmid);
 
 /* The number of closid supported by this resource regardless of CDP */
 u32 resctrl_arch_get_num_closid(struct rdt_resource *r);

--- a/include/linux/resctrl.h
+++ b/include/linux/resctrl.h
@@ -56,6 +56,7 @@ enum resctrl_res_level {
 	RDT_RESOURCE_SMBA,
 	RDT_RESOURCE_L3_MAX,
 	RDT_RESOURCE_L2_MAX,
+	RDT_RESOURCE_MBA_MIN,
 
 	/* Must be the last */
 	RDT_NUM_RESOURCES,


### PR DESCRIPTION
Please merge the following MPAM commits:

1. DGX-15400 MPAM MBW monitoring events missing in 6.17 devel This issue is fixed by the following commits:

NVIDIA: SAUCE: arm_mpam: Fix missing mbm_local_bytes and mbm_total_bytes

2. DGX-15561 MPAM: stream performance degradation on 6.17-devel and 6.19-rc upstream v3. This issue is fixed by this commit:
NVIDIA: SAUCE: arm_mpam: Fix memory access performance issue due to too small mbw_min

3. CPU-less memory node enabling and NUMA node id as domain id. Commits:

NVIDIA: SAUCE: arm_mpam: Fix support for CPU-less NUMA nodes in memory...
NVIDIA: SAUCE: arm_mpam: Add memory type checks to support mbw monitor event assignment mode
NVIDIA: SAUCE: arm_mpam: Handle CPU-less numa nodes
NVIDIA: SAUCE: arm_mpam: Include all associated MSC components during domain setup
NVIDIA: SAUCE: arm_mpam: Sort the domain list by domain-id

4. MBW_MIN support. Commits:
NVIDIA: SAUCE: arm_mpam: Add support for MBW_MIN

5. misc fixes:

NVIDIA: SAUCE: fs/resctrl: Export the closid/rmid to user-space
NVIDIA: SAUCE: arm_mpam: Avoid MSC teardown for the SW programming errors