### PR TITLE
[linux-nvidia-6.18]: Backport PCI/MSI: Enable memory decoding before restoring MSI-X messages

### DIFF
--- a/drivers/pci/msi/msi.c
+++ b/drivers/pci/msi/msi.c
@@ -862,6 +862,7 @@ void __pci_restore_msix_state(struct pci_dev *dev)
 {
 	struct msi_desc *entry;
 	bool write_msg;
+	u16 cmd;
 
 	if (!dev->msix_enabled)
 		return;
@@ -870,6 +871,8 @@ void __pci_restore_msix_state(struct pci_dev *dev)
 	pci_intx_for_msi(dev, 0);
 	pci_msix_clear_and_set_ctrl(dev, 0,
 				PCI_MSIX_FLAGS_ENABLE | PCI_MSIX_FLAGS_MASKALL);
+	pci_read_config_word(dev, PCI_COMMAND, &cmd);
+	pci_write_config_word(dev, PCI_COMMAND, cmd | PCI_COMMAND_MEMORY);
 
 	write_msg = arch_restore_msi_irqs(dev);
 
@@ -881,6 +884,7 @@ void __pci_restore_msix_state(struct pci_dev *dev)
 		}
 	}
 
+	pci_write_config_word(dev, PCI_COMMAND, cmd);
 	pci_msix_clear_and_set_ctrl(dev, PCI_MSIX_FLAGS_MASKALL, 0);
 }
 


### PR DESCRIPTION
During VFIO/FLR recovery, the saved PCI Command register state may have Memory Space disabled. Restoring MSI-X messages in that state can issue MMIO writes to the MSI-X table while memory decoding is off, causing Unsupported Request completions and DPC containment on the root port.

The patch enables `PCI_COMMAND_MEMORY` before MSI-X restore and restores the original Command register value afterward.

The patch is currently under review on LKML and is therefore taking as SAUCE: https://lore.kernel.org/all/c8abc1c8-71e0-443f-820f-182c0ff931e9@linux.ibm.com/

Note that the patch applied cleanly.

As of now, this issue only impacts VR systems as GB is currently configured to treat UR as ANF.

## Validation

  - Verified backport is patch-id identical to the referenced LKML v20 patch.
  - `scripts/checkpatch.pl --strict --git HEAD`
  - `git diff --check HEAD~1 HEAD`

<hr>

Nvbug: 6375598