### PR TITLE
patchscan: distinguish E: (verification errors) from W: (missing fixes)

### DIFF
--- a/.github/scripts/patchscan
+++ b/.github/scripts/patchscan
@@ -30,9 +30,10 @@ def get_src_commit_strs(msg):
     # Match common backport/cherry-pick annotations:
     #   (cherry picked from commit <sha>)
     #   (backported from commit <sha>)
-    #   upstream commit <sha>
-    #   Upstream commit <sha>
-    matches = list(re.finditer(r"(?:from commit|[Uu]pstream commit) ([a-fA-F0-9]+)", msg))
+    #   Upstream commit <sha>  (only at start of line, used as a trailer)
+    # Note: "upstream commit <sha>" embedded in prose is intentionally NOT matched
+    # to avoid false positives from commits that reference upstream SHAs informally.
+    matches = list(re.finditer(r"(?:from commit|^[Uu]pstream commit) ([a-fA-F0-9]+)", msg, re.MULTILINE))
     return list(map(lambda m: m.group(1) if len(m.groups()) == 1 else None, matches))
 
 def references_upstream(commit):

--- a/.github/workflows/patchscan.yml
+++ b/.github/workflows/patchscan.yml
@@ -106,14 +106,14 @@ jobs:
           sed 's/\x1B\[[0-9;]*[A-Za-z]//g; s/\x1B\]8;;[^\x1B]*\x1B\\//g; s/\x1B\]8;;[^\a]*\a//g' \
             patchscan_output.txt > patchscan_clean.txt
 
-          # Record runtime errors so the comment step can report them before failing
-          if [ $exit_code -ne 0 ]; then
-            echo "fixes_found=error" >> $GITHUB_OUTPUT
-          fi
-
-          # Check if missing fixes or scan errors were found
-          if grep -qE "^W:|^E:|Fixes for" patchscan_clean.txt; then
+          # Classify the outcome — order matters: W: (missing fixes) takes priority,
+          # then E: / non-zero exit (verification errors), then all-clear.
+          # Writing fixes_found twice to GITHUB_OUTPUT would make the last write win,
+          # so use a single mutually-exclusive block.
+          if grep -qE "^W:|Fixes for" patchscan_clean.txt; then
             echo "fixes_found=true" >> $GITHUB_OUTPUT
+          elif grep -qE "^E:" patchscan_clean.txt || [ $exit_code -ne 0 ]; then
+            echo "fixes_found=error" >> $GITHUB_OUTPUT
           else
             echo "fixes_found=false" >> $GITHUB_OUTPUT
           fi
@@ -142,9 +142,12 @@ jobs:
             );
 
             const body = [
-              '## :x: Patchscan: Scan Error',
+              '## :x: Patchscan: Upstream Verification Error',
               '',
-              'Patchscan encountered an error while scanning this PR:',
+              'Patchscan could not fully verify one or more commits in this PR.',
+              'This is often a false positive caused by a SAUCE commit whose message',
+              'body references an upstream SHA but has a different title.',
+              'No `Fixes:` patches appear to be missing.',
               '',
               '````',
               truncated.trim(),
@@ -260,7 +263,7 @@ jobs:
         if: steps.patchscan.outputs.fixes_found == 'true' || steps.patchscan.outputs.fixes_found == 'error'
         run: |
           if [ "${{ steps.patchscan.outputs.fixes_found }}" = "error" ]; then
-            echo "::error::Patchscan encountered a runtime error — see PR comment for details."
+            echo "::error::Patchscan upstream verification error — see PR comment for details."
           else
             echo "::warning::Missing upstream fixes detected — see PR comment for details."
           fi


### PR DESCRIPTION
## Summary

- **Bug**: `E:` (upstream commit-message mismatch) and `W:` (missing `Fixes:` patch) both set `fixes_found=true`, so the `:warning: Missing Fixes Detected` comment appeared even when `All fixes:` was empty and no patches were actually missing.
- **Root cause 1**: Two separate `if` blocks both wrote to `GITHUB_OUTPUT` for the same variable; the second write (`true`/`false`) always overwrote the first (`error`).
- **Root cause 2**: The `[Uu]pstream commit` regex in `get_src_commit_strs()` matched `upstream commit <sha>` embedded in prose (e.g. "was removed by upstream commit d18f1b7beadf"), not just as a backport trailer. Jacob's original script uses only `from commit`, which correctly ignores such prose references.
- **Fix 1**: Replace two independent `if` blocks with a single mutually-exclusive `if/elif/else` chain:
  - `W:` / `Fixes for` → `fixes_found=true` → "Missing Fixes Detected" comment
  - `E:` / non-zero exit → `fixes_found=error` → "Upstream Verification Error" comment
  - neither → `fixes_found=false` → all-clear comment
- **Fix 2**: Anchor `[Uu]pstream commit` to line start with `re.MULTILINE` so it only matches as a standalone trailer, not in prose.

Triggered by PR #342, where commit `ad33ca9f` (a SAUCE config commit) had `upstream commit d18f1b7beadf` in its description prose — not a backport marker — causing a spurious failure.

## Test plan
- [x] Re-run patchscan against a PR with only `E:` errors — should post `:x: Upstream Verification Error` comment and fail the check
- [x] Verify a PR with actual missing `Fixes:` patches still posts `:warning: Missing Fixes Detected`
- [x] Verify a clean PR still posts `:white_check_mark: No Missing Fixes`
- [x] Verify `ad33ca9f`-style prose reference (`upstream commit X` not at line start) is no longer matched

Tested on nirmoy/NV-Kernels fork — see comments below for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)