### PR TITLE
[26.04_linux-nvidia] UBUNTU: [Config] nvidia: Disable default CMA reservation

### DIFF
--- a/debian.nvidia/config/annotations
+++ b/debian.nvidia/config/annotations
@@ -39,8 +39,8 @@ CONFIG_ARM_FFA_TRANSPORT                        note<'LP: #2111511'>
 CONFIG_ARM_SMMU_V3_IOMMUFD                      policy<{'arm64': 'y'}>
 CONFIG_ARM_SMMU_V3_IOMMUFD                      note<'LP: #2095028'>
 
-CONFIG_CMA_SIZE_MBYTES                          policy<{'amd64': '0', 'arm64': '32', 'arm64-nvidia': '128', 'arm64-nvidia-64k': '1024'}>
-CONFIG_CMA_SIZE_MBYTES                          note<'LP: #2095028'>
+CONFIG_CMA_SIZE_MBYTES                          policy<{'amd64': '0', 'arm64': '0'}>
+CONFIG_CMA_SIZE_MBYTES                          note<'LP: #2150898'>
 
 CONFIG_CORESIGHT                                policy<{'arm64': 'm'}>
 CONFIG_CORESIGHT                                note<'Required for Grace enablement'>


### PR DESCRIPTION
## Summary

Set `CONFIG_CMA_SIZE_MBYTES=0` for arm64 linux-nvidia kernels.

This keeps CMA support compiled into the kernel, but stops reserving a default global CMA pool unless one is explicitly requested with the `cma=` kernel command-line option.

## Rationale

The arm64 linux-nvidia kernels previously reserved CMA by default to reduce noisy `cma_alloc()` failures seen during SMMUv3 initialization on large NVIDIA systems. After further testing, the default CMA pool does not appear to be required for the affected paths. The DMA/IOMMU allocation paths that try CMA also have fallback paths through the normal page allocator, and testing confirms that SMMUv3 queue allocation continues to succeed with `cma=0`.

Keeping the default CMA pool has become a liability on larger systems because the pool can still be exhausted, which produces misleading kernel log noise even though the allocation fallback succeeds. There is also no existing knob to keep a default CMA pool while suppressing the failed `cma_alloc()` messages.

Using `CONFIG_CMA_SIZE_MBYTES=0` also aligns the arm64 linux-nvidia default with amd64 behavior and with other enterprise arm64 distro kernels, including RHEL and SLES, which use `CONFIG_CMA_SIZE_MBYTES=0`.

Users that need a default CMA reservation can still opt in with the `cma=` kernel command-line parameter.

## Compatibility

The main user-visible change is that CMA-backed dma-heap nodes are not created by default when there is no default CMA area. For example, with CMA reserved the system exposes:

```text
/dev/dma_heap/default_cma_region
/dev/dma_heap/reserved
/dev/dma_heap/system
```

With `cma=0`, only the generic system heap remains:

```text
/dev/dma_heap/system
```

This is a compatibility consideration for userspace that explicitly opens the CMA-backed heap names. Generic dma-buf system heap users are unaffected.

## Validation

Tested with `cma=0` on linux-nvidia arm64 systems and guests, including 4K and 64K kernel combinations.

Observed behavior:

- kernel command line contains `cma=0`
- dmesg reports `0K cma-reserved`
- `/proc/meminfo` reports `CmaTotal: 0 kB` and `CmaFree: 0 kB`
- no `__cma_alloc` failures
- no DMA pool exhaustion or DMA out-of-memory messages
- SMMUv3 cmdq/evtq/priq allocation succeeds
- atomic DMA pool remains separately preallocated
- `/dev/dma_heap/system` remains present

DGX Spark testing also showed a clean boot with `cma=0`; the only observed dma-heap difference was the expected disappearance of the CMA-backed heap nodes.

<hr>

LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia/+bug/2150898