### PR TITLE
[26.04-linux-nvidia] Backport: fuse: back uncached readdir buffers with pages

### DIFF
--- a/fs/fuse/readdir.c
+++ b/fs/fuse/readdir.c
@@ -12,6 +12,7 @@
 #include <linux/posix_acl.h>
 #include <linux/pagemap.h>
 #include <linux/highmem.h>
+#include <linux/vmalloc.h>
 
 static bool fuse_use_readdirplus(struct inode *dir, struct dir_context *ctx)
 {
@@ -331,6 +332,43 @@ static int parse_dirplusfile(char *buf, size_t nbytes, struct file *file,
 	return 0;
 }
 
+static struct page **fuse_readdir_alloc_buf(struct fuse_args_pages *ap, size_t *bufsize)
+{
+	unsigned int i, nr_alloc, nr_pages = DIV_ROUND_UP(*bufsize, PAGE_SIZE);
+	struct page **pages = kcalloc(nr_pages, sizeof(*pages), GFP_KERNEL);
+
+	if (!pages)
+		return NULL;
+
+	nr_alloc = alloc_pages_bulk(GFP_KERNEL, nr_pages, pages);
+	if (!nr_alloc)
+		goto free_array;
+
+	if (nr_alloc < nr_pages) {
+		nr_pages = nr_alloc;
+		*bufsize = (size_t) nr_pages << PAGE_SHIFT;
+	}
+
+	ap->folios = fuse_folios_alloc(nr_pages, GFP_KERNEL, &ap->descs);
+	if (!ap->folios)
+		goto release_pages;
+
+	for (i = 0; i < nr_pages; i++) {
+		ap->folios[i] = page_folio(pages[i]);
+		ap->descs[i].length = min_t(size_t, *bufsize - (size_t)i * PAGE_SIZE, PAGE_SIZE);
+	}
+	ap->num_folios = nr_pages;
+	ap->args.out_pages = true;
+
+	return pages;
+
+release_pages:
+	release_pages(pages, nr_pages);
+free_array:
+	kfree(pages);
+	return NULL;
+}
+
 static int fuse_readdir_uncached(struct file *file, struct dir_context *ctx)
 {
 	int plus;
@@ -339,17 +377,15 @@ static int fuse_readdir_uncached(struct file *file, struct dir_context *ctx)
 	struct fuse_mount *fm = get_fuse_mount(inode);
 	struct fuse_conn *fc = fm->fc;
 	struct fuse_io_args ia = {};
-	struct fuse_args *args = &ia.ap.args;
+	struct fuse_args_pages *ap = &ia.ap;
 	void *buf;
 	size_t bufsize = clamp((unsigned int) ctx->count, PAGE_SIZE, fc->max_pages << PAGE_SHIFT);
 	u64 attr_version = 0, evict_ctr = 0;
 	bool locked;
+	struct page **pages = fuse_readdir_alloc_buf(ap, &bufsize);
 
-	buf = kvmalloc(bufsize, GFP_KERNEL);
-	if (!buf)
+	if (!pages)
 		return -ENOMEM;
-
-	args->out_args[0].value = buf;
 
 	plus = fuse_use_readdirplus(inode, ctx);
 	if (plus) {
@@ -360,24 +396,37 @@ static int fuse_readdir_uncached(struct file *file, struct dir_context *ctx)
 		fuse_read_args_fill(&ia, file, ctx->pos, bufsize, FUSE_READDIR);
 	}
 	locked = fuse_lock_inode(inode);
-	res = fuse_simple_request(fm, args);
+	res = fuse_simple_request(fm, &ap->args);
 	fuse_unlock_inode(inode, locked);
-	if (res >= 0) {
-		if (!res) {
-			struct fuse_file *ff = file->private_data;
+	if (res < 0)
+		goto out;
 
-			if (ff->open_flags & FOPEN_CACHE_DIR)
-				fuse_readdir_cache_end(file, ctx->pos);
-		} else if (plus) {
-			res = parse_dirplusfile(buf, res, file, ctx, attr_version,
-						evict_ctr);
-		} else {
-			res = parse_dirfile(buf, res, file, ctx);
-		}
+	if (!res) {
+		struct fuse_file *ff = file->private_data;
+
+		if (ff->open_flags & FOPEN_CACHE_DIR)
+			fuse_readdir_cache_end(file, ctx->pos);
+		goto out;
 	}
 
-	kvfree(buf);
+	buf = vm_map_ram(pages, ap->num_folios, -1);
+	if (!buf) {
+		res = -ENOMEM;
+	} else {
+		if (plus)
+			res = parse_dirplusfile(buf, res, file, ctx, attr_version, evict_ctr);
+		else
+			res = parse_dirfile(buf, res, file, ctx);
+
+		vm_unmap_ram(buf, ap->num_folios);
+	}
+out:
+	kfree(ap->folios);
+	release_pages(pages, ap->num_folios);
+	kfree(pages);
+
 	fuse_invalidate_atime(inode);
+
 	return res;
 }
 


### PR DESCRIPTION
This updates FUSE uncached readdir to back the temporary output buffer with pages and set out_pages, instead of passing the buffer as a kvec output argument.

For virtiofs, kvec output arguments are copied through req->argbuf, which is allocated with kmalloc(..., GFP_ATOMIC). Large uncached readdir requests can therefore require a multi-megabyte contiguous atomic allocation before the request is queued. Using output pages lets transports such as virtiofs pass the buffer as scatter-gather entries instead.

The existing uncached readdir buffer sizing is unchanged. Pages are mapped with vm_map_ram() only while parsing returned dirents.

LKML:
[PATCH v4] fuse: back uncached readdir buffers with pages - https://lore.kernel.org/all/20260526152021.891412-1-mochs@nvidia.com/

linux-next:
2fcb1dd15fab fuse: back uncached readdir buffers with pages

Testing

Validated the original failing configuration:
```
4K host page size + 64K guest page size
virtme-ng with --overlay-rwdir /tmp
```
Command:
```
git log --oneline -1
getconf PAGE_SIZE
vng --run arch/arm64/boot/Image --memory 16G --cpus 4 --overlay-rwdir /tmp --exec 'uname -r; getconf PAGE_SIZE; ls /tmp; echo "ls rc=$?"; python3 -c "import os; print(len(os.listdir(\"/tmp\")))"'
```
Result:
```
nvidia@gb200-nvl4-47:~/mochs/nvbugs_6059208/NV-Kernels$ git log --oneline -1;getconf PAGE_SIZE;vng --run arch/arm64/boot/Image     --memory 16G --cpus 4 --overlay-rwdir /tmp     --exec 'uname -r; getconf PAGE_SIZE; ls /tmp; echo "ls rc=$?"; python3 -c "import os; print(len(os.listdir(\"/tmp\")))"'
3d12b88b9368 (HEAD -> nvb6059208_fuse_readdir_70lts, origin/nvb6059208_fuse_readdir_70lts) fuse: back uncached readdir buffers with pages
4096
7.0.0+
65536
hca_self_test_modprobe.output
mstflint_lockfiles
snap-private-tmp
systemd-private-0e36d3a03cea44e3bb3be4dcbee6cc15-ModemManager.service-1EqTRU
systemd-private-0e36d3a03cea44e3bb3be4dcbee6cc15-fwupd.service-1M1G3S
systemd-private-0e36d3a03cea44e3bb3be4dcbee6cc15-polkit.service-zWSn0u
systemd-private-0e36d3a03cea44e3bb3be4dcbee6cc15-systemd-logind.service-Nr99bX
systemd-private-0e36d3a03cea44e3bb3be4dcbee6cc15-systemd-resolved.service-vuJ3EG
systemd-private-0e36d3a03cea44e3bb3be4dcbee6cc15-systemd-timesyncd.service-7ttgTq
virtiofsd-wrapper.log
virtme_retfsc_lx68
virtmebbriomyd
virtmebbriomyd.pid
ls rc=0
18
```


This is the configuration that previously failed with Cannot allocate memory.

<hr>

LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia/+bug/2156632

NVbug: 6059208