### PR TITLE
update-and-rebase: Stop pushing rebases to -next branches

### DIFF
--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -3,8 +3,8 @@ name: Kernel Test
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'Branch to build'
+      build_ref:
+        description: 'Ref to build'
         required: true
         type: choice
         options:
@@ -13,8 +13,8 @@ on:
           - linux-nvidia-6.18
   workflow_call:
     inputs:
-      branch:
-        description: 'Branch to build'
+      build_ref:
+        description: 'Ref to build'
         required: true
         type: string
 
@@ -32,10 +32,10 @@ jobs:
           - runs-on: ubuntu-24.04-arm
             config: config_64k
     steps:
-      - name: Checkout kernel branch
+      - name: Checkout kernel ref
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.build_ref }}
           fetch-depth: 0
 
       - name: Fetch config files from github-actions branch

--- a/.github/workflows/update-and-rebase.yml
+++ b/.github/workflows/update-and-rebase.yml
@@ -60,9 +60,9 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     outputs:
-      branch-6-6: ${{ steps.mark-success.outputs.branch-6-6 }}
-      branch-6-12: ${{ steps.mark-success.outputs.branch-6-12 }}
-      branch-6-18: ${{ steps.mark-success.outputs.branch-6-18 }}
+      tag-6-6: ${{ steps.mark-success.outputs.tag-6-6 }}
+      tag-6-12: ${{ steps.mark-success.outputs.tag-6-12 }}
+      tag-6-18: ${{ steps.mark-success.outputs.tag-6-18 }}
     steps:
       - name: Check if already rebased to this tag
         id: check-tag
@@ -96,11 +96,6 @@ jobs:
           base=$(git merge-base HEAD ${{ matrix.tag }})
           echo "base=$base" >> $GITHUB_OUTPUT
 
-      - name: Create rebased branch
-        if: steps.check-tag.outputs.skip != 'true'
-        run: |
-          git checkout -B ${{ matrix.branch }}-next
-
       - name: Set git user identity
         if: steps.check-tag.outputs.skip != 'true'
         run: |
@@ -112,11 +107,6 @@ jobs:
         run: |
           git rebase --onto ${{ matrix.tag }} ${{ steps.merge_base.outputs.base }}
 
-      - name: Push rebased branch
-        if: steps.check-tag.outputs.skip != 'true'
-        run: |
-          git push --force origin HEAD:${{ matrix.branch }}-next
-
       - name: Create and push version tag
         if: steps.check-tag.outputs.skip != 'true'
         run: |
@@ -127,26 +117,26 @@ jobs:
         if: steps.check-tag.outputs.skip != 'true'
         id: mark-success
         run: |
-          key=$(echo "${{ matrix.branch }}" | sed 's/linux-nvidia-/branch-/' | tr '.' '-')
-          echo "${key}=${{ matrix.branch }}-next" >> $GITHUB_OUTPUT
+          key=$(echo "${{ matrix.branch }}" | sed 's/linux-nvidia-/tag-/' | tr '.' '-')
+          echo "${key}=${{ matrix.branch }}-${{ matrix.tag }}" >> $GITHUB_OUTPUT
 
   build-6-6:
     needs: [prepare, update-rebase-branch]
-    if: ${{ !cancelled() && needs.update-rebase-branch.outputs.branch-6-6 != '' }}
+    if: ${{ !cancelled() && needs.update-rebase-branch.outputs.tag-6-6 != '' }}
     uses: ./.github/workflows/kernel-build.yml
     with:
-      branch: ${{ needs.update-rebase-branch.outputs.branch-6-6 }}
+      build_ref: ${{ needs.update-rebase-branch.outputs.tag-6-6 }}
 
   build-6-12:
     needs: [prepare, update-rebase-branch]
-    if: ${{ !cancelled() && needs.update-rebase-branch.outputs.branch-6-12 != '' }}
+    if: ${{ !cancelled() && needs.update-rebase-branch.outputs.tag-6-12 != '' }}
     uses: ./.github/workflows/kernel-build.yml
     with:
-      branch: ${{ needs.update-rebase-branch.outputs.branch-6-12 }}
+      build_ref: ${{ needs.update-rebase-branch.outputs.tag-6-12 }}
 
   build-6-18:
     needs: [prepare, update-rebase-branch]
-    if: ${{ !cancelled() && needs.update-rebase-branch.outputs.branch-6-18 != '' }}
+    if: ${{ !cancelled() && needs.update-rebase-branch.outputs.tag-6-18 != '' }}
     uses: ./.github/workflows/kernel-build.yml
     with:
-      branch: ${{ needs.update-rebase-branch.outputs.branch-6-18 }}
+      build_ref: ${{ needs.update-rebase-branch.outputs.tag-6-18 }}


### PR DESCRIPTION
We intend to adopt a new workflow for the upstream stable branches whereby new patches are applied to the -next branches and promoted to the main branch following integration testing. This means we don't want the update-and-rebase workflow force-pushing rebases to this branch anymore. It turns out that this is really only a convenience, since the workflow also pushes a tag, so update the workflow to only push a tag and skip pushing to any branch.

This means that update-and-rebase is now passing a tag to kernel-build instead of a branch. This is fine; while the input parameter was named 'branch', it really works with any ref. Rename the 'branch' parameter to 'build_ref' for clarity.