### PR TITLE
[24.04-linux-nvidia-6.17] MPAM: Please pull arm_mpam: Consider overflow in bandwidth counter state

### DIFF
--- a/drivers/resctrl/mpam_devices.c
+++ b/drivers/resctrl/mpam_devices.c
@@ -1382,17 +1382,8 @@ static void write_msmon_ctl_flt_vals(struct mon_read *m, u32 ctl_val,
 
 static u64 mpam_msmon_overflow_val(enum mpam_device_features type)
 {
-	/* TODO: implement scaling counters */
-	switch (type) {
-	case mpam_feat_msmon_mbwu_63counter:
-		return GENMASK_ULL(62, 0);
-	case mpam_feat_msmon_mbwu_44counter:
-		return GENMASK_ULL(43, 0);
-	case mpam_feat_msmon_mbwu_31counter:
-		return GENMASK_ULL(30, 0);
-	default:
-		return 0;
-	}
+	/* TODO: scaling, and long counters */
+	return BIT_ULL(hweight_long(MSMON___VALUE));
 }
 
 /* Call with MSC lock held */
@@ -1400,8 +1391,9 @@ static void __ris_msmon_read(void *arg)
 {
 	bool nrdy = false;
 	bool config_mismatch;
+	bool overflow = false;
 	struct mon_read *m = arg;
-	u64 now, overflow_val = 0;
+	u64 now;
 	struct mon_cfg *ctx = m->ctx;
 	bool reset_on_next_read = false;
 	struct mpam_msc_ris *ris = m->ris;
@@ -1431,13 +1423,20 @@ static void __ris_msmon_read(void *arg)
 	 * This saves waiting for 'nrdy' on subsequent reads.
 	 */
 	read_msmon_ctl_flt_vals(m, &cur_ctl, &cur_flt);
+	overflow = cur_ctl & MSMON_CFG_x_CTL_OFLOW_STATUS;
+
 	clean_msmon_ctl_val(&cur_ctl);
 	gen_msmon_ctl_flt_vals(m, &ctl_val, &flt_val);
 	config_mismatch = cur_flt != flt_val ||
 			  cur_ctl != (ctl_val | MSMON_CFG_x_CTL_EN);
 
-	if (config_mismatch || reset_on_next_read)
+	if (config_mismatch || reset_on_next_read) {
 		write_msmon_ctl_flt_vals(m, ctl_val, flt_val);
+		overflow = false;
+	} else if (overflow) {
+		mpam_write_monsel_reg(msc, CFG_MBWU_CTL,
+				      cur_ctl & ~MSMON_CFG_x_CTL_OFLOW_STATUS);
+	}
 
 	switch (m->type) {
 	case mpam_feat_msmon_csu:
@@ -1477,18 +1476,18 @@ static void __ris_msmon_read(void *arg)
 
 		mbwu_state = &ris->mbwu_state[ctx->mon];
 
-		/* Add any pre-overflow value to the mbwu_state->val */
-		if (mbwu_state->prev_val > now) {
-			overflow_val = mpam_msmon_overflow_val(m->type);
+		if (overflow) {
+			u64 overflow_val = mpam_msmon_overflow_val(m->type);
+
 			if (mpam_has_quirk(T241_MBW_COUNTER_SCALE_64, msc))
 				overflow_val *= 64;
-			overflow_val -= mbwu_state->prev_val;
+			mbwu_state->correction += overflow_val;
 		}
 
-		mbwu_state->prev_val = now;
-		mbwu_state->correction += overflow_val;
-
-		/* Include bandwidth consumed before the last hardware reset */
+		/*
+		 * Include bandwidth consumed before the last hardware reset and
+		 * a counter size increment for each overflow.
+		 */
 		now += mbwu_state->correction;
 		break;
 	default:

--- a/drivers/resctrl/mpam_devices.c
+++ b/drivers/resctrl/mpam_devices.c
@@ -1380,10 +1380,31 @@ static void write_msmon_ctl_flt_vals(struct mon_read *m, u32 ctl_val,
 	}
 }
 
-static u64 mpam_msmon_overflow_val(enum mpam_device_features type)
+static u64 __mpam_msmon_overflow_val(enum mpam_device_features type)
 {
-	/* TODO: scaling, and long counters */
-	return BIT_ULL(hweight_long(MSMON___VALUE));
+	/* TODO: implement scaling counters */
+	switch (type) {
+	case mpam_feat_msmon_mbwu_63counter:
+		return BIT_ULL(hweight_long(MSMON___LWD_VALUE));
+	case mpam_feat_msmon_mbwu_44counter:
+		return BIT_ULL(hweight_long(MSMON___L_VALUE));
+	case mpam_feat_msmon_mbwu_31counter:
+		return BIT_ULL(hweight_long(MSMON___VALUE));
+	default:
+		return 0;
+	}
+}
+
+static u64 mpam_msmon_overflow_val(enum mpam_device_features type,
+				   struct mpam_msc *msc)
+{
+	u64 overflow_val = __mpam_msmon_overflow_val(type);
+
+	if (mpam_has_quirk(T241_MBW_COUNTER_SCALE_64, msc) &&
+	    type != mpam_feat_msmon_mbwu_63counter)
+		overflow_val *= 64;
+
+	return overflow_val;
 }
 
 /* Call with MSC lock held */
@@ -1410,7 +1431,9 @@ static void __ris_msmon_read(void *arg)
 		  FIELD_PREP(MSMON_CFG_MON_SEL_RIS, ris->ris_idx);
 	mpam_write_monsel_reg(msc, CFG_MON_SEL, mon_sel);
 
-	if (m->type == mpam_feat_msmon_mbwu) {
+	if (m->type == mpam_feat_msmon_mbwu_31counter ||
+	    m->type == mpam_feat_msmon_mbwu_44counter ||
+	    m->type == mpam_feat_msmon_mbwu_63counter) {
 		mbwu_state = &ris->mbwu_state[ctx->mon];
 		if (mbwu_state) {
 			reset_on_next_read = mbwu_state->reset_on_next_read;
@@ -1423,7 +1446,12 @@ static void __ris_msmon_read(void *arg)
 	 * This saves waiting for 'nrdy' on subsequent reads.
 	 */
 	read_msmon_ctl_flt_vals(m, &cur_ctl, &cur_flt);
-	overflow = cur_ctl & MSMON_CFG_x_CTL_OFLOW_STATUS;
+
+	if (mpam_feat_msmon_mbwu_31counter == m->type)
+		overflow = cur_ctl & MSMON_CFG_x_CTL_OFLOW_STATUS;
+	else if (mpam_feat_msmon_mbwu_44counter == m->type ||
+		 mpam_feat_msmon_mbwu_63counter == m->type)
+		overflow = cur_ctl & MSMON_CFG_MBWU_CTL_OFLOW_STATUS_L;
 
 	clean_msmon_ctl_val(&cur_ctl);
 	gen_msmon_ctl_flt_vals(m, &ctl_val, &flt_val);
@@ -1435,7 +1463,9 @@ static void __ris_msmon_read(void *arg)
 		overflow = false;
 	} else if (overflow) {
 		mpam_write_monsel_reg(msc, CFG_MBWU_CTL,
-				      cur_ctl & ~MSMON_CFG_x_CTL_OFLOW_STATUS);
+				      cur_ctl &
+				      ~(MSMON_CFG_x_CTL_OFLOW_STATUS |
+					MSMON_CFG_MBWU_CTL_OFLOW_STATUS_L));
 	}
 
 	switch (m->type) {
@@ -1468,7 +1498,8 @@ static void __ris_msmon_read(void *arg)
 			now = FIELD_GET(MSMON___VALUE, now);
 		}
 
-		if (mpam_has_quirk(T241_MBW_COUNTER_SCALE_64, msc))
+		if (mpam_has_quirk(T241_MBW_COUNTER_SCALE_64, msc) &&
+		    m->type != mpam_feat_msmon_mbwu_63counter)
 			now *= 64;
 
 		if (nrdy)
@@ -1476,13 +1507,8 @@ static void __ris_msmon_read(void *arg)
 
 		mbwu_state = &ris->mbwu_state[ctx->mon];
 
-		if (overflow) {
-			u64 overflow_val = mpam_msmon_overflow_val(m->type);
-
-			if (mpam_has_quirk(T241_MBW_COUNTER_SCALE_64, msc))
-				overflow_val *= 64;
-			mbwu_state->correction += overflow_val;
-		}
+		if (overflow)
+			mbwu_state->correction += mpam_msmon_overflow_val(m->type, msc);
 
 		/*
 		 * Include bandwidth consumed before the last hardware reset and
@@ -1545,10 +1571,10 @@ static enum mpam_device_features mpam_msmon_choose_counter(struct mpam_class *cl
 {
 	struct mpam_props *cprops = &class->props;
 
-	if (mpam_has_feature(mpam_feat_msmon_mbwu_44counter, cprops))
-		return mpam_feat_msmon_mbwu_44counter;
 	if (mpam_has_feature(mpam_feat_msmon_mbwu_63counter, cprops))
 		return mpam_feat_msmon_mbwu_63counter;
+	if (mpam_has_feature(mpam_feat_msmon_mbwu_44counter, cprops))
+		return mpam_feat_msmon_mbwu_44counter;
 
 	return mpam_feat_msmon_mbwu_31counter;
 }

--- a/drivers/resctrl/mpam_internal.h
+++ b/drivers/resctrl/mpam_internal.h
@@ -327,7 +327,7 @@ struct msmon_mbwu_state {
 
 	/*
 	 * The value to add to the new reading to account for power management,
-	 * and shifts to trigger the overflow interrupt.
+	 * and overflow.
 	 */
 	u64		correction;
 


### PR DESCRIPTION
Backport this commit to fix a bug: https://nvbugspro.nvidia.com/bug/6207279

Since the commit is in 6.19 upstream already, 7.0 bos and lts don't have this issue. 

Use the overflow status bit to track overflow on each bandwidth counter read and add the counter size to the correction when overflow is detected.

This assumes that only a single overflow has occurred since the last read of the counter. Overflow interrupts, on hardware that supports them could be used to remove this limitation.

Cc: Zeng Heng <zengheng4@huawei.com>
Reviewed-by: Gavin Shan <gshan@redhat.com>
Reviewed-by: Zeng Heng <zengheng4@huawei.com>
Reviewed-by: Jonathan Cameron <jonathan.cameron@huawei.com>
Reviewed-by: Shaopeng Tan <tan.shaopeng@jp.fujitsu.com>
Reviewed-by: Fenghua Yu <fenghuay@nvidia.com>
Tested-by: Carl Worth <carl@os.amperecomputing.com>
Tested-by: Gavin Shan <gshan@redhat.com>
Tested-by: Zeng Heng <zengheng4@huawei.com>
Tested-by: Shaopeng Tan <tan.shaopeng@jp.fujitsu.com>
Tested-by: Hanjun Guo <guohanjun@huawei.com>


(backported from commit b35363793291e36c91d4a5b62d7ae7079c70d826)

[fenghuay: Fix mem bw monitoring counter overflow issue.
 - Resolve conflict in mpam_msmon_overflow_val();
 - Resolve conflict in __ris_msmon_read(); ]

<hr>

LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-6.17/+bug/2157912