### PR TITLE
[linux-nvidia-6.18-next] Cherry-pick detected missing patch from Vera

### DIFF
--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -5022,12 +5022,8 @@ static int pci_reset_bus_function(struct pci_dev *dev, bool probe)
 	 * If "dev" is below a CXL port that has SBR control masked, SBR
 	 * won't do anything, so return error.
 	 */
-	if (bridge && cxl_sbr_masked(bridge)) {
-		if (probe)
-			return 0;
-
+	if (bridge && pcie_is_cxl(bridge) && cxl_sbr_masked(bridge))
 		return -ENOTTY;
-	}
 
 	rc = pci_dev_reset_slot_function(dev, probe);
 	if (rc != -ENOTTY)


### PR DESCRIPTION
Only 1 patch listed for Vera is not currently applied to 6.18. All other patches, including SAUCE patches, are applied.

Unable to test this as I don't have access to a host with CXL. However the patch is already upstream and pretty simple.