### PR TITLE
 Optimize Memory Allocation for Small Queues in ETH Driver

### DIFF
--- a/include/net/page_pool/types.h
+++ b/include/net/page_pool/types.h
@@ -44,6 +44,8 @@
  * use-case.  The NAPI budget is 64 packets.  After a NAPI poll the RX
  * ring is usually refilled and the max consumed elements will be 64,
  * thus a natural max size of objects needed in the cache.
+ * The refill watermark is set to 64 for 4KB pages,
+ * and scales to balance its size in bytes across page sizes.
  *
  * Keeping room for more objects, is due to XDP_DROP use-case.  As
  * XDP_DROP allows the opportunity to recycle objects directly into
@@ -51,8 +53,15 @@
  * cache is already full (or partly full) then the XDP_DROP recycles
  * would have to take a slower code path.
  */
-#define PP_ALLOC_CACHE_SIZE	128
+#if PAGE_SIZE >= SZ_64K
+#define PP_ALLOC_CACHE_REFILL	4
+#elif PAGE_SIZE >= SZ_16K
+#define PP_ALLOC_CACHE_REFILL	16
+#else
 #define PP_ALLOC_CACHE_REFILL	64
+#endif
+
+#define PP_ALLOC_CACHE_SIZE	(PP_ALLOC_CACHE_REFILL * 2)
 struct pp_alloc_cache {
 	u32 count;
 	netmem_ref cache[PP_ALLOC_CACHE_SIZE];


### PR DESCRIPTION
Backport a change to reduce memory usage of SF netdevices with 64k page kernels.

For this test, one SF can be created as such:

devlink port add pci/0000:00:08.0 flavour pcisf pfnum 0 sfnum 1
devlink port function set pci/0000:00:08.0/32768 state active
devlink dev param set auxiliary/mlx5_core.sf.2 name enable_eth cmode driverinit value true
devlink dev reload auxiliary/mlx5_core.sf.2
ip link set dev eth4 up  # PR netdev
ip link set dev eth5 up  # SF netdev

When creating 230 SFs, I observed the following results based on /proc/meminfo MemAvailable:

6.17.0-1015-nvidia-64k 61.42MB/SF
6.17.0-0x45444b163097-nvidia-64k 41.80MB/SF

These changes were tested over tag Ubuntu-nvidia-6.17-6.17.0-1015.15
I tested with the in-tree drivers. I also build tested doca-kernel 3.2.2 from
https://linux.mellanox.com/public/repo/doca/3.2.2/ubuntu24.04/arm64-sbsa/