### PR TITLE
patchscan: re-run PR validation on PR body/title edits

### DIFF
--- a/.github/workflows/patchscan.yml
+++ b/.github/workflows/patchscan.yml
@@ -2,6 +2,7 @@ name: PR Validation
 
 on:
   pull_request_target:
+    types: [opened, synchronize, reopened, edited]
     branches:
       - 24.04_linux-nvidia-6.17-next
       - 26.04_linux-nvidia-bos


### PR DESCRIPTION
## Summary
- Add `edited` to the `pull_request_target` activity types for the PR Validation workflow.
- Without this, GitHub's default activity types are `opened`, `synchronize`, `reopened` only, so fixing a missing `BugLink:` in the PR body does not re-trigger the validation. Authors currently have to push a no-op commit or manually dispatch the workflow.
- With this change, editing the PR body or title is enough to re-run the validation.