### PR TITLE
Support RSS with crypto offload

### DIFF
--- a/include/net/xfrm.h
+++ b/include/net/xfrm.h
@@ -1156,19 +1156,19 @@ struct xfrm_offload {
 #define CRYPTO_INVALID_PROTOCOL			128
 
 	/* Used to keep whole l2 header for transport mode GRO */
-	__u32			orig_mac_len;
+	__u16			orig_mac_len;
 
 	__u8			proto;
 	__u8			inner_ipproto;
 };
 
 struct sec_path {
-	int			len;
-	int			olen;
-	int			verified_cnt;
-
 	struct xfrm_state	*xvec[XFRM_MAX_DEPTH];
 	struct xfrm_offload	ovec[XFRM_MAX_OFFLOAD_DEPTH];
+
+	u8			len;
+	u8			olen;
+	u8			verified_cnt;
 };
 
 struct sec_path *secpath_set(struct sk_buff *skb);

--- a/net/xfrm/xfrm_input.c
+++ b/net/xfrm/xfrm_input.c
@@ -505,6 +505,7 @@ int xfrm_input(struct sk_buff *skb, int nexthdr, __be32 spi, int encap_type)
 			async = 1;
 			dev_put(skb->dev);
 			seq = XFRM_SKB_CB(skb)->seq.input.low;
+			spin_lock(&x->lock);
 			goto resume;
 		}
 		/* GRO call */
@@ -541,6 +542,8 @@ int xfrm_input(struct sk_buff *skb, int nexthdr, __be32 spi, int encap_type)
 				XFRM_INC_STATS(net, LINUX_MIB_XFRMINHDRERROR);
 				goto drop;
 			}
+
+			nexthdr = x->type_offload->input_tail(x, skb);
 		}
 
 		goto lock;
@@ -638,11 +641,9 @@ lock:
 			goto drop_unlock;
 		}
 
-		spin_unlock(&x->lock);
-
 		if (xfrm_tunnel_check(skb, x, family)) {
 			XFRM_INC_STATS(net, LINUX_MIB_XFRMINSTATEMODEERROR);
-			goto drop;
+			goto drop_unlock;
 		}
 
 		seq_hi = htonl(xfrm_replay_seqhi(x, seq));
@@ -650,9 +651,8 @@ lock:
 		XFRM_SKB_CB(skb)->seq.input.low = seq;
 		XFRM_SKB_CB(skb)->seq.input.hi = seq_hi;
 
-		if (crypto_done) {
-			nexthdr = x->type_offload->input_tail(x, skb);
-		} else {
+		if (!crypto_done) {
+			spin_unlock(&x->lock);
 			dev_hold(skb->dev);
 
 			nexthdr = x->type->input(x, skb);
@@ -660,9 +660,9 @@ lock:
 				return 0;
 
 			dev_put(skb->dev);
+			spin_lock(&x->lock);
 		}
 resume:
-		spin_lock(&x->lock);
 		if (nexthdr < 0) {
 			if (nexthdr == -EBADMSG) {
 				xfrm_audit_state_icvfail(x, skb,


### PR DESCRIPTION
Backport changes to improve IPsec crypto offload performance for workloads with multiple flows in the same SA.

These core changes work in conjunction with driver changes from https://lore.kernel.org/all/1758179963-649455-1-git-send-email-tariqt@nvidia.com/ which are included in some ofed branches, in particular the upcoming 26.04.

Tested using the script from https://redmine.mellanox.com/issues/4869652 comment 0 which creates multiple iperf3 streams; and ofed 26_04 at commit 7a65236209. Numbers in Gb/s, two repetitions.

```
6.17.0-1015-nvidia, ofed 26_04 7a65236209
	sw_only 2.11, 1.87
	crypto 6.76, 5.92
	full_offload 51.35, 52.22

6.17.0-0x115113e3092d-nvidia, ofed 26_04 7a65236209
	sw_only 2.2, 1.69
	crypto 14.25, 14.05
	full_offload 52.04, 48.23
```

These changes were tested over tag Ubuntu-nvidia-6.17-6.17.0-1015.15
I also tested doca-kernel 3.2.2 from
https://linux.mellanox.com/public/repo/doca/3.2.2/ubuntu24.04/x86_64/
It does not show this performance improvement because the driver changes are not included but it builds and works.