### PR TITLE
[linux-nvidia-bos] Set LED_HW_PLUGGABLE for NPEM and fix class init ordering issue of CXL/fwctl

### DIFF
--- a/drivers/fwctl/main.c
+++ b/drivers/fwctl/main.c
@@ -415,7 +415,7 @@ static void __exit fwctl_exit(void)
 	unregister_chrdev_region(fwctl_dev, FWCTL_MAX_DEVICES);
 }
 
-module_init(fwctl_init);
+subsys_initcall(fwctl_init);
 module_exit(fwctl_exit);
 MODULE_DESCRIPTION("fwctl device firmware access framework");
 MODULE_LICENSE("GPL");

--- a/drivers/pci/npem.c
+++ b/drivers/pci/npem.c
@@ -504,7 +504,7 @@ static int pci_npem_set_led_classdev(struct npem *npem, struct npem_led *nled)
 	led->brightness_get = brightness_get;
 	led->max_brightness = 1;
 	led->default_trigger = "none";
-	led->flags = 0;
+	led->flags = LED_HW_PLUGGABLE;
 
 	ret = led_classdev_register(&npem->dev->dev, led);
 	if (ret)


### PR DESCRIPTION
## Description
This backport adds fixes for issue encountered when doing CXL device hotplug.
1. Set LED_HW_PLUGGABLE for NPEM - Add the flag `LED_HW_PLUGGABLE` since NPEM LEDs are on
hot-pluggable hardware by nature.
2. Fix class init ordering on CXL device removal - Use `subsys_initcall()` to correct the initialization ordering of CXL and fwctl subsystem.

---

## Source
Patch Breakdown (2 patches):
| # | Category | Count | Source |
|---|----------|-------|--------|
| 1 | Richard Cheng's PCI/NPEM: Set LED_HW_PLUGGABLE for hotplug-capable ports | 1 | LKML (v1,  merged and applied to v7.1 |
| 2 | Richard Cheng's fwctl: Fix class init ordering to avoid NULL pointer dereference on device removal | 1 | LKML (v1, merged and applied to v7.1 )|
---

## Lore Links:
* Richard Cheng's PCI/NPEM: Set LED_HW_PLUGGABLE for hotplug-capable ports (v1, applied to v7.1): https://lore.kernel.org/all/20260402093850.23075-1-icheng@nvidia.com/
* Richard Cheng's fwctl: Fix class init ordering to avoid NULL pointer dereference on device removal (v1, applied to v7.1): https://lore.kernel.org/all/20260409051902.40218-1-icheng@nvidia.com/

---

## Upstream Status
| Series | Status |
|-------|--------|
|Richard NPEM v1| Applied to v7.1 and merged |
|Richard fwctl v1| Applied to v7.1 and merged |

---
## Testing
### Build Validation:

- [x] Built successfully for ARM 64 4k page size kernel
- [x] Built successfully for ARM 64 64k page size kernel

### Config Verification:
CXL-related configs enabled as expected:
```
CONFIG_ACPI_APEI_EINJ_CXL=y
CONFIG_PCI_CXL=y
CONFIG_CXL_BUS=y
CONFIG_CXL_PCI=y
CONFIG_CXL_MEM_RAW_COMMANDS=y
CONFIG_CXL_ACPI=m
CONFIG_CXL_PMEM=m
CONFIG_CXL_MEM=y
CONFIG_CXL_FEATURES=y
# CONFIG_CXL_EDAC_MEM_FEATURES is not set
CONFIG_CXL_PORT=y
CONFIG_CXL_SUSPEND=y
CONFIG_CXL_REGION=y
# CONFIG_CXL_REGION_INVALIDATION_TEST is not set
CONFIG_CXL_RAS=y
# CONFIG_CACHEMAINT_FOR_HOTPLUG is not set
# CONFIG_SFC_CXL is not set
CONFIG_CXL_PMU=m
CONFIG_DEV_DAX=y
CONFIG_DEV_DAX_PMEM=m
CONFIG_DEV_DAX_HMEM=m
CONFIG_DEV_DAX_CXL=y
CONFIG_DEV_DAX_HMEM_DEVICES=y
CONFIG_DEV_DAX_KMEM=y
CONFIG_ARCH_HAS_CPU_CACHE_INVALIDATE_MEMREGION=y
CONFIG_GENERIC_CPU_CACHE_MAINTENANCE=y
```

fwctl config needs to be enabled ,too
```
CONFIG_FWCTL=y
```

### Runtime Testing:

- [x] Boot test on ARM64 system
- [x] CXL device enumeration test (ls /sys/bus/cxl/devices/)
- [x] CXL interleaving testing
- [x] CXL reset test (echo 1 > /sys/bus/pci/devices/<dev>/cxl_reset)
- [x] CXL hotplug test

---

## Notes
If you need a full CXL type 2-capable kernel, [Jiandi's backport](https://github.com/NVIDIA/NV-Kernels/pull/342) should be added as well.
Since these 2 patches are bug fixes and independent of them, we can backport them seperately.

<hr>

LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-6.17/+bug/2149918