### PR TITLE
[for 26.04_linux-nvidia]: gpio: tegra186: Simplify GPIO line name prefix and support multi-socket devices

### DIFF
--- a/drivers/gpio/gpio-tegra186.c
+++ b/drivers/gpio/gpio-tegra186.c
@@ -942,12 +942,8 @@ static int tegra186_gpio_probe(struct platform_device *pdev)
 		char *name;
 
 		for (j = 0; j < port->pins; j++) {
-			if (gpio->soc->prefix)
-				name = devm_kasprintf(gpio->gpio.parent, GFP_KERNEL, "%s-P%s.%02x",
-						      gpio->soc->prefix, port->name, j);
-			else
-				name = devm_kasprintf(gpio->gpio.parent, GFP_KERNEL, "P%s.%02x",
-						      port->name, j);
+			name = devm_kasprintf(gpio->gpio.parent, GFP_KERNEL, "%sP%s.%02x",
+					      gpio->soc->prefix ?: "", port->name, j);
 			if (!name)
 				return -ENOMEM;
 
@@ -1373,6 +1369,9 @@ static const struct tegra_gpio_soc tegra256_main_soc = {
 	.has_vm_support = true,
 };
 
+/* Macro to define GPIO name prefix with separator */
+#define TEGRA_GPIO_PREFIX(_x)	_x "-"
+
 #define TEGRA410_COMPUTE_GPIO_PORT(_name, _bank, _port, _pins)	\
 	TEGRA_GPIO_PORT(TEGRA410_COMPUTE, _name, _bank, _port, _pins)
 
@@ -1388,7 +1387,7 @@ static const struct tegra_gpio_soc tegra410_compute_soc = {
 	.num_ports = ARRAY_SIZE(tegra410_compute_ports),
 	.ports = tegra410_compute_ports,
 	.name = "tegra410-gpio-compute",
-	.prefix = "COMPUTE",
+	.prefix = TEGRA_GPIO_PREFIX("COMPUTE"),
 	.num_irqs_per_bank = 8,
 	.instance = 0,
 };
@@ -1418,7 +1417,7 @@ static const struct tegra_gpio_soc tegra410_system_soc = {
 	.num_ports = ARRAY_SIZE(tegra410_system_ports),
 	.ports = tegra410_system_ports,
 	.name = "tegra410-gpio-system",
-	.prefix = "SYSTEM",
+	.prefix = TEGRA_GPIO_PREFIX("SYSTEM"),
 	.num_irqs_per_bank = 8,
 	.instance = 0,
 };

--- a/drivers/gpio/gpio-tegra186.c
+++ b/drivers/gpio/gpio-tegra186.c
@@ -857,7 +857,7 @@ static int tegra186_gpio_probe(struct platform_device *pdev)
 	struct device_node *np;
 	struct resource *res;
 	char **names;
-	int err;
+	int node, err;
 
 	gpio = devm_kzalloc(&pdev->dev, sizeof(*gpio), GFP_KERNEL);
 	if (!gpio)
@@ -937,13 +937,23 @@ static int tegra186_gpio_probe(struct platform_device *pdev)
 	if (!names)
 		return -ENOMEM;
 
+	node = dev_to_node(&pdev->dev);
+
 	for (i = 0, offset = 0; i < gpio->soc->num_ports; i++) {
 		const struct tegra_gpio_port *port = &gpio->soc->ports[i];
 		char *name;
 
 		for (j = 0; j < port->pins; j++) {
-			name = devm_kasprintf(gpio->gpio.parent, GFP_KERNEL, "%sP%s.%02x",
-					      gpio->soc->prefix ?: "", port->name, j);
+			if (node >= 0)
+				name = devm_kasprintf(gpio->gpio.parent, GFP_KERNEL,
+						      "%d-%sP%s.%02x", node,
+						      gpio->soc->prefix ?: "",
+						      port->name, j);
+			else
+				name = devm_kasprintf(gpio->gpio.parent, GFP_KERNEL,
+						      "%sP%s.%02x",
+						      gpio->soc->prefix ?: "",
+						      port->name, j);
 			if (!name)
 				return -ENOMEM;
 


### PR DESCRIPTION
BugLink: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-7.0/+bug/2148601
BugLink: https://jirasw.nvidia.com/browse/DGX-16092

These two patches from the linux-gpio tree were not carried forward from
6.17-HWE because they were merged after the 7.0 branch was created.

- gpio: tegra186: Simplify GPIO line name prefix handling
  Introduce TEGRA_GPIO_PREFIX() to define the Tegra SoC GPIO name prefix
  in one place.

- gpio: tegra186: Support multi-socket devices
  On multi-socket Tegra platforms, prepend the NUMA node ID to the GPIO
  name prefix to ensure GPIO line names remain distinct across sockets.

## Test

Tested on NVIDIA VR NVL72 (2-socket Tegra410) running kernel 7.0.0+:

```
nvidia@localhost:~$ sudo gpiodetect
gpiochip0 [tegra410-gpio-compute] (30 lines)
gpiochip1 [tegra410-gpio-system] (94 lines)
gpiochip2 [tegra410-gpio-compute] (30 lines)
gpiochip3 [tegra410-gpio-system] (94 lines)

nvidia@localhost:~$ sudo gpioinfo
gpiochip0 - 30 lines:
	line   0: "0-COMPUTE-PA.00" kernel input active-high [used]
	line   1: "0-COMPUTE-PA.01" kernel input active-high [used]
	line   2: "0-COMPUTE-PA.02" kernel input active-high [used]
	...
	line  29: "0-COMPUTE-PE.07" kernel input active-high [used]
gpiochip1 - 94 lines:
	line   0: "0-SYSTEM-PA.00" kernel input active-high [used]
	...
	line  93: "0-SYSTEM-PV.01" unused input active-high
gpiochip2 - 30 lines:
	line   0: "1-COMPUTE-PA.00" kernel input active-high [used]
	...
	line  29: "1-COMPUTE-PE.07" kernel input active-high [used]
gpiochip3 - 94 lines:
	line   0: "1-SYSTEM-PA.00" kernel input active-high [used]
	...
	line  93: "1-SYSTEM-PV.01" unused input active-high
```

Socket 0 lines prefixed with \`0-\`, socket 1 with \`1-\`. No duplicate names observed.