### PR TITLE
[for 26.04_linux-nvidia]: NVIDIA: SAUCE: iommu/arm-smmu-v3: Use identity domain for ASPEED BMC devices

### DIFF
--- a/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c
+++ b/drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c
@@ -3731,6 +3731,19 @@ static int arm_smmu_def_domain_type(struct device *dev)
 		if (IS_HISI_PTT_DEVICE(pdev))
 			return IOMMU_DOMAIN_IDENTITY;
 
+		/*
+		 * ASPEED BMC devices behind an AST1150 PCIe-to-PCI bridge
+		 * receive DMA from BMC firmware using host physical addresses
+		 * that bypass the kernel DMA API.  Use identity mapping so
+		 * the SMMU passes these transactions through untranslated.
+		 */
+		if (pdev->bus->self &&
+		    (pdev->bus->self->dev_flags &
+		     PCI_DEV_FLAGS_PCI_BRIDGE_NO_ALIAS) &&
+		    pdev->bus->self->vendor == PCI_VENDOR_ID_ASPEED &&
+		    pdev->bus->self->device == 0x1150)
+			return IOMMU_DOMAIN_IDENTITY;
+
 		if (pdev->vendor == PCI_VENDOR_ID_NVIDIA &&
 		    (pdev->device == 0x2E12 || pdev->device == 0x2E2A ||
 		     pdev->device == 0x2E2B))


### PR DESCRIPTION
Backport of #371 to `26.04_linux-nvidia` (kernel 7.0).

Companion to https://github.com/NVIDIA/NV-Kernels/pull/371 (`24.04_linux-nvidia-6.17-next`).
BugLink: 5918716

### Backport delta vs PR #371

Single rename in `drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.c`:

`PCI_DEV_FLAGS_PCI_BRIDGE_NO_ALIASES` → `PCI_DEV_FLAGS_PCI_BRIDGE_NO_ALIAS`

The flag was renamed between 6.17 and 7.0 (`include/linux/pci.h` declares
it as bit 14 in 7.0 vs bit 15 in 6.17). The AST1150 NO_ALIAS quirk
(`drivers/pci/quirks.c:quirk_aspeed_pci_bridge_no_alias`) is already
present on this branch, so the `dev_flags` check fires correctly.

### Sanity build

```
make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- defconfig
make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- drivers/iommu/arm/arm-smmu-v3/arm-smmu-v3.o
```

builds cleanly; `arm_smmu_def_domain_type` is present in the resulting
object.

### Verification carried over from PR #371

| Test                          | ASPEED F_TRANSLATION | USB    | VGA    |
|-------------------------------|----------------------|--------|--------|
| Without fix (passthrough=0)   | 8+ faults per boot   | Works  | Works  |
| `iommu.passthrough=1`         | Zero                 | Works  | Works  |
| With identity domain patch    | Zero                 | Works  | Works  |

Verified on Vera by Koba Ko and Carol Soto on 2026-04-15.

<hr>

LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia/+bug/2150470
