### PR TITLE
[for 26.04_linux-nvidia-bos]: NVIDIA: SAUCE: r8169: remove PCI IDs claimed by r8127 driver

### DIFF
--- a/drivers/net/ethernet/realtek/r8169_main.c
+++ b/drivers/net/ethernet/realtek/r8169_main.c
@@ -241,10 +241,8 @@ static const struct pci_device_id rtl8169_pci_tbl[] = {
 	{ 0x0001, 0x8168, PCI_ANY_ID, 0x2410 },
 	{ PCI_VDEVICE(REALTEK,	0x8125) },
 	{ PCI_VDEVICE(REALTEK,	0x8126) },
-	{ PCI_VDEVICE(REALTEK,	0x8127) },
 	{ PCI_VDEVICE(REALTEK,	0x3000) },
 	{ PCI_VDEVICE(REALTEK,	0x5000) },
-	{ PCI_VDEVICE(REALTEK,	0x0e10) },
 	{}
 };
 


### PR DESCRIPTION
Remove device IDs 0x8127 and 0x0e10 from the r8169 PCI device table so that the r8127 vendor driver binds to these devices instead.

Tested-by: Keith Berger <kberger@nvidia.com>