### PR TITLE
[24.04_linux-nvidia-6.17-next] Backport PCI/CXL: Hide SBR from reset_methods if masked by CXL

### DIFF
--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -5105,12 +5105,8 @@ static int pci_reset_bus_function(struct pci_dev *dev, bool probe)
 	 * If "dev" is below a CXL port that has SBR control masked, SBR
 	 * won't do anything, so return error.
 	 */
-	if (bridge && cxl_sbr_masked(bridge)) {
-		if (probe)
-			return 0;
-
+	if (bridge && pcie_is_cxl(bridge) && cxl_sbr_masked(bridge))
 		return -ENOTTY;
-	}
 
 	rc = pci_dev_reset_slot_function(dev, probe);
 	if (rc != -ENOTTY)


### PR DESCRIPTION
This upstream patch from v7.1 is needed for CXL support. When an endpoint is below a CXL-mode upstream bridge whose CXL Port Control "Unmask SBR" bit is clear, Secondary Bus Reset has no hardware effect. The old probe path still reported success, so sysfs advertised `bus` in `reset_method` even though selecting or falling back to that reset path would fail. Return `-ENOTTY` during probe for masked CXL SBR so `bus` is not advertised when the platform cannot perform it.

Patch: 702c1d56c717 PCI/CXL: Hide SBR from reset_methods if masked by CXL

 ## Testing

  Built and booted patched 6.17 kernel on `vr-nvl72-ts1-l10-comp016`:

  ```text
  Linux vr-nvl72-ts1-l10-comp016 6.17.13hide_sbr_cxl_617+ #1 SMP PREEMPT_DYNAMIC Tue May 26 14:10:52 UTC 2026 aarch64

  Validated PCI/CXL reset-method behavior with a scanner that checks each endpoint's immediate upstream bridge for:

  - CXL Port DVSEC present
  - CXL Flex Bus DVSEC status indicating CXL mode
  - CXL Port Control Unmask SBR clear
  - endpoint reset_method does not advertise bus

  Results:

  0002:81:00.0  sbr masked  cxl yes  has_bus no  PASS_BUS_HIDDEN
  0002:c1:00.0  sbr masked  cxl yes  has_bus no  PASS_BUS_HIDDEN
  000a:81:00.0  sbr masked  cxl yes  has_bus no  PASS_BUS_HIDDEN
  000a:e1:00.0  sbr masked  cxl yes  has_bus no  PASS_BUS_HIDDEN

  summary: cxl_related=28 masked_cxl_targets=4 failures=0

  Non-CXL-mode bridges continued to report NOT_CXL_MODE, so the behavior remains scoped to CXL-mode upstream bridges with SBR masked.
```

Thanks to Carol Soto for assisting with testing this patch!

<hr>

LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-bos/+bug/2154302