### PR TITLE
[linux-nvidia-6.17] Use device ID range for DGX Spark iGPU

### DIFF
--- a/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c
+++ b/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c
@@ -3775,8 +3775,7 @@ static int arm_smmu_def_domain_type(struct device *dev)
 			return IOMMU_DOMAIN_IDENTITY;
 
 		if (pdev->vendor == PCI_VENDOR_ID_NVIDIA &&
-		    (pdev->device == 0x2E12 || pdev->device == 0x2E2A ||
-		     pdev->device == 0x2E2B))
+		    pdev->device >= 0x2E00 && pdev->device <= 0x2E3F)
 			return IOMMU_DOMAIN_DMA;
 	}
 


### PR DESCRIPTION
Replace the explicit DGX Spark iGPU device ID list with a range check covering 0x2E00-0x2E3F to accommodate all possible DGX Spark iGPU PCI device IDs without requiring individual additions.

<br>

LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-6.17/+bug/2150487