### PR TITLE
patchscan: add validate-pr script and unified PR Validation Report

### DIFF
--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,2 +1,3 @@
+b4>=0.13
 colorama==0.4.6
 GitPython==3.1.37

--- a/.github/scripts/validate-pr
+++ b/.github/scripts/validate-pr
@@ -1,0 +1,591 @@
+#!/usr/bin/python3
+from argparse import ArgumentParser
+from colorama import Fore
+import git
+import hashlib
+import mailbox
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+parser = ArgumentParser(
+    description="Validates PR commit hygiene and PR metadata.")
+parser.add_argument("check_range",
+    help="Git commit range, e.g. origin/base..origin/head")
+parser.add_argument("upstream_remote",
+    help="Remote containing upstream branch, e.g. origin")
+parser.add_argument("upstream_branch",
+    help="Upstream branch name, e.g. linux")
+parser.add_argument("--no-update", action="store_true",
+    help="Skip git fetch")
+parser.add_argument("--pr-title", default=None,
+    help="PR title string (enables title check)")
+parser.add_argument("--pr-body", default=None,
+    help="Path to file containing PR body (enables body checks)")
+parser.add_argument("--base-branch", default=None,
+    help="Target branch name (used for BugLink requirement)")
+args = parser.parse_args()
+
+
+def get_cherry_pick_sha(message):
+    m = re.search(r'\(cherry picked from commit ([a-fA-F0-9]+)\)', message)
+    return m.group(1) if m else None
+
+def get_backport_url(message):
+    m = re.search(r'\(backported from (https?://[^\)]+)\)', message)
+    return m.group(1) if m else None
+
+def is_sauce(subject):
+    return bool(re.match(r'^NVIDIA:.*SAUCE:', subject))
+
+def is_revert(subject):
+    return subject.startswith('Revert "')
+
+def is_merge_commit(commit):
+    return len(commit.parents) > 1
+
+def subject_of(commit):
+    return commit.message.split('\n')[0]
+
+def get_sob_lines(message):
+    return re.findall(r'^Signed-off-by:.*$', message, re.MULTILINE)
+
+
+def get_patch_id(commit):
+    """Return the stable patch-ID string for a commit, or None on failure."""
+    show = subprocess.run(
+        ['git', 'show', commit.hexsha],
+        capture_output=True,
+        cwd=commit.repo.working_dir,
+    )
+    pid = subprocess.run(
+        ['git', 'patch-id', '--stable'],
+        input=show.stdout,
+        capture_output=True,
+        cwd=commit.repo.working_dir,
+    )
+    if pid.returncode == 0 and pid.stdout:
+        parts = pid.stdout.decode().strip().split()
+        if parts:
+            return parts[0]
+    return None
+
+
+def describe_sob_chain(local_commit, upstream_commit):
+    """Return a human-readable SoB chain status string."""
+    local_sobs = get_sob_lines(local_commit.message)
+    upstream_sobs = get_sob_lines(upstream_commit.message)
+    missing = [s for s in upstream_sobs if s not in local_sobs]
+    if missing:
+        short = missing[0][len('Signed-off-by: '):].split('<')[0].strip()[:20]
+        return "MISSING: {}".format(short)
+    added = [s for s in local_sobs if s not in upstream_sobs]
+    if not added:
+        return "preserved"
+    names = []
+    for s in added:
+        m = re.match(r'Signed-off-by:\s+\S.*<([^@>]+)', s)
+        names.append(m.group(1).split('.')[-1][:8] if m else '?')
+    return "preserved + {} added".format(' '.join(names))
+
+
+def describe_sob_simple(message):
+    """Return SoB status for a commit with no upstream to compare against."""
+    sobs = get_sob_lines(message)
+    if not sobs:
+        return 'MISSING'
+    names = []
+    for s in sobs:
+        m = re.match(r'Signed-off-by:\s+\S.*<([^@>]+)', s)
+        names.append(m.group(1).split('.')[-1][:8] if m else '?')
+    return ', '.join(names)
+
+
+def describe_sob_chain_backport(message):
+    """Check SOB ordering for a (backported from <url>) commit.
+
+    Correct order: original-author SOB(s), then (backported from ...), then
+    backporter SOB.  Returns a short status string; strings starting with
+    'MISSING' indicate an error.
+    """
+    bp_match = re.search(r'\(backported from https?://[^\)]+\)', message)
+    if bp_match is None:
+        return 'no backport tag'
+    bp_pos = bp_match.start()
+    sobs = [(m.start(), m.group()) for m in
+            re.finditer(r'^Signed-off-by:.*$', message, re.MULTILINE)]
+    before = [s for pos, s in sobs if pos < bp_pos]
+    after  = [s for pos, s in sobs if pos > bp_pos]
+    if not before:
+        return 'MISSING: no SOB before (backported from)'
+    if not after:
+        return 'MISSING: backporter SOB after (backported from)'
+    names = []
+    for s in after:
+        m = re.match(r'Signed-off-by:\s+\S.*<([^@>]+)', s)
+        names.append(m.group(1).split('.')[-1][:8] if m else '?')
+    return "ok, backporter: {}".format(' '.join(names))
+
+
+COL_WIDTHS = [12, 45, 10, 7, 25]
+HEADERS    = ['Local', 'Referenced upstream / Patch subject', 'Patch-ID', 'Subject', 'SoB chain']
+
+def _hline(left, sep, right):
+    return left + sep.join('─' * (w + 2) for w in COL_WIDTHS) + right
+
+def _row_line(cells):
+    return '│ ' + ' │ '.join(
+        str(c)[:w].ljust(w) for c, w in zip(cells, COL_WIDTHS)
+    ) + ' │'
+
+def print_digest_table(rows):
+    """Print a Unicode box-drawing table of cherry-pick digest rows.
+
+    Each row dict: local, upstream, patch_id, subject, sob, error (bool).
+    """
+    print(_hline('┌', '┬', '┐'))
+    print(_row_line(HEADERS))
+    for row in rows:
+        print(_hline('├', '┼', '┤'))
+        cells = [row['local'], row['upstream'],
+                 row['patch_id'], row['subject'], row['sob']]
+        line = _row_line(cells)
+        if row.get('error'):
+            print(Fore.RED + line + Fore.RESET)
+        else:
+            print(Fore.GREEN + line + Fore.RESET)
+    print(_hline('└', '┴', '┘'))
+
+
+def _shorten_lkml_url(url):
+    """Shorten a lore.kernel.org URL to a compact display form."""
+    m = re.search(r'lore\.kernel\.org/[^/]+/([^/]+)', url)
+    if m:
+        msgid = m.group(1)
+        return msgid[:19] if len(msgid) > 19 else msgid
+    return url[:19]
+
+
+_b4_series_cache = {}  # url -> {norm_subject: diff_text} or None on error
+
+
+def _extract_diff_text(text):
+    """Return only the diff section from an email patch or git-show output."""
+    out = []
+    in_diff = False
+    for line in text.splitlines():
+        if line.startswith('diff --git '):
+            in_diff = True
+        if in_diff:
+            if line == '-- ':  # mbox end-of-diff marker
+                break
+            out.append(line)
+    return '\n'.join(out)
+
+
+def _diff_fingerprint(diff_text):
+    """SHA-1 over added/removed content lines only (excludes @@ hunk headers
+    whose line numbers differ between email patches and git-show output)."""
+    content = '\n'.join(
+        l for l in diff_text.splitlines()
+        if (l.startswith('+') or l.startswith('-'))
+        and not l.startswith('+++') and not l.startswith('---')
+    )
+    return hashlib.sha1(content.encode()).hexdigest()
+
+
+def has_conflict_annotation(message):
+    """Return True if commit message has a [Name: backport-note] annotation."""
+    return bool(re.search(r'^\[[\w][\w .\-]+:.*\]', message, re.MULTILINE))
+
+
+def _norm_lkml_subject(subj):
+    """Strip [PATCH vN M/N] prefix and lowercase for subject matching."""
+    subj = re.sub(r'\r?\n[ \t]+', ' ', subj)  # unfold RFC 2822 header folding
+    s = re.sub(r'^\[PATCH[^\]]*\]\s*', '', subj).strip()
+    return s.lower() if s else ''
+
+
+def _norm_sauce_subject(subj):
+    """Strip NVIDIA:...:SAUCE: prefix and lowercase for subject matching."""
+    s = re.sub(r'^NVIDIA:.*?SAUCE:\s*', '', subj).strip()
+    return s.lower() if s else ''
+
+
+def _b4_fetch_series(url, workdir):
+    """Fetch a patch series via 'b4 am -o -'; return {norm_subj: diff_text}.
+
+    Returns None on b4 failure; {} if no diffs found (e.g. cover-letter only).
+    Cached by URL so a series shared by multiple commits is fetched once.
+    """
+    if url in _b4_series_cache:
+        return _b4_series_cache[url]
+
+    result = subprocess.run(
+        ['b4', 'am', '-o', '-', url],
+        capture_output=True,
+        timeout=120,
+        cwd=workdir,
+    )
+    if result.returncode != 0 or not result.stdout:
+        _b4_series_cache[url] = None
+        return None
+
+    with tempfile.NamedTemporaryFile(suffix='.mbx', delete=False) as f:
+        f.write(result.stdout)
+        tmppath = f.name
+
+    patches = {}
+    try:
+        mbox = mailbox.mbox(tmppath)
+        for msg in mbox:
+            norm = _norm_lkml_subject(msg.get('Subject', ''))
+            if not norm:
+                continue
+            payload = msg.get_payload(decode=True)
+            if payload is None and msg.is_multipart():
+                for part in msg.walk():
+                    if part.get_content_type() == 'text/plain':
+                        payload = part.get_payload(decode=True)
+                        break
+            if payload:
+                diff = _extract_diff_text(payload.decode('utf-8', errors='replace'))
+                if diff:
+                    patches[norm] = diff
+    finally:
+        os.unlink(tmppath)
+
+    _b4_series_cache[url] = patches
+    return patches
+
+
+def check_backport_diff(commit):
+    """Compare local commit diff against the matching upstream patch via b4.
+
+    Returns (status_str, is_error).  is_error is True only when a matching
+    patch is found, diffs differ, and no [Author: ...] annotation explains it.
+
+    Status strings:
+      'match'      – diffs identical
+      'annotated'  – differs but [Author: note] present (intentional)
+      'MISMATCH'   – differs, no annotation  → error
+      'no-match'   – series fetched but no patch matches this commit's subject
+      'no-diff'    – series has no patches with diffs (cover-letter only)
+      'fetch-err'  – b4 failed (network/tool issue) → warning, not error
+      'non-lore'   – URL is not a lore.kernel.org link → skipped
+    """
+    url = get_backport_url(commit.message)
+    if url is None:
+        return 'N/A', False, 'N/A'
+
+    if 'lore.kernel.org' not in url and 'patchwork.kernel.org' not in url:
+        return 'non-lore', False, 'non-lore'
+
+    patches = _b4_fetch_series(url, commit.repo.working_dir)
+    if patches is None:
+        return 'fetch-err', False, 'fetch-err'
+    if not patches:
+        return 'no-diff', False, 'no-diff'
+
+    norm_local = _norm_sauce_subject(subject_of(commit))
+    upstream_diff = patches.get(norm_local)
+    if upstream_diff is None:
+        for key in patches:
+            if norm_local and (norm_local in key or key in norm_local):
+                upstream_diff = patches[key]
+                break
+
+    if upstream_diff is None:
+        return 'no-match', False, 'not found'
+
+    show = subprocess.run(
+        ['git', 'show', commit.hexsha],
+        capture_output=True,
+        cwd=commit.repo.working_dir,
+    )
+    local_diff = _extract_diff_text(show.stdout.decode('utf-8', errors='replace'))
+
+    if _diff_fingerprint(local_diff) == _diff_fingerprint(upstream_diff):
+        return 'match', False, 'found'
+
+    if has_conflict_annotation(commit.message):
+        return 'noted', False, 'found'
+
+    return 'MISMATCH', True, 'found'
+
+
+def build_digest(commits, repo, upstream_remote=None):
+    """Build digest rows for cherry-pick and backported-from commits."""
+    rows = []
+    errors = []
+
+    for commit in commits:
+        src_sha = get_cherry_pick_sha(commit.message)
+        bp_url  = get_backport_url(commit.message)
+
+        # --- SAUCE / Revert: no upstream reference, show as informational row ---
+        if src_sha is None and bp_url is None:
+            local_sha12 = commit.hexsha[:12]
+            subj        = subject_of(commit)
+            if is_merge_commit(commit):
+                continue  # merge commits handled by lint; don't clutter the table
+            if is_revert(subj):
+                kind = 'Revert'
+                # Strip outer Revert "..." wrapper and SAUCE prefix for display
+                inner = re.sub(r'^Revert\s+"', '', subj).rstrip('"')
+                display = _norm_sauce_subject(inner) or inner
+            else:
+                kind    = 'SAUCE'
+                display = _norm_sauce_subject(subj) or subj
+            sob_status = describe_sob_simple(commit.message)
+            sob_error  = sob_status == 'MISSING'
+            if sob_error:
+                errors.append("E: {} (\"{}\"): missing Signed-off-by".format(
+                    local_sha12, subj[:50]))
+            rows.append(dict(local=local_sha12,
+                             upstream='[{}] {}'.format(kind, display),
+                             patch_id='N/A', subject='N/A',
+                             sob=sob_status, error=sob_error))
+            continue
+
+        # --- backported-from: check SOB order + compare diff against lore patch ---
+        if src_sha is None:
+            local_sha12 = commit.hexsha[:12]
+            sob_status  = describe_sob_chain_backport(commit.message)
+            sob_error   = sob_status.startswith('MISSING')
+            if sob_error:
+                errors.append("E: {} (\"{}\"): SOB chain: {}".format(
+                    local_sha12, subject_of(commit)[:40], sob_status))
+            diff_status, diff_error, subj_status = check_backport_diff(commit)
+            if diff_error:
+                errors.append(
+                    "E: {} (\"{}\"): diff MISMATCH with lore patch"
+                    " (add [Author: reason] annotation if intentional)".format(
+                        local_sha12, subject_of(commit)[:40]))
+            has_error = sob_error or diff_error
+            patch_subj = _norm_sauce_subject(subject_of(commit))
+            rows.append(dict(local=local_sha12,
+                             upstream=patch_subj,
+                             patch_id=diff_status, subject=subj_status,
+                             sob=sob_status, error=has_error))
+            continue
+
+        local_sha12    = commit.hexsha[:12]
+        upstream_sha12 = src_sha[:12]
+
+        # Resolve upstream commit — try local object store first, then a
+        # targeted fetch (GitHub allows fetching any reachable SHA by ID).
+        upstream = None
+        try:
+            upstream = repo.commit(src_sha)
+        except Exception:
+            if upstream_remote:
+                try:
+                    repo.git.fetch(upstream_remote, src_sha)
+                    upstream = repo.commit(src_sha)
+                except Exception:
+                    pass
+
+        if upstream is None:
+            errors.append("E: {} (\"{}\"): cannot resolve upstream SHA {}".format(
+                local_sha12, subject_of(commit)[:40], upstream_sha12))
+            rows.append(dict(local=local_sha12, upstream=upstream_sha12,
+                             patch_id='ERROR', subject='ERROR', sob='ERROR',
+                             error=True))
+            continue
+
+        # Patch-ID
+        local_pid    = get_patch_id(commit)
+        upstream_pid = get_patch_id(upstream)
+        if local_pid and upstream_pid and local_pid == upstream_pid:
+            pid_status = 'match'
+            pid_error  = False
+        else:
+            pid_status = 'MISMATCH'
+            pid_error  = True
+            errors.append("E: {} (\"{}\"): patch-ID mismatch with upstream {}".format(
+                local_sha12, subject_of(commit)[:40], upstream_sha12))
+
+        # Subject
+        local_subj    = subject_of(commit)
+        upstream_subj = subject_of(upstream)
+        if local_subj == upstream_subj:
+            subj_status = 'match'
+            subj_error  = False
+        else:
+            subj_status = 'MISMATCH'
+            subj_error  = True
+            errors.append("E: {} (\"{}\"): subject differs from upstream \"{}\"".format(
+                local_sha12, local_subj[:40], upstream_subj[:40]))
+
+        sob_status = describe_sob_chain(commit, upstream)
+        sob_error  = sob_status.startswith('MISSING')
+        if sob_error:
+            errors.append("E: {} (\"{}\"): SoB chain problem: {}".format(
+                local_sha12, subject_of(commit)[:40], sob_status))
+
+        has_error = pid_error or subj_error or sob_error
+        rows.append(dict(local=local_sha12, upstream=upstream_sha12,
+                         patch_id=pid_status, subject=subj_status,
+                         sob=sob_status, error=has_error))
+
+    return rows, errors
+
+
+def lint_commits(commits):
+    """Run per-commit lint checks. Returns (warnings, errors) as lists of strings."""
+    warnings = []
+    errors   = []
+
+    SAUCE_PREFIX_RE = re.compile(
+        r'^NVIDIA:(\s+VR:)?(\s+[A-Z][A-Z0-9]+:)?\s+SAUCE:')
+
+    for commit in commits:
+        sha12   = commit.hexsha[:12]
+        subject = subject_of(commit)
+        label   = '{} ("{}")'.format(sha12, subject[:50])
+
+        # R8: no merge commits
+        if is_merge_commit(commit):
+            errors.append("E: {}: merge commit in PR range".format(label))
+            continue  # skip further checks on merge commits
+
+        sobs = get_sob_lines(commit.message)
+
+        # R5: Signed-off-by required
+        if not sobs:
+            errors.append("E: {}: missing Signed-off-by trailer".format(label))
+
+        # Classification for R6/R7/R9/R10
+        sauce   = is_sauce(subject)
+        revert  = is_revert(subject)
+
+        # R9: subject length — exempt SAUCE and Reverts of SAUCE; the mandatory
+        # "NVIDIA: [VR: ]SAUCE:" prefix already consumes 15–20 characters.
+        revert_of_sauce = revert and bool(re.match(r'^Revert "NVIDIA:.*SAUCE:', subject))
+        if len(subject) > 72 and not sauce and not revert_of_sauce:
+            warnings.append("W: {}: subject {} chars (>72)".format(label, len(subject)))
+        cp_sha  = get_cherry_pick_sha(commit.message)
+        bp_url  = get_backport_url(commit.message)
+
+        # R6: non-SAUCE, non-Revert commits must have an upstream reference trailer
+        if not sauce and not revert and cp_sha is None and bp_url is None:
+            errors.append(
+                "E: {}: not SAUCE/Revert but has no upstream reference trailer"
+                " (cherry picked from commit ... or backported from ...)".format(label))
+
+        # R7: detect wrong trailer for LKML in-review backports
+        # Heuristic: SAUCE commit whose message contains a lore.kernel.org URL
+        # but uses (cherry picked from commit <sha>) instead of (backported from <url>)
+        if sauce and cp_sha is not None:
+            if re.search(r'lore\.kernel\.org|patchwork\.kernel\.org', commit.message):
+                warnings.append(
+                    "W: {}: LKML-in-review backport should use"
+                    " '(backported from <url>)' not '(cherry picked from commit ...)'".format(label))
+
+        # R10: SAUCE prefix canonicality
+        if sauce and not SAUCE_PREFIX_RE.match(subject):
+            warnings.append(
+                "W: {}: non-canonical SAUCE prefix (expected 'NVIDIA: [VR: ][VENDOR: ]SAUCE:')".format(label))
+
+    return warnings, errors
+
+
+TRACKED_BRANCH_RE = re.compile(r'^(24|26)\.04_linux-nvidia')
+
+def check_pr_metadata(pr_title, pr_body_path, base_branch):
+    """Check PR title and body for required fields. Returns (warnings, errors)."""
+    warnings = []
+    errors   = []
+
+    # R1: title must start with [<branch>] unless exempted
+    exempt_base  = base_branch in ('github-actions',) if base_branch else False
+    exempt_title = pr_title.startswith('TEST:') if pr_title else False
+    if pr_title and not exempt_base and not exempt_title:
+        if not pr_title.startswith('['):
+            warnings.append(
+                "W: PR title missing [<branch>] prefix: \"{}\"".format(pr_title[:80]))
+
+    # R3: BugLink required for tracked branches
+    if pr_body_path and base_branch and TRACKED_BRANCH_RE.match(base_branch):
+        try:
+            body = open(pr_body_path).read()
+        except OSError as e:
+            errors.append("E: cannot read --pr-body {}: {}".format(pr_body_path, e))
+            body = ''
+        buglink_re = re.compile(
+            r'^(?:BugLink:|LP:)\s+https://bugs\.launchpad\.net/', re.MULTILINE)
+        if not buglink_re.search(body):
+            errors.append(
+                "E: PR targets {} but body has no 'BugLink:' or 'LP:'"
+                " https://bugs.launchpad.net/... line".format(base_branch))
+
+    return warnings, errors
+
+
+def main():
+    repo = git.Repo(os.getcwd())
+    assert not repo.bare
+
+    commits = list(repo.iter_commits(args.check_range))
+    if not commits:
+        print("No commits in range {}; nothing to check.".format(args.check_range))
+        return
+
+    upstream_ref = "{}/{}".format(args.upstream_remote, args.upstream_branch)
+    assert upstream_ref in repo.git.branch('-r'), \
+        "Upstream ref {} not found".format(upstream_ref)
+
+    if not args.no_update:
+        print("Fetching upstream {}...".format(upstream_ref))
+        repo.remote(args.upstream_remote).fetch(args.upstream_branch)
+
+    print("Checking {} commits...\n".format(len(commits)))
+
+    all_errors = []
+
+    # --- Cherry-pick digest ---
+    digest_rows, digest_errors = build_digest(commits, repo, args.upstream_remote)
+    if digest_rows:
+        print("Cherry-pick digest:")
+        for msg in digest_errors:
+            print(Fore.RED + msg + Fore.RESET)
+        print_digest_table(digest_rows)
+        print()
+    all_errors.extend(digest_errors)
+
+    # --- Per-commit lint ---
+    lint_warnings, lint_errors = lint_commits(commits)
+    if lint_warnings or lint_errors:
+        print("Lint results:")
+        for msg in lint_warnings:
+            print(Fore.YELLOW + msg + Fore.RESET)
+        for msg in lint_errors:
+            print(Fore.RED + msg + Fore.RESET)
+        print()
+    else:
+        print(Fore.GREEN + "Lint: all checks passed." + Fore.RESET)
+        print()
+    all_errors.extend(lint_errors)
+
+    # --- PR metadata ---
+    if args.pr_title or args.pr_body:
+        meta_warnings, meta_errors = check_pr_metadata(
+            args.pr_title, args.pr_body, args.base_branch)
+        if meta_warnings or meta_errors:
+            print("PR metadata:")
+            for msg in meta_warnings:
+                print(Fore.YELLOW + msg + Fore.RESET)
+            for msg in meta_errors:
+                print(Fore.RED + msg + Fore.RESET)
+            print()
+        all_errors.extend(meta_errors)
+
+    if all_errors:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/patchscan.yml
+++ b/.github/workflows/patchscan.yml
@@ -1,4 +1,4 @@
-name: Patchscan - Check Missing Fixes
+name: PR Validation
 
 on:
   pull_request_target:
@@ -12,10 +12,14 @@ on:
         description: 'PR number to scan'
         required: true
         type: number
+      repo:
+        description: 'Repo containing the PR (owner/repo). Leave empty for this repo.'
+        required: false
+        type: string
 
 jobs:
   patchscan:
-    name: Check for missing upstream fixes
+    name: Patchscan + PR lint
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -27,11 +31,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          pr_json=$(gh api repos/${{ github.repository }}/pulls/${{ inputs.pr_number }})
+          pr_repo="${{ inputs.repo || github.repository }}"
+          pr_json=$(gh api repos/${pr_repo}/pulls/${{ inputs.pr_number }})
           echo "head_sha=$(echo "$pr_json" | jq -r .head.sha)" >> $GITHUB_OUTPUT
           echo "base_sha=$(echo "$pr_json" | jq -r .base.sha)" >> $GITHUB_OUTPUT
           echo "base_ref=$(echo "$pr_json" | jq -r .base.ref)" >> $GITHUB_OUTPUT
           echo "pr_number=${{ inputs.pr_number }}" >> $GITHUB_OUTPUT
+          echo "pr_repo=${pr_repo}" >> $GITHUB_OUTPUT
 
       - name: Set PR variables
         id: pr
@@ -41,11 +47,13 @@ jobs:
             echo "base_sha=${{ steps.pr_info.outputs.base_sha }}" >> $GITHUB_OUTPUT
             echo "base_ref=${{ steps.pr_info.outputs.base_ref }}" >> $GITHUB_OUTPUT
             echo "pr_number=${{ steps.pr_info.outputs.pr_number }}" >> $GITHUB_OUTPUT
+            echo "pr_repo=${{ steps.pr_info.outputs.pr_repo }}" >> $GITHUB_OUTPUT
           else
             echo "head_sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
             echo "base_sha=${{ github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
             echo "base_ref=${{ github.base_ref }}" >> $GITHUB_OUTPUT
             echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "pr_repo=${{ github.repository }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout base branch
@@ -57,14 +65,37 @@ jobs:
 
       - name: Fetch PR commits
         run: |
-          git fetch --no-tags origin \
+          pr_repo="${{ steps.pr.outputs.pr_repo }}"
+          if [ "$pr_repo" = "${{ github.repository }}" ]; then
+            fetch_remote="origin"
+          else
+            git remote add pr-upstream "https://github.com/${pr_repo}.git"
+            fetch_remote="pr-upstream"
+          fi
+          git fetch --no-tags "$fetch_remote" \
             ${{ steps.pr.outputs.base_sha }}:refs/remotes/origin/patchscan-base \
             refs/pull/${{ steps.pr.outputs.pr_number }}/head:refs/remotes/origin/patchscan-head
 
-      - name: Fetch patchscan from github-actions branch
+      - name: Write PR title and body to files
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            pr_json=$(gh api repos/${{ steps.pr.outputs.pr_repo }}/pulls/${{ steps.pr.outputs.pr_number }})
+            echo "$pr_json" | jq -r '.title' > pr_title.txt
+            echo "$pr_json" | jq -r '.body // ""' > pr_body.txt
+          else
+            printf '%s' "${{ github.event.pull_request.title }}" > pr_title.txt
+            printf '%s' "${{ github.event.pull_request.body }}" > pr_body.txt
+          fi
+
+      - name: Fetch scripts from github-actions branch
         run: |
           git fetch origin github-actions
-          git checkout origin/github-actions -- .github/scripts/patchscan .github/scripts/requirements.txt
+          git checkout origin/github-actions -- \
+            .github/scripts/patchscan \
+            .github/scripts/validate-pr \
+            .github/scripts/requirements.txt
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -108,165 +139,163 @@ jobs:
           sed 's/\x1B\[[0-9;]*[A-Za-z]//g; s/\x1B\]8;;[^\x1B]*\x1B\\//g; s/\x1B\]8;;[^\a]*\a//g' \
             patchscan_output.txt > patchscan_clean.txt
 
-          # Classify the outcome — order matters: W: (missing fixes) takes priority,
-          # then E: / non-zero exit (verification errors), then all-clear.
-          # Writing fixes_found twice to GITHUB_OUTPUT would make the last write win,
-          # so use a single mutually-exclusive block.
-          if grep -qE "^W:|Fixes for" patchscan_clean.txt; then
+          # Classify the outcome:
+          # 1. "Fixes for" lines after "All fixes:" → missing fixes found
+          # 2. "All fixes:" with no entries         → no missing fixes
+          # 3. No "All fixes:" marker              → patchscan crashed before finishing
+          if awk '
+            /^All fixes:/ { in_all_fixes = 1; next }
+            in_all_fixes && /^Fixes for / { found = 1; exit 0 }
+            END { exit found ? 0 : 1 }
+          ' patchscan_clean.txt; then
             echo "fixes_found=true" >> $GITHUB_OUTPUT
-          elif grep -qE "^E:" patchscan_clean.txt || [ $exit_code -ne 0 ]; then
-            echo "fixes_found=error" >> $GITHUB_OUTPUT
-          else
+          elif grep -q "^All fixes:" patchscan_clean.txt; then
             echo "fixes_found=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Post PR comment on patchscan error
-        if: steps.patchscan.outputs.fixes_found == 'error'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const output = fs.readFileSync('patchscan_clean.txt', 'utf8');
-            const MAX_LEN = 60000;
-            const truncated = output.length > MAX_LEN
-              ? output.slice(0, MAX_LEN) + '\n...(truncated)'
-              : output;
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: ${{ steps.pr.outputs.pr_number }},
-              per_page: 100,
-            });
-            const existing = comments.find(c =>
-              c.user.login === 'github-actions[bot]' &&
-              c.body.includes('Patchscan:')
-            );
-
-            const body = [
-              '## :x: Patchscan: Upstream Verification Error',
-              '',
-              'Patchscan could not fully verify one or more commits in this PR.',
-              'This is often a false positive caused by a SAUCE commit whose message',
-              'body references an upstream SHA but has a different title.',
-              'No `Fixes:` patches appear to be missing.',
-              '',
-              '````',
-              truncated.trim(),
-              '````',
-            ].join('\n');
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body: body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: ${{ steps.pr.outputs.pr_number }},
-                body: body,
-              });
-            }
-
-      - name: Post PR comment with missing fixes
-        if: steps.patchscan.outputs.fixes_found == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const output = fs.readFileSync('patchscan_clean.txt', 'utf8');
-
-            // Find existing patchscan comment to update instead of spamming
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: ${{ steps.pr.outputs.pr_number }},
-              per_page: 100,
-            });
-            const existing = comments.find(c =>
-              c.user.login === 'github-actions[bot]' &&
-              c.body.includes('Patchscan:')
-            );
-
-            // Sanitize output: escape fence sequences and truncate to stay under GitHub's comment limit
-            const MAX_LEN = 60000;
-            const safeOutput = output.replace(/`{3,}/g, '` ` `');
-            const truncated = safeOutput.length > MAX_LEN
-              ? safeOutput.slice(0, MAX_LEN) + '\n...(truncated)'
-              : safeOutput;
-
-            const body = [
-              '## :warning: Patchscan: Missing Fixes Detected',
-              '',
-              'The following upstream fix commits appear to be missing from this PR:',
-              '',
-              '````',
-              truncated.trim(),
-              '````',
-              '',
-              'Please review and consider including them.',
-            ].join('\n');
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body: body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: ${{ steps.pr.outputs.pr_number }},
-                body: body,
-              });
-            }
-
-      - name: Post all-clear comment
-        if: steps.patchscan.outputs.fixes_found == 'false'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: ${{ steps.pr.outputs.pr_number }},
-              per_page: 100,
-            });
-            const existing = comments.find(c =>
-              c.user.login === 'github-actions[bot]' &&
-              c.body.includes('Patchscan:')
-            );
-
-            const body = '## :white_check_mark: Patchscan: No Missing Fixes\n\nAll cherry-picked commits have been checked — no missing upstream fixes found.';
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body: body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: ${{ steps.pr.outputs.pr_number }},
-                body: body,
-              });
-            }
-
-      - name: Fail if missing fixes found or scan error
-        if: steps.patchscan.outputs.fixes_found == 'true' || steps.patchscan.outputs.fixes_found == 'error'
-        run: |
-          if [ "${{ steps.patchscan.outputs.fixes_found }}" = "error" ]; then
-            echo "::error::Patchscan upstream verification error — see PR comment for details."
           else
-            echo "::warning::Missing upstream fixes detected — see PR comment for details."
+            echo "fixes_found=error" >> $GITHUB_OUTPUT
           fi
+
+      - name: Run validate-pr
+        id: validate
+        run: |
+          base_sha="${{ steps.pr.outputs.base_sha }}"
+          head_sha="${{ steps.pr.outputs.head_sha }}"
+          merge_base="$(git merge-base "$base_sha" "$head_sha")"
+          range="${merge_base}..${head_sha}"
+
+          pr_title="$(cat pr_title.txt)"
+          base_ref="${{ steps.pr.outputs.base_ref }}"
+
+          set +e
+          set -o pipefail
+          python3 .github/scripts/validate-pr \
+            "$range" \
+            origin \
+            linux \
+            --no-update \
+            --pr-title "$pr_title" \
+            --pr-body pr_body.txt \
+            --base-branch "$base_ref" \
+            2>&1 | tee validate_output.txt
+          exit_code=${PIPESTATUS[0]}
+          set +o pipefail
+          set -e
+
+          sed 's/\x1B\[[0-9;]*[A-Za-z]//g; s/\x1B\]8;;[^\x1B]*\x1B\\//g; s/\x1B\]8;;[^\a]*\a//g' \
+            validate_output.txt > validate_clean.txt
+
+          if grep -qE "^E:" validate_clean.txt || [ $exit_code -ne 0 ]; then
+            echo "result=error" >> $GITHUB_OUTPUT
+          elif grep -qE "^W:" validate_clean.txt; then
+            echo "result=warn" >> $GITHUB_OUTPUT
+          else
+            echo "result=pass" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Post unified PR Validation Report comment
+        if: always() && steps.pr.outputs.pr_repo == github.repository
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const safeRead = (f) => fs.existsSync(f) ? fs.readFileSync(f, 'utf8') : '(no output captured)';
+            const truncateOutput = (raw) =>
+              raw.length > 30000 ? raw.slice(0, 30000) + '\n...(truncated)' : raw;
+            const escapeHtml = (s) =>
+              s
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;');
+            const renderDetails = (raw) => {
+              const escaped = escapeHtml(truncateOutput(raw).trim());
+              return '<details><summary>Details</summary>\n\n<pre>' + escaped + '</pre>\n\n</details>';
+            };
+
+            // --- Patchscan section ---
+            const psResult = '${{ steps.patchscan.outputs.fixes_found }}' || 'error';
+            let psIcon, psHeading, psBody;
+            if (psResult === 'false') {
+              psIcon = ':white_check_mark:';
+              psHeading = 'No Missing Fixes';
+              psBody = 'All cherry-picked commits checked — no missing upstream fixes found.';
+            } else if (psResult === 'true') {
+              psIcon = ':warning:';
+              psHeading = 'Missing Fixes Detected';
+              const raw = safeRead('patchscan_clean.txt');
+              psBody = 'The following upstream fix commits appear to be missing:\n\n' + renderDetails(raw);
+            } else {
+              psIcon = ':x:';
+              psHeading = 'Upstream Verification Error';
+              const raw = safeRead('patchscan_clean.txt');
+              psBody = 'Could not verify one or more commits (often a false positive for SAUCE commits).\n\n' + renderDetails(raw);
+            }
+
+            // --- validate-pr section ---
+            const valResult = '${{ steps.validate.outputs.result }}' || 'error';
+            let valIcon, valHeading, valBody;
+            if (valResult === 'pass') {
+              valIcon = ':white_check_mark:';
+              valHeading = 'All checks passed';
+              const raw = safeRead('validate_clean.txt');
+              valBody = renderDetails(raw);
+            } else if (valResult === 'warn') {
+              valIcon = ':warning:';
+              valHeading = 'Warnings';
+              const raw = safeRead('validate_clean.txt');
+              valBody = renderDetails(raw);
+            } else {
+              valIcon = ':x:';
+              valHeading = 'Errors found';
+              const raw = safeRead('validate_clean.txt');
+              valBody = renderDetails(raw);
+            }
+
+            const body = [
+              '## PR Validation Report',
+              '',
+              `### Patchscan ${psIcon} ${psHeading}`,
+              psBody,
+              '',
+              `### PR Lint ${valIcon} ${valHeading}`,
+              valBody,
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.pr.outputs.pr_number }},
+              per_page: 100,
+            });
+            const existing = comments.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes('PR Validation Report')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: ${{ steps.pr.outputs.pr_number }},
+                body,
+              });
+            }
+
+      - name: Fail on errors
+        if: |
+          steps.patchscan.outputs.fixes_found == 'true' ||
+          steps.patchscan.outputs.fixes_found == 'error' ||
+          steps.validate.outputs.result == 'error'
+        run: |
+          ps="${{ steps.patchscan.outputs.fixes_found }}"
+          val="${{ steps.validate.outputs.result }}"
+          [ "$ps"  = "error" ] && echo "::error::Patchscan upstream verification error — see PR comment."
+          [ "$ps"  = "true"  ] && echo "::warning::Missing upstream fixes — see PR comment."
+          [ "$val" = "error" ] && echo "::error::PR lint errors — see PR comment."
           exit 1


### PR DESCRIPTION
Add `.github/scripts/validate-pr`: a new Python script that checks commit hygiene and PR metadata alongside the existing `patchscan` script.

## Checks performed

- **Cherry-pick digest table**: for each `(cherry picked from commit <sha>)` trailer, compare patch-ID, subject, and SoB chain against upstream. Unresolvable SHAs are fetched directly by object ID before failing (handles intra-tree cherry-picks from unfetched branches).
- **R5** `E:` missing `Signed-off-by:` trailer
- **R6** `E:` non-SAUCE/non-Revert commit lacks upstream reference trailer
- **R7** `W:` LKML in-review backport uses wrong trailer form
- **R8** `E:` merge commit in PR range
- **R9** `W:` subject line >72 chars (exempt: SAUCE and Reverts of SAUCE)
- **R10** `W:` non-canonical SAUCE subject prefix
- **R1** `W:` PR title missing `[<branch>]` prefix
- **R3** `E:` PR targets a tracked branch but body has no `BugLink:` or `LP:` line

## Workflow changes (`patchscan.yml`)

- Add `26.04_linux-nvidia` and `26.04_linux-nvidia-bos` to `pull_request_target` branch list (was only `24.04_linux-nvidia-6.17-next`)
- Add optional `repo` input for cross-repo PR scanning via `workflow_dispatch`
- Move "Write PR title and body to files" step to after `actions/checkout` so files survive into later steps
- Add `validate-pr` invocation step
- Replace separate patchscan comment with a single unified **PR Validation Report** comment (always runs); uses `safeRead()` guard for missing output files
- Classify patchscan result by presence of empty `All fixes:` section rather than `E:` lines (avoids false failures on VR/intra-tree cherry-picks)
- Fail job when patchscan finds missing fixes or validate-pr emits `E:` findings

## Testing

Validated end-to-end on fork PR [nirmoy/NV-Kernels#11](https://github.com/nirmoy/NV-Kernels/pull/11) (replica of upstream PR #384). All checks pass — example output:

![PR Validation Report example](https://github.com/nirmoy/NV-Kernels/pull/11#issuecomment)

```
## PR Validation Report

### Patchscan ✅ No Missing Fixes
All cherry-picked commits checked — no missing upstream fixes found.

### PR Lint ✅ All checks passed
<details><summary>Details</summary>

Checking 17 commits...

Cherry-pick digest:
┌──────────────┬─────────────────────┬──────────┬─────────┬───────────────────────────┐
│ Local        │ Referenced upstream │ Patch-ID │ Subject │ SoB chain                 │
├──────────────┼─────────────────────┼──────────┼─────────┼───────────────────────────┤
│ 5e154c93f76c │ 86ff690f45cc        │ match    │ match   │ preserved + mochs added   │
...
└──────────────┴─────────────────────┴──────────┴─────────┴───────────────────────────┘

Lint: all checks passed.
```