### PR TITLE
[linux-nvidia-6.17] NVIDIA: VR: SAUCE: perf/arm_pmu: Skip PMCCNTR_EL0 on NVIDIA Olympus

### DIFF
--- a/drivers/perf/arm_pmu.c
+++ b/drivers/perf/arm_pmu.c
@@ -24,6 +24,8 @@
 #include <linux/irq.h>
 #include <linux/irqdesc.h>
 
+#include <asm/cpu.h>
+#include <asm/cputype.h>
 #include <asm/irq_regs.h>
 
 static int armpmu_count_irq_users(const int irq);
@@ -932,6 +934,76 @@ void armpmu_free(struct arm_pmu *pmu)
 	kfree(pmu);
 }
 
+#ifdef CONFIG_ARM64
+/*
+ * List of CPUs that should avoid using PMCCNTR_EL0.
+ */
+static struct midr_range armpmu_avoid_pmccntr_cpus[] = {
+	/*
+	 * The PMCCNTR_EL0 in Olympus CPU may still increment while in WFI/WFE state.
+	 * This is an implementation specific behavior and not an erratum.
+	 *
+	 * From ARM DDI0487 D14.4:
+	 *   It is IMPLEMENTATION SPECIFIC whether CPU_CYCLES and PMCCNTR count
+	 *   when the PE is in WFI or WFE state, even if the clocks are not stopped.
+	 *
+	 * From ARM DDI0487 D24.5.2:
+	 *   All counters are subject to any changes in clock frequency, including
+	 *   clock stopping caused by the WFI and WFE instructions.
+	 *   This means that it is CONSTRAINED UNPREDICTABLE whether or not
+	 *   PMCCNTR_EL0 continues to increment when clocks are stopped by WFI and
+	 *   WFE instructions.
+	 */
+	MIDR_ALL_VERSIONS(MIDR_NVIDIA_OLYMPUS),
+	{}
+};
+
+static bool armpmu_is_in_avoid_pmccntr_cpus(int cpu)
+{
+	struct midr_range const *r = armpmu_avoid_pmccntr_cpus;
+	u32 midr = (u32)per_cpu(cpu_data, cpu).reg_midr;
+
+	while (r->model) {
+		if (midr_is_cpu_model_range(midr, r->model, r->rv_min, r->rv_max))
+			return true;
+		r++;
+	}
+
+	return false;
+}
+#else
+static bool armpmu_is_in_avoid_pmccntr_cpus(int cpu)
+{
+	return false;
+}
+#endif
+
+static bool armpmu_avoid_pmccntr(struct arm_pmu *pmu)
+{
+	int cpu = cpumask_first(&pmu->supported_cpus);
+
+	/*
+	 * By this stage we know our supported CPUs on either DT/ACPI platforms,
+	 * detect the SMT implementation.
+	 * On SMT CPUs, the PMCCNTR_EL0 increments from the processor clock rather
+	 * than the PE clock (ARM DDI0487 L.b D13.1.3) which means it'll continue
+	 * counting on a WFI PE if one of its SMT sibling is not idle on a
+	 * multi-threaded implementation. So don't use it on SMT cores.
+	 */
+	if (topology_core_has_smt(cpu))
+		return true;
+
+	/*
+	 * On some CPUs, PMCCNTR_EL0 does not match the behavior of CPU_CYCLES
+	 * programmable counter, so avoid routing cycles through PMCCNTR_EL0 to
+	 * prevent inconsistency in the results.
+	 */
+	if (armpmu_is_in_avoid_pmccntr_cpus(cpu))
+		return true;
+
+	return false;
+}
+
 int armpmu_register(struct arm_pmu *pmu)
 {
 	int ret;
@@ -940,11 +1012,7 @@ int armpmu_register(struct arm_pmu *pmu)
 	if (ret)
 		return ret;
 
-	/*
-	 * By this stage we know our supported CPUs on either DT/ACPI platforms,
-	 * detect the SMT implementation.
-	 */
-	pmu->has_smt = topology_core_has_smt(cpumask_first(&pmu->supported_cpus));
+	pmu->avoid_pmccntr = armpmu_avoid_pmccntr(pmu);
 
 	if (!pmu->set_event_filter)
 		pmu->pmu.capabilities |= PERF_PMU_CAP_NO_EXCLUDE;

--- a/drivers/perf/arm_pmuv3.c
+++ b/drivers/perf/arm_pmuv3.c
@@ -1002,13 +1002,7 @@ static bool armv8pmu_can_use_pmccntr(struct pmu_hw_events *cpuc,
 	if (has_branch_stack(event))
 		return false;
 
-	/*
-	 * The PMCCNTR_EL0 increments from the processor clock rather than
-	 * the PE clock (ARM DDI0487 L.b D13.1.3) which means it'll continue
-	 * counting on a WFI PE if one of its SMT sibling is not idle on a
-	 * multi-threaded implementation. So don't use it on SMT cores.
-	 */
-	if (cpu_pmu->has_smt)
+	if (cpu_pmu->avoid_pmccntr)
 		return false;
 
 	return true;

--- a/include/linux/perf/arm_pmu.h
+++ b/include/linux/perf/arm_pmu.h
@@ -119,7 +119,7 @@ struct arm_pmu {
 
 	/* PMUv3 only */
 	int		pmuver;
-	bool		has_smt;
+	bool		avoid_pmccntr;
 	u64		reg_pmmir;
 	u64		reg_brbidr;
 #define ARMV8_PMUV3_MAX_COMMON_EVENTS		0x40


### PR DESCRIPTION
The PMCCNTR_EL0 in NVIDIA Olympus CPU may increment while in WFI/WFE, which does not align with counting CPU_CYCLES on a programmable counter. Add a MIDR range entry and refuse PMCCNTR_EL0 for cycle events on affected parts so perf does not mix the two behaviors.


(backported from https://lore.kernel.org/all/20260406232034.2566133-1-bwicaksono@nvidia.com/)

<hr>

This patch is currently being reviewed on LKML and addresses an issue when the Olympus core is in single-threaded mode (disabled via UEFI, cannot use the nosmt kernel parameter).

LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-6.17/+bug/2149758
NVB: `5736369`

<hr>

Without the patch:

```
$ sudo PERF=/home/nvidia/mochs/NV-Kernels/tools/perf/perf ./test_tegra410_pmu/test_pmccntr_skip.sh
========================================
Olympus PMCCNTR_EL0 Skip Test
========================================

[INFO] Using perf: perf version 6.17.13.ge399e4ea3cd3

----------------------------------------
Test 1: Platform Check
----------------------------------------
[INFO] Olympus CPU found: cpu0 (MIDR=0x000000004e0f0100)
[PASS] Running on NVIDIA Olympus CPU (cpu0)

----------------------------------------
Test 2: PMCCNTR_EL0 WFI Inflation
----------------------------------------
[INFO] Measuring '{cpu_cycles,cpu_cycles}' group on cpu0 during sleep 1...
[INFO] (PMCCNTR_EL0 inflates during WFI; programmable counters do not)
[INFO] Raw perf output:
CPU0             83163294      cpu_cycles                                                            
CPU0              5675024      cpu_cycles                                                            
[INFO]   cpu_cycles[0] (may be PMCCNTR_EL0): 83163294
[INFO]   cpu_cycles[1] (programmable counter): 5675024
[INFO]   ratio cc[0]/cc[1]: 14.7x
[FAIL] cc[0]/cc[1]=14.7x (>>5x) — PMCCNTR_EL0 inflating WFI cycles (patch NOT working)

========================================
Test Summary
========================================
Passed:  1
Failed:  1
Skipped: 0

[ERROR] One or more tests failed.
```

With the patch:

```
$ sudo PERF=/home/nvidia/mochs/NV-Kernels/tools/perf/perf ./test_tegra410_pmu/test_pmccntr_skip.sh
========================================
Olympus PMCCNTR_EL0 Skip Test
========================================

[INFO] Using perf: perf version 6.17.13.ge399e4ea3cd3

----------------------------------------
Test 1: Platform Check
----------------------------------------
[INFO] Olympus CPU found: cpu0 (MIDR=0x000000004e0f0100)
[PASS] Running on NVIDIA Olympus CPU (cpu0)

----------------------------------------
Test 2: PMCCNTR_EL0 WFI Inflation
----------------------------------------
[INFO] Measuring '{cpu_cycles,cpu_cycles}' group on cpu0 during sleep 1...
[INFO] (PMCCNTR_EL0 inflates during WFI; programmable counters do not)
[INFO] Raw perf output:
CPU0             11759855      cpu_cycles                                                            
CPU0             11759855      cpu_cycles                                                            
[INFO]   cpu_cycles[0] (may be PMCCNTR_EL0): 11759855
[INFO]   cpu_cycles[1] (programmable counter): 11759855
[INFO]   ratio cc[0]/cc[1]: 1.0x
[PASS] cc[0]/cc[1]=1.0x — both counters equal, PMCCNTR_EL0 not used (patch working)

========================================
Test Summary
========================================
Passed:  2
Failed:  0
Skipped: 0

[INFO] All tests passed.
```