### PR TITLE
[for 26.04_linux-nvidia-bos]: fs/ntfs3: fix mount failure on 64K page-size kernels

### DIFF
--- a/fs/ntfs3/fslog.c
+++ b/fs/ntfs3/fslog.c
@@ -1172,7 +1172,7 @@ static int read_log_page(struct ntfs_log *log, u32 vbo,
 		goto out;
 
 	if (page_buf->rhdr.sign != NTFS_FFFF_SIGNATURE)
-		ntfs_fix_post_read(&page_buf->rhdr, PAGE_SIZE, false);
+		ntfs_fix_post_read(&page_buf->rhdr, log->page_size, false);
 
 	if (page_buf != *buffer)
 		memcpy(*buffer, Add2Ptr(page_buf, page_off), bytes);
@@ -3786,11 +3786,7 @@ int log_replay(struct ntfs_inode *ni, bool *initialized)
 	log->l_size = log->orig_file_size = ni->vfs_inode.i_size;
 
 	/* Get the size of page. NOTE: To replay we can use default page. */
-#if PAGE_SIZE >= DefaultLogPageSize && PAGE_SIZE <= DefaultLogPageSize * 2
 	log->page_size = norm_file_page(PAGE_SIZE, &log->l_size, true);
-#else
-	log->page_size = norm_file_page(PAGE_SIZE, &log->l_size, false);
-#endif
 	if (!log->page_size) {
 		err = -EINVAL;
 		goto out;


### PR DESCRIPTION
## Summary

Backport linux-next commit `b7a9125cac8645245d2473c6c0a50e338280ad23`
to fix an `ntfs3` mount failure on 64K page-size kernels.

The original failure was reproduced by LTP `fsconfig01` using the new mount
API path:

- `fsopen("ntfs")`
- `fsconfig(FSCONFIG_CMD_CREATE)`
- kernel `ntfs3` driver

On 64K kernels, small NTFS volumes could fail with `EINVAL` because
`log_replay()` used `PAGE_SIZE` for the initial NTFS log page-size probe.
For a 64K kernel this inflated the minimum accepted `$LogFile` size from
about 200 KiB to about 3.2 MiB. A 300 MiB NTFS filesystem, such as the one
created by LTP `fsconfig01`, has a smaller log file and was rejected.

The fix makes the initial probe use the NTFS default log page size and makes
`read_log_page()` pass the actual log page size to `ntfs_fix_post_read()`.

## Backport Provenance

The patch cherry-picked cleanly from linux-next.

- Upstream commit: `b7a9125cac8645245d2473c6c0a50e338280ad23`
- `26.04_linux-nvidia-bos` commit: `1eeabccaa766806f47ca672795ba092204876904`

## Test Methodology

- Test execution: QEMU/KVM aarch64 guest
- Kernel under test: locally built target branch `Image`
- Filesystem module under test: matching locally built `ntfs3.ko`
- Test binary: LTP `fsconfig01` from LTP `20260130`
- Test mode: `LTP_SINGLE_FS_TYPE=ntfs`
- Test device: fresh 300 MiB virtio disk per run
- Guest page-size assertion:
  - 4K runs verified `PAGE_SIZE=4096`
  - 64K runs verified `PAGE_SIZE=65536`

## LTP Results

| Branch | Kernel | Page Size | LTP `fsconfig01` `ntfs` Result |
| --- | --- | ---: | --- |
| `26.04_linux-nvidia-bos` | `7.0.0-2008-nvidia-bos` | 4K | PASS: passed 1, failed 0, `LTP_EXIT=0` |
| `26.04_linux-nvidia-bos` | `7.0.0-2008-nvidia-bos-64k` | 64K | PASS: passed 1, failed 0, `LTP_EXIT=0` |

## Validation Summary

The reported 64K `ntfs3` failure is fixed on both target branches: LTP
`fsconfig01` now passes for `ntfs` with `PAGE_SIZE=65536`.

The same LTP `fsconfig01` `ntfs` test also passes on 4K kernels for both
target branches, so no regression was observed in the fixed `ntfs3` code path.

LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-7.0/+bug/2155467