### PR TITLE
[6.18] NVIDIA: VR: SAUCE: firmware: smccc: lfa: fix work item re-initialization race

### DIFF
--- a/drivers/firmware/smccc/lfa_fw.c
+++ b/drivers/firmware/smccc/lfa_fw.c
@@ -653,7 +653,6 @@ static int update_fw_images_tree(void)
 	 * _store() handler, so have to postpone the list removal to a
 	 * workqueue.
 	 */
-	INIT_WORK(&fw_images_update_work, remove_invalid_fw_images);
 	queue_work(fw_images_update_wq, &fw_images_update_work);
 
 	return 0;
@@ -680,7 +679,7 @@ static void lfa_notify_handler(acpi_handle handle, u32 event, void *data)
 	 * of all activable and pending images.
 	 */
 	do {
-		/* Reset activable image flag */
+		flush_workqueue(fw_images_update_wq);
 		found_activable_image = false;
 		list_for_each_entry(attrs, &lfa_fw_images, image_node) {
 			if (attrs->fw_seq_id == -1)
@@ -781,6 +780,8 @@ static int __init lfa_init(void)
 
 		return -ENOMEM;
 	}
+
+	INIT_WORK(&fw_images_update_work, remove_invalid_fw_images);
 
 	pr_info("Live Firmware Activation: detected v%ld.%ld\n",
 		reg.a0 >> 16, reg.a0 & 0xffff);


### PR DESCRIPTION

Move INIT_WORK() for fw_images_update_work from update_fw_images_tree() to lfa_init() so the work item is initialized once at module load rather than re-initialized on every firmware image tree update. Re-initializing a work item that may already be queued is unsafe and can corrupt the workqueue.

Add flush_workqueue() in lfa_notify_handler() before rescanning the image list to ensure any pending remove_invalid_fw_images work completes first, preventing use-after-free on the image list.

Fixes: 1dd9a8f3ee5d ("NVIDIA: VR: SAUCE: firmware: smccc: add support for Live Firmware Activation (LFA)")