### PR TITLE
[linux-nvidia-6.17] Backport GPIO line name prefix handling

### DIFF
--- a/drivers/gpio/gpio-tegra186.c
+++ b/drivers/gpio/gpio-tegra186.c
@@ -856,7 +856,7 @@ static int tegra186_gpio_probe(struct platform_device *pdev)
 	struct device_node *np;
 	struct resource *res;
 	char **names;
-	int err;
+	int node, err;
 
 	gpio = devm_kzalloc(&pdev->dev, sizeof(*gpio), GFP_KERNEL);
 	if (!gpio)
@@ -936,13 +936,23 @@ static int tegra186_gpio_probe(struct platform_device *pdev)
 	if (!names)
 		return -ENOMEM;
 
+	node = dev_to_node(&pdev->dev);
+
 	for (i = 0, offset = 0; i < gpio->soc->num_ports; i++) {
 		const struct tegra_gpio_port *port = &gpio->soc->ports[i];
 		char *name;
 
 		for (j = 0; j < port->pins; j++) {
-			name = devm_kasprintf(gpio->gpio.parent, GFP_KERNEL, "%sP%s.%02x",
-					      gpio->soc->prefix ?: "", port->name, j);
+			if (node >= 0)
+				name = devm_kasprintf(gpio->gpio.parent, GFP_KERNEL,
+						      "%d-%sP%s.%02x", node,
+						      gpio->soc->prefix ?: "",
+						      port->name, j);
+			else
+				name = devm_kasprintf(gpio->gpio.parent, GFP_KERNEL,
+						      "%sP%s.%02x",
+						      gpio->soc->prefix ?: "",
+						      port->name, j);
 			if (!name)
 				return -ENOMEM;
 

--- a/drivers/gpio/gpio-tegra186.c
+++ b/drivers/gpio/gpio-tegra186.c
@@ -941,12 +941,8 @@ static int tegra186_gpio_probe(struct platform_device *pdev)
 		char *name;
 
 		for (j = 0; j < port->pins; j++) {
-			if (gpio->soc->prefix)
-				name = devm_kasprintf(gpio->gpio.parent, GFP_KERNEL, "%s-P%s.%02x",
-						      gpio->soc->prefix, port->name, j);
-			else
-				name = devm_kasprintf(gpio->gpio.parent, GFP_KERNEL, "P%s.%02x",
-						      port->name, j);
+			name = devm_kasprintf(gpio->gpio.parent, GFP_KERNEL, "%sP%s.%02x",
+					      gpio->soc->prefix ?: "", port->name, j);
 			if (!name)
 				return -ENOMEM;
 
@@ -1296,6 +1292,9 @@ static const struct tegra_gpio_soc tegra256_main_soc = {
 	.has_vm_support = true,
 };
 
+/* Macro to define GPIO name prefix with separator */
+#define TEGRA_GPIO_PREFIX(_x)	_x "-"
+
 #define TEGRA410_COMPUTE_GPIO_PORT(_name, _bank, _port, _pins)	\
 	TEGRA_GPIO_PORT(TEGRA410_COMPUTE, _name, _bank, _port, _pins)
 
@@ -1311,7 +1310,7 @@ static const struct tegra_gpio_soc tegra410_compute_soc = {
 	.num_ports = ARRAY_SIZE(tegra410_compute_ports),
 	.ports = tegra410_compute_ports,
 	.name = "tegra410-gpio-compute",
-	.prefix = "COMPUTE",
+	.prefix = TEGRA_GPIO_PREFIX("COMPUTE"),
 	.num_irqs_per_bank = 8,
 	.instance = 0,
 };
@@ -1341,7 +1340,7 @@ static const struct tegra_gpio_soc tegra410_system_soc = {
 	.num_ports = ARRAY_SIZE(tegra410_system_ports),
 	.ports = tegra410_system_ports,
 	.name = "tegra410-gpio-system",
-	.prefix = "SYSTEM",
+	.prefix = TEGRA_GPIO_PREFIX("SYSTEM"),
 	.num_irqs_per_bank = 8,
 	.instance = 0,
 };


### PR DESCRIPTION
These two upstream patches (currently in linux-next, ETA v7.1) add support for GPIO devices on multi-socket systems and are required for VR. Without these patches, there are duplicate gpio names and the kernel logs warnings during boot:

```
$ sudo gpioinfo
gpiochip0 - 30 lines:
	line   0: "COMPUTE-PA.00" kernel input active-high [used]
...
	line  29: "COMPUTE-PE.07" kernel input active-high [used]
gpiochip1 - 94 lines:
	line   0: "SYSTEM-PA.00" kernel input active-high [used]
...
	line  93: "SYSTEM-PV.01" unused input active-high 
gpiochip2 - 30 lines:
	line   0: "COMPUTE-PA.00" kernel input active-high [used]
...
	line  29: "COMPUTE-PE.07" kernel input active-high [used]
gpiochip3 - 94 lines:
	line   0: "SYSTEM-PA.00" kernel input active-high [used]
...
	line  93: "SYSTEM-PV.01" unused input active-high 

$ sudo journalctl -k -b 0 | grep -i collision 
Mar 11 18:05:37 localhost.localdomain kernel: gpio gpiochip2: Detected name collision for GPIO name 'COMPUTE-PA.00'
Mar 11 18:05:37 localhost.localdomain kernel: gpio gpiochip2: Detected name collision for GPIO name 'COMPUTE-PA.01'
Mar 11 18:05:37 localhost.localdomain kernel: gpio gpiochip2: Detected name collision for GPIO name 'COMPUTE-PA.02'
Mar 11 18:05:37 localhost.localdomain kernel: gpio gpiochip2: Detected name collision for GPIO name 'COMPUTE-PB.00’
```

With the patches in place on a system that defines ACPI PXM nodes for the GPIO devices, gpio names include the corresponding NUMA node:
```
$ sudo gpioinfo
gpiochip0 - 30 lines:
	line   0: "0-COMPUTE-PA.00" kernel input active-high [used]
...
	line  29: "0-COMPUTE-PE.07" kernel input active-high [used]
gpiochip1 - 94 lines:
	line   0: "0-SYSTEM-PA.00" kernel input active-high [used]
...
	line  93: "0-SYSTEM-PV.01" unused input active-high 
gpiochip2 - 30 lines:
	line   0: "1-COMPUTE-PA.00" kernel input active-high [used]
...
	line  29: "1-COMPUTE-PE.07" kernel input active-high [used]
gpiochip3 - 94 lines:
	line   0: "1-SYSTEM-PA.00" kernel input active-high [used]
...
	line  93: "1-SYSTEM-PV.01" unused input active-high 
```

This removes the collisions warnings during boot:
```
$ sudo journalctl -k -b 0 | grep -i collision 
$
```

LKML: https://lore.kernel.org/all/20260217081431.1208351-1-pshete@nvidia.com/

linux-next:
```
2423e336d948 gpio: tegra186: Simplify GPIO line name prefix handling
2c299030c681 gpio: tegra186: Support multi-socket devices
```

<hr>

To test, I verified the presence of the PXM nodes:
```
$ egrep -A 2 'NVDA0808|NVDA0708' *.dsl
dsdt.dsl:            Name (_HID, "NVDA0708")  // _HID: Hardware ID
dsdt.dsl-            Name (_UID, 0x00)  // _UID: Unique ID
dsdt.dsl-            Name (_PXM, 0x00)  // _PXM: Device Proximity
--
dsdt.dsl:            Name (_HID, "NVDA0808")  // _HID: Hardware ID
dsdt.dsl-            Name (_UID, 0x00)  // _UID: Unique ID
dsdt.dsl-            Name (_PXM, 0x00)  // _PXM: Device Proximity
--
ssdt18.dsl:            Name (_HID, "NVDA0708")  // _HID: Hardware ID
ssdt18.dsl-            Name (_UID, 0x10)  // _UID: Unique ID
ssdt18.dsl-            Name (_PXM, 0x01)  // _PXM: Device Proximity
--
ssdt18.dsl:            Name (_HID, "NVDA0808")  // _HID: Hardware ID
ssdt18.dsl-            Name (_UID, 0x10)  // _UID: Unique ID
ssdt18.dsl-            Name (_PXM, 0x01)  // _PXM: Device Proximity
```

And the removal of the duplicate gpio names and collision warnings (included above).

Note that this requires UEFI support added in nvb5277588.

<hr>

LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-6.17/+bug/2143954