### PR TITLE
[24.04_linux-nvidia-6.17-next] NVIDIA: VR: SAUCE: cxl: guard unlinked endpoints

### DIFF
--- a/drivers/cxl/core/hdm.c
+++ b/drivers/cxl/core/hdm.c
@@ -3,6 +3,7 @@
 #include <linux/seq_file.h>
 #include <linux/device.h>
 #include <linux/delay.h>
+#include <linux/err.h>
 #include <cxl/cxl.h>
 
 #include "cxlmem.h"
@@ -631,6 +632,9 @@ cxl_find_free_decoder(struct cxl_memdev *cxlmd)
 	struct cxl_port *endpoint = cxlmd->endpoint;
 	struct device *dev;
 
+	if (IS_ERR_OR_NULL(endpoint))
+		return NULL;
+
 	guard(rwsem_read)(&cxl_rwsem.dpa);
 	dev = device_find_child(&endpoint->dev, NULL,
 				find_free_decoder);
@@ -791,7 +795,7 @@ struct cxl_endpoint_decoder *cxl_get_committed_decoder(struct cxl_memdev *cxlmd,
 	struct cxl_endpoint_decoder *cxled;
 	struct device *cxled_dev;
 
-	if (!endpoint)
+	if (IS_ERR_OR_NULL(endpoint))
 		return NULL;
 
 	guard(rwsem_read)(&cxl_rwsem.dpa);

--- a/drivers/cxl/core/region.c
+++ b/drivers/cxl/core/region.c
@@ -4,6 +4,7 @@
 #include <linux/genalloc.h>
 #include <linux/debugfs.h>
 #include <linux/device.h>
+#include <linux/err.h>
 #include <linux/module.h>
 #include <linux/memory.h>
 #include <linux/slab.h>
@@ -860,7 +861,7 @@ struct cxl_root_decoder *cxl_get_hpa_freespace(struct cxl_memdev *cxlmd,
 	struct cxl_port *endpoint;
 
 	endpoint = cxlmd->endpoint;
-	if (!endpoint) {
+	if (IS_ERR_OR_NULL(endpoint)) {
 		dev_dbg(&cxlmd->dev, "endpoint not linked to memdev\n");
 		return ERR_PTR(-ENXIO);
 	}
@@ -3187,7 +3188,8 @@ struct cxl_region *cxl_dpa_to_region(const struct cxl_memdev *cxlmd, u64 dpa)
 		.dpa = dpa,
 	};
 	port = cxlmd->endpoint;
-	if (port && is_cxl_endpoint(port) && cxl_num_decoders_committed(port))
+	if (!IS_ERR_OR_NULL(port) && is_cxl_endpoint(port) &&
+	    cxl_num_decoders_committed(port))
 		device_for_each_child(&port->dev, &ctx, __cxl_dpa_to_region);
 
 	return ctx.cxlr;

--- a/drivers/cxl/pci.c
+++ b/drivers/cxl/pci.c
@@ -5,6 +5,7 @@
 #include <linux/moduleparam.h>
 #include <linux/module.h>
 #include <linux/delay.h>
+#include <linux/err.h>
 #include <linux/sizes.h>
 #include <linux/mutex.h>
 #include <linux/list.h>
@@ -1028,7 +1029,7 @@ static void cxl_reset_done(struct pci_dev *pdev)
 	 * that no longer exists.
 	 */
 	guard(device)(&cxlmd->dev);
-	if (cxlmd->endpoint &&
+	if (!IS_ERR_OR_NULL(cxlmd->endpoint) &&
 	    cxl_endpoint_decoder_reset_detected(cxlmd->endpoint)) {
 		dev_crit(dev, "SBR happened without memory regions removal.\n");
 		dev_crit(dev, "System may be unstable if regions hosted system memory.\n");


### PR DESCRIPTION
## Summary

Fix [NVBug 6274048](https://nvbugspro.nvidia.com/bug/6274048) for `24.04_linux-nvidia-6.17-next`.

Launchpad: https://bugs.launchpad.net/bugs/2143032

`cxlmd->endpoint` starts as `ERR_PTR(-ENXIO)` until endpoint port registration completes. Guard CXL helper paths with `IS_ERR_OR_NULL()` before dereferencing it.

## BOS note

I did not find evidence that this 6.17-next boot/probe NULL dereference has reproduced on BOS. BOS CXL Type-2/reset coverage is tracked separately:

- [PR #448](https://github.com/NVIDIA/NV-Kernels/pull/448), with BOS remote-branch commits [47dcd72db344a](https://github.com/NVIDIA/NV-Kernels/commit/47dcd72db344a) (`CONFIG_VFIO_CXL_CORE`) and [07fa68eb25751](https://github.com/NVIDIA/NV-Kernels/commit/07fa68eb25751) (`vfio_cxl_reset()`).
- [PR #440](https://github.com/NVIDIA/NV-Kernels/pull/440), with BOS remote-branch commit [5eaafc5097618](https://github.com/NVIDIA/NV-Kernels/commit/5eaafc5097618) (`PCI/CXL: Hide SBR from reset_methods if masked by CXL`).

Those SHAs are on `upstream/26.04_linux-nvidia-bos`. If the same early `cxlmd->endpoint` access is reproduced on BOS, backport this guard there too.

## Testing

- `git diff --check`
- `scripts/checkpatch.pl --strict --no-tree`: clean
- Focused CXL object build passed in a clean temp worktree with CXL options enabled; `CONFIG_WERROR` was disabled for an existing unrelated `enum cxl_regloc_type` warning.