### PR TITLE
Add patchscan workflow to check PRs for missing upstream fixes

### DIFF
--- a/.github/scripts/patchscan
+++ b/.github/scripts/patchscan
@@ -1,0 +1,173 @@
+#!/usr/bin/python3
+# Author: Jacob Martin <jacob.martin@canonical.com>
+from argparse import ArgumentParser
+from colorama import Fore
+import git
+import os
+import re
+
+parser = ArgumentParser(
+        description="Checks that cherry-picked or backported commits actually exist upstream.")
+parser.add_argument("check_range", help="Git commit range to check, e.g. HEAD~10..HEAD")
+parser.add_argument("upstream_remote", help="Remote to consider as the upstream with potential fixes, e.g. torvalds")
+parser.add_argument("upstream_branch", help="Branch to consider as the upstream with potential fixes, e.g. master")
+parser.add_argument("--no-update", action='store_true')
+parser.add_argument("--no-fixes", action='store_true')
+parser.add_argument("--url", help="URL prefix to use for commit links", default="https://github.com/torvalds/linux/commit/")
+args = parser.parse_args()
+
+def format_commit_hex12_msg(commit):
+    firstline = commit.message.split('\n')[0]
+    return f"{commit.hexsha[0:12]} (\"{firstline}\")"
+
+def format_hyperlink(url, text):
+    return f"\33]8;;{url}\a{text}\33]8;;\a"
+
+def format_commit_with_hyperlink(commit, url_prefix):
+    return format_hyperlink(f"{url_prefix}{commit.hexsha}", format_commit_hex12_msg(commit))
+
+def get_src_commit_strs(msg):
+    # Match common backport/cherry-pick annotations:
+    #   (cherry picked from commit <sha>)
+    #   (backported from commit <sha>)
+    #   upstream commit <sha>
+    #   Upstream commit <sha>
+    matches = list(re.finditer(r"(?:from commit|[Uu]pstream commit) ([a-fA-F0-9]+)", msg))
+    return list(map(lambda m: m.group(1) if len(m.groups()) == 1 else None, matches))
+
+def references_upstream(commit):
+    return len(get_src_commit_strs(commit.message)) > 0
+
+def is_upstream(upstream, commit):
+    assert commit
+
+    repo = commit.repo
+
+    for commit_str in get_src_commit_strs(commit.message):
+        pick_title = commit.message.split('\n')[0]
+
+        try:
+            src_commit = repo.commit(commit_str)
+        except Exception as exc:
+            print("\nE: {} refers to invalid 'upstream' SHA {}: {}".format(pick_title, commit_str, exc))
+            return False
+
+        src_title = src_commit.message.split('\n')[0]
+        if src_title != pick_title:
+            print("\nE: Commit messages differ: upstream '{}' != pick '{}'".format(src_title, pick_title))
+            return False
+
+        if src_commit.author != commit.author:
+            print("\nE: Commit authors differ: upstream '{}' != pick '{}'".format(src_commit.author, commit.author))
+            return False
+
+        if upstream not in commit.repo.git.branch('-r', '--contains', src_commit.hexsha):
+            print("\nE: Upstream does not contain commit {} {}".format(src_commit.hexsha, src_title))
+            return False
+
+    return True
+
+def has_fix(fix):
+    assert fix
+
+    for commit in fix.repo.iter_commits(args.check_range):
+        for src_sha in get_src_commit_strs(commit.message):
+            if fix.hexsha.startswith(src_sha) or fix.hexsha[:len(src_sha)] == src_sha:
+                return True
+
+    return False
+
+def check_fixes(upstream, commit):
+    assert upstream
+    assert commit
+
+    repo = commit.repo
+
+    found_fixes = []
+
+    for commit_str in get_src_commit_strs(commit.message):
+        try:
+            src_commit = repo.commit(commit_str)
+        except Exception as exc:
+            print("\nE: refers to invalid 'upstream' SHA {}: {}".format(commit_str, exc))
+            return None
+
+        grep_pattern = "Fixes: {}".format(src_commit.hexsha[0:8])
+        fix_shas = repo.git.log(
+            "{}..{}".format(src_commit.hexsha, upstream),
+            '--grep', grep_pattern,
+            '--format=%H'
+        ).splitlines()
+
+        for sha in fix_shas:
+            if not sha:
+                continue
+            try:
+                fix_commit = repo.commit(sha)
+            except Exception:
+                continue
+            if not has_fix(fix_commit):
+                found_fixes.append(fix_commit)
+                print(Fore.YELLOW + "W: Found fix commit {} for {}".format(fix_commit.hexsha, src_commit.hexsha) + Fore.RESET)
+
+    return found_fixes
+
+def update(repo, upstream_remote, upstream_branch):
+    repo.remote(upstream_remote).fetch(upstream_branch)
+
+def main():
+    repo = git.Repo(os.getcwd())
+    assert not repo.bare
+
+    commits = list(repo.iter_commits(args.check_range))
+    if not commits:
+        print("No commits found in range {}; nothing to check.".format(args.check_range))
+        return
+
+    upstream = f"{args.upstream_remote}/{args.upstream_branch}"
+    assert upstream in repo.git.branch('-r')
+
+    if not args.no_update:
+        print(f"Fetching upstream {upstream}...")
+        update(repo, args.upstream_remote, args.upstream_branch)
+
+    print("Checking {} commits...".format(len(commits)))
+
+    all_fix_commits = {}
+    verification_failed = False
+    for commit in commits:
+        print("checking {} {}.....".format(commit.hexsha, commit.message.split("\n")[0]), end=" ")
+        if not references_upstream(commit):
+            print(Fore.YELLOW + "no upstream reference" + Fore.RESET)
+            continue
+
+        if is_upstream(upstream, commit):
+            print(Fore.GREEN + "found upstream" + Fore.RESET)
+            if not args.no_fixes:
+                fixes_for_commit = check_fixes(upstream, commit)
+                if not fixes_for_commit:
+                    continue
+
+                fixes_from_dict = all_fix_commits.get(commit, [])
+                fixes_from_dict.extend(fixes_for_commit)
+                all_fix_commits[commit] = fixes_from_dict
+        else:
+            print(Fore.RED + "ERROR: failed to verify commit {}".format(commit.hexsha) + Fore.RESET)
+            verification_failed = True
+
+    if not args.no_fixes:
+        print("All fixes:")
+        for commit in all_fix_commits:
+            broke_hyperlink = format_commit_with_hyperlink(commit, args.url)
+            print(Fore.YELLOW + f"Fixes for {broke_hyperlink}" + Fore.RESET)
+            for fix in all_fix_commits.get(commit, []):
+                fix_hyperlink = format_commit_with_hyperlink(fix, args.url)
+                print(f"          {fix_hyperlink}")
+            print()
+
+    if verification_failed:
+        import sys
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,0 +1,2 @@
+colorama==0.4.6
+GitPython==3.1.37

--- a/.github/workflows/patchscan.yml
+++ b/.github/workflows/patchscan.yml
@@ -1,0 +1,267 @@
+name: Patchscan - Check Missing Fixes
+
+on:
+  pull_request_target:
+    branches:
+      - 24.04_linux-nvidia-6.17-next
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to scan'
+        required: true
+        type: number
+
+jobs:
+  patchscan:
+    name: Check for missing upstream fixes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Get PR info (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        id: pr_info
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pr_json=$(gh api repos/${{ github.repository }}/pulls/${{ inputs.pr_number }})
+          echo "head_sha=$(echo "$pr_json" | jq -r .head.sha)" >> $GITHUB_OUTPUT
+          echo "base_sha=$(echo "$pr_json" | jq -r .base.sha)" >> $GITHUB_OUTPUT
+          echo "base_ref=$(echo "$pr_json" | jq -r .base.ref)" >> $GITHUB_OUTPUT
+          echo "pr_number=${{ inputs.pr_number }}" >> $GITHUB_OUTPUT
+
+      - name: Set PR variables
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "head_sha=${{ steps.pr_info.outputs.head_sha }}" >> $GITHUB_OUTPUT
+            echo "base_sha=${{ steps.pr_info.outputs.base_sha }}" >> $GITHUB_OUTPUT
+            echo "base_ref=${{ steps.pr_info.outputs.base_ref }}" >> $GITHUB_OUTPUT
+            echo "pr_number=${{ steps.pr_info.outputs.pr_number }}" >> $GITHUB_OUTPUT
+          else
+            echo "head_sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+            echo "base_sha=${{ github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
+            echo "base_ref=${{ github.base_ref }}" >> $GITHUB_OUTPUT
+            echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.base_ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch PR commits
+        run: |
+          git fetch --no-tags origin \
+            ${{ steps.pr.outputs.base_sha }}:refs/remotes/origin/patchscan-base \
+            refs/pull/${{ steps.pr.outputs.pr_number }}/head:refs/remotes/origin/patchscan-head
+
+      - name: Fetch patchscan from github-actions branch
+        run: |
+          git fetch origin github-actions
+          git checkout origin/github-actions -- .github/scripts/patchscan .github/scripts/requirements.txt
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: .github/scripts/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r .github/scripts/requirements.txt
+
+      - name: Fetch origin/linux branch (used as upstream reference)
+        run: |
+          git fetch origin linux
+
+      - name: Run patchscan
+        id: patchscan
+        run: |
+          base_sha="${{ steps.pr.outputs.base_sha }}"
+          head_sha="${{ steps.pr.outputs.head_sha }}"
+          merge_base="$(git merge-base "$base_sha" "$head_sha")"
+          range="${merge_base}..${head_sha}"
+          echo "Merge base: $merge_base"
+          echo "Scanning commit range: $range"
+          echo "Upstream: origin/linux"
+
+          # Run patchscan, capture output; use PIPESTATUS to get patchscan's exit code, not tee's
+          set +e
+          set -o pipefail
+          python3 .github/scripts/patchscan \
+            "$range" \
+            origin \
+            linux \
+            --no-update \
+            2>&1 | tee patchscan_output.txt
+          exit_code=${PIPESTATUS[0]}
+          set +o pipefail
+          set -e
+
+          # Strip ANSI escape codes for the summary
+          sed 's/\x1B\[[0-9;]*[A-Za-z]//g; s/\x1B\]8;;[^\x1B]*\x1B\\//g; s/\x1B\]8;;[^\a]*\a//g' \
+            patchscan_output.txt > patchscan_clean.txt
+
+          # Record runtime errors so the comment step can report them before failing
+          if [ $exit_code -ne 0 ]; then
+            echo "fixes_found=error" >> $GITHUB_OUTPUT
+          fi
+
+          # Check if missing fixes or scan errors were found
+          if grep -qE "^W:|^E:|Fixes for" patchscan_clean.txt; then
+            echo "fixes_found=true" >> $GITHUB_OUTPUT
+          else
+            echo "fixes_found=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Post PR comment on patchscan error
+        if: steps.patchscan.outputs.fixes_found == 'error'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const output = fs.readFileSync('patchscan_clean.txt', 'utf8');
+            const MAX_LEN = 60000;
+            const truncated = output.length > MAX_LEN
+              ? output.slice(0, MAX_LEN) + '\n...(truncated)'
+              : output;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.pr.outputs.pr_number }},
+              per_page: 100,
+            });
+            const existing = comments.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes('Patchscan:')
+            );
+
+            const body = [
+              '## :x: Patchscan: Scan Error',
+              '',
+              'Patchscan encountered an error while scanning this PR:',
+              '',
+              '````',
+              truncated.trim(),
+              '````',
+            ].join('\n');
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: ${{ steps.pr.outputs.pr_number }},
+                body: body,
+              });
+            }
+
+      - name: Post PR comment with missing fixes
+        if: steps.patchscan.outputs.fixes_found == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const output = fs.readFileSync('patchscan_clean.txt', 'utf8');
+
+            // Find existing patchscan comment to update instead of spamming
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.pr.outputs.pr_number }},
+              per_page: 100,
+            });
+            const existing = comments.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes('Patchscan:')
+            );
+
+            // Sanitize output: escape fence sequences and truncate to stay under GitHub's comment limit
+            const MAX_LEN = 60000;
+            const safeOutput = output.replace(/`{3,}/g, '` ` `');
+            const truncated = safeOutput.length > MAX_LEN
+              ? safeOutput.slice(0, MAX_LEN) + '\n...(truncated)'
+              : safeOutput;
+
+            const body = [
+              '## :warning: Patchscan: Missing Fixes Detected',
+              '',
+              'The following upstream fix commits appear to be missing from this PR:',
+              '',
+              '````',
+              truncated.trim(),
+              '````',
+              '',
+              'Please review and consider including them.',
+            ].join('\n');
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: ${{ steps.pr.outputs.pr_number }},
+                body: body,
+              });
+            }
+
+      - name: Post all-clear comment
+        if: steps.patchscan.outputs.fixes_found == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.pr.outputs.pr_number }},
+              per_page: 100,
+            });
+            const existing = comments.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes('Patchscan:')
+            );
+
+            const body = '## :white_check_mark: Patchscan: No Missing Fixes\n\nAll cherry-picked commits have been checked — no missing upstream fixes found.';
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: ${{ steps.pr.outputs.pr_number }},
+                body: body,
+              });
+            }
+
+      - name: Fail if missing fixes found or scan error
+        if: steps.patchscan.outputs.fixes_found == 'true' || steps.patchscan.outputs.fixes_found == 'error'
+        run: |
+          if [ "${{ steps.patchscan.outputs.fixes_found }}" = "error" ]; then
+            echo "::error::Patchscan encountered a runtime error — see PR comment for details."
+          else
+            echo "::warning::Missing upstream fixes detected — see PR comment for details."
+          fi
+          exit 1

--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ Automatically rebases NVIDIA kernel branches onto the latest upstream stable tag
 
 When successful, creates rebased branches named `linux-nvidia-X.Y-vX.Y.Z` (e.g., `linux-nvidia-6.12-v6.12.65`).
 
+### patchscan.yml
+
+Checks that cherry-picked commits in a PR are not missing any upstream `Fixes:` patches. Runs on every PR targeting `24.04_linux-nvidia-6.17-next` and posts a comment listing any missing fixes, failing the check if any are found.
+
+Uses `origin/linux` as the upstream reference. The patchscan script and its dependencies are stored in `.github/scripts/` so no changes are needed on target branches.
+
+**Triggers:**
+- Automatically on pull requests targeting `24.04_linux-nvidia-6.17-next`
+- Manual dispatch (enter a PR number to scan)
+
 ### kernel-build.yml
 
 Builds and tests kernels with the following matrix:


### PR DESCRIPTION
## Summary

Adds patchscan support to \`24.04_linux-nvidia-6.17-next\` to begin with —
more branches can be added to the trigger list as needed.

The workflow runs on every PR targeting \`24.04_linux-nvidia-6.17-next\` and
checks that cherry-picked commits are not missing upstream \`Fixes:\` patches.
It posts a comment on the PR listing any missing fixes and fails the check,
or posts an all-clear if none are found.

## How it works

The workflow lives entirely on the \`github-actions\` default branch — no
changes needed on target branches. On each PR it:

1. Checks out the PR head (full history)
2. Fetches \`origin/linux\` as the upstream reference
3. Runs \`patchscan <base>..<head> origin linux --no-update\`
4. Posts a warning comment listing any missing fix commits, or an all-clear otherwise

## Files added

| File | Description |
|------|-------------|
| \`.github/workflows/patchscan.yml\` | The workflow |
| \`.github/scripts/patchscan\` | The patchscan script (from @jmartin-lc) |
| \`.github/scripts/requirements.txt\` | Python deps (\`colorama\`, \`GitPython\`) |

## Test

Validated on a fork with two scenarios:

- **No missing fixes** — nirmoy/NV-Kernels#7: all-clear comment posted ✅
- **Missing fix detected** — nirmoy/NV-Kernels#8: backport of \`bd23f293a0d5\` without its fix \`83da212b7fca\` correctly flagged ✅

Co-developed-by: Claude AI