### PR TITLE
NVIDIA: SAUCE: sched/deadline: Skip DL server initialization on nohz_full CPUs

### DIFF
--- a/kernel/sched/deadline.c
+++ b/kernel/sched/deadline.c
@@ -1620,6 +1620,9 @@ void sched_init_dl_servers(void)
 		u64 runtime =  50 * NSEC_PER_MSEC;
 		u64 period = 1000 * NSEC_PER_MSEC;
 
+		if (tick_nohz_full_cpu(cpu))
+			continue;
+
 		rq = cpu_rq(cpu);
 
 		guard(rq_lock_irq)(rq);


### PR DESCRIPTION
### [issue description]

The DL scheduler server (`fair_server`) is initialized on every online CPU with the default 50ms/1000ms bandwidth. On `nohz_full` isolated CPUs, its `dl_task_timer` hrtimer fires periodically and reactivates the scheduler tick before the IRQ-exit path can suppress it. The result is that isolated CPUs can run the scheduler tick at full HZ rate.

This regresses from v6.8, where the DL server did not exist and `nohz_full` CPUs had no matching spurious hrtimer activity.

### [how to reproduce]

Use the osnoise testing procedure:

```bash
echo 0-60 | sudo tee /sys/kernel/tracing/osnoise/cpus
echo 1000000 | sudo tee /sys/kernel/tracing/osnoise/period_us
echo 1000000 | sudo tee /sys/kernel/tracing/osnoise/runtime_us
echo 0 | sudo cat /sys/kernel/tracing/osnoise/stop_tracing_total_us
echo 0 | sudo cat /sys/kernel/tracing/osnoise/stop_tracing_us
#Run osnoise tracer for 30min, stop osnoise tracer, run cyclictest for 30min, stop cyclictest
echo osnoise | sudo tee /sys/kernel/tracing/current_tracer
sleep 10
sudo cp /sys/kernel/tracing/trace osnoise.txt
echo nop | sudo tee /sys/kernel/tracing/current_tracer
```

Observed before this fix:

```text
IRQ=~1000/s SIRQ=~30/s on isolated CPUs
```

Observed after this fix:

```text
IRQ=0 SIRQ=0 on isolated CPUs (100.00000% CPU availability)
```

The validation was repeated across 6 reboot cycles.

### [how to fix]

Skip DL server initialization for CPUs covered by `tick_nohz_full_cpu(cpu)`. These CPUs are isolated and do not need CFS bandwidth protection from the DL server.

Fixes: bd9bbc96e8356 ("sched: Rework dl_server")
