### PR TITLE
validate-pr: accept context-only cherry-picks

### DIFF
--- a/.github/scripts/test_validate_pr.py
+++ b/.github/scripts/test_validate_pr.py
@@ -93,10 +93,96 @@ class ValidatePrPatchIdTest(unittest.TestCase):
                   input_text="{}\n\n{}\n".format(subject, body))
         return self._git("rev-parse", "HEAD")
 
-    def _patch_id(self, commit):
-        patch = self._git("show", commit)
+    def _patch_id(self, commit, zero_context=False):
+        show_args = ["show"]
+        if zero_context:
+            show_args.extend([
+                "--format=", "--no-color", "--no-ext-diff", "--no-textconv",
+                "--full-index", "--binary", "--unified=0",
+            ])
+        patch = self._git(*show_args, commit)
         output = self._git("patch-id", "--stable", input_text=patch)
         return output.split()[0]
+
+    def _merge_tree_conflicts(self, parent, local, upstream):
+        result = subprocess.run(
+            [
+                "git", "merge-tree", "--write-tree",
+                "--merge-base={}^".format(upstream),
+                parent, upstream,
+            ],
+            cwd=self.repo,
+            text=True,
+            capture_output=True,
+        )
+        return result.returncode != 0 and len(result.stdout.splitlines()) > 1
+
+    def _build_adjacent_conflict_case(self, placement="matching"):
+        """Same +/- edit with divergent neighbors so merge-tree conflicts.
+
+        Upstream inserts X after C. Local replaces C with C1/C2, then inserts X
+        either before D (matching unique right anchor) or after A (wrong
+        placement).
+        """
+        self._write_fixture(["A", "B", "C", "D"])
+        self.base = self._commit("fixture: conflict base", LOCAL_SOB)
+
+        self._git("checkout", "-b", "upstream-topic", self.base)
+        self._set_identity("Upstream Author", "upstream@example.com")
+        self._write_fixture(["A", "B", "C", "X", "D"])
+        upstream = self._commit(SUBJECT, UPSTREAM_SOB)
+        self._git("update-ref", "refs/remotes/upstream/linux", upstream)
+
+        self._git("checkout", "-b", "local", self.base)
+        self._set_identity("Local Author", "local@example.com")
+        self._write_fixture(["A", "B", "C1", "C2", "D"])
+        self._commit("fixture: diverge adjacent neighbors", LOCAL_SOB)
+        parent = self._git("rev-parse", "HEAD")
+
+        if placement == "matching":
+            self._write_fixture(["A", "B", "C1", "C2", "X", "D"])
+        elif placement == "wrong":
+            self._write_fixture(["A", "X", "B", "C1", "C2", "D"])
+        else:
+            self.fail("unknown placement: {}".format(placement))
+        self._commit(
+            SUBJECT,
+            "{}\n\n(cherry picked from commit {})\n{}".format(
+                UPSTREAM_SOB, upstream, LOCAL_SOB))
+        local = self._git("rev-parse", "HEAD")
+        return parent, local, upstream
+
+    def _build_duplicate_context_conflict_case(self):
+        """Same +/- edit under repeated context that misleads LCS alignment.
+
+        Upstream parent [A,B,C,D,S,A,B,C,D] inserts X before the first D.
+        Local parent [A1,B1,C1,D1,T,A,B,C,L,D] inserts X before the remaining D.
+        Standard patch IDs differ, zero-context IDs match, and merge-tree
+        conflicts. Ambiguous C/D anchors must reject.
+        """
+        self._write_fixture(["A", "B", "C", "D", "S", "A", "B", "C", "D"])
+        self.base = self._commit("fixture: duplicate conflict base", LOCAL_SOB)
+
+        self._git("checkout", "-b", "upstream-topic", self.base)
+        self._set_identity("Upstream Author", "upstream@example.com")
+        self._write_fixture(["A", "B", "C", "X", "D", "S", "A", "B", "C", "D"])
+        upstream = self._commit(SUBJECT, UPSTREAM_SOB)
+        self._git("update-ref", "refs/remotes/upstream/linux", upstream)
+
+        self._git("checkout", "-b", "local", self.base)
+        self._set_identity("Local Author", "local@example.com")
+        self._write_fixture(["A1", "B1", "C1", "D1", "T", "A", "B", "C", "L", "D"])
+        self._commit("fixture: diverge duplicate context", LOCAL_SOB)
+        parent = self._git("rev-parse", "HEAD")
+
+        self._write_fixture(
+            ["A1", "B1", "C1", "D1", "T", "A", "B", "C", "L", "X", "D"])
+        self._commit(
+            SUBJECT,
+            "{}\n\n(cherry picked from commit {})\n{}".format(
+                UPSTREAM_SOB, upstream, LOCAL_SOB))
+        local = self._git("rev-parse", "HEAD")
+        return parent, local, upstream
 
     def _build_case(self, change, context_parent=True):
         self._git("checkout", "-b", "upstream-topic", self.base)
@@ -175,6 +261,12 @@ if (mode == "rev-parse-invalid-utf8" and
 
 if mode == "merge-tree-failure" and args and args[0] == "merge-tree":
     sys.stderr.write("synthetic merge-tree failure\\n")
+    sys.exit(2)
+
+if mode == "merge-tree-conflict-exit-2" and args and args[0] == "merge-tree":
+    result = subprocess.run([real_git, *args], capture_output=True)
+    sys.stdout.buffer.write(result.stdout)
+    sys.stderr.buffer.write(result.stderr)
     sys.exit(2)
 
 if mode == "merge-tree-extra-line" and args and args[0] == "merge-tree":
@@ -320,6 +412,68 @@ os.execv(real_git, [real_git, *args])
         result = self._validate(parent, local)
 
         self.assertEqual(result.returncode, 1, self._output(result))
+        self.assertIn("patch-ID mismatch with upstream", result.stdout)
+
+    def test_accepts_context_conflict_with_adjacent_baseline(self):
+        parent, local, upstream = self._build_adjacent_conflict_case("matching")
+
+        self.assertNotEqual(self._patch_id(local), self._patch_id(upstream))
+        self.assertEqual(
+            self._patch_id(local, zero_context=True),
+            self._patch_id(upstream, zero_context=True))
+        self.assertTrue(self._merge_tree_conflicts(parent, local, upstream))
+
+        result = self._validate(parent, local)
+
+        self.assertEqual(result.returncode, 0, self._output(result))
+        self.assertEqual(self._patch_id_status(result, local), "context")
+
+    def test_rejects_wrong_placement_when_merge_tree_conflicts(self):
+        parent, local, upstream = self._build_adjacent_conflict_case("wrong")
+
+        self.assertNotEqual(self._patch_id(local), self._patch_id(upstream))
+        self.assertEqual(
+            self._patch_id(local, zero_context=True),
+            self._patch_id(upstream, zero_context=True))
+        self.assertTrue(self._merge_tree_conflicts(parent, local, upstream))
+
+        result = self._validate(parent, local)
+
+        self.assertEqual(result.returncode, 1, self._output(result))
+        self.assertIn("patch-ID mismatch with upstream", result.stdout)
+
+    def test_rejects_duplicate_context_conflict_misaligned_placement(self):
+        parent, local, upstream = self._build_duplicate_context_conflict_case()
+
+        self.assertNotEqual(self._patch_id(local), self._patch_id(upstream))
+        self.assertEqual(
+            self._patch_id(local, zero_context=True),
+            self._patch_id(upstream, zero_context=True))
+        self.assertTrue(self._merge_tree_conflicts(parent, local, upstream))
+
+        result = self._validate(parent, local)
+
+        self.assertEqual(result.returncode, 1, self._output(result))
+        self.assertIn("patch-ID mismatch with upstream", result.stdout)
+
+    def test_rejects_merge_tree_tool_error_without_transplant_bypass(self):
+        parent, local, _upstream = self._build_adjacent_conflict_case(
+            "matching")
+
+        result = self._validate(parent, local, "merge-tree-failure")
+
+        self.assertEqual(result.returncode, 1, self._output(result))
+        self.assertIn("synthetic merge-tree failure", result.stderr)
+        self.assertIn("patch-ID mismatch with upstream", result.stdout)
+
+    def test_rejects_conflict_output_with_non_conflict_exit_code(self):
+        parent, local, _upstream = self._build_adjacent_conflict_case(
+            "matching")
+
+        result = self._validate(parent, local, "merge-tree-conflict-exit-2")
+
+        self.assertEqual(result.returncode, 1, self._output(result))
+        self.assertIn("git merge-tree exited 2", result.stderr)
         self.assertIn("patch-ID mismatch with upstream", result.stdout)
 
 

--- a/.github/scripts/test_validate_pr.py
+++ b/.github/scripts/test_validate_pr.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Black-box regression tests for validate-pr cherry-pick matching."""
+
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+VALIDATE_PR = pathlib.Path(__file__).with_name("validate-pr")
+SUBJECT = "fixture: insert payload"
+UPSTREAM_SOB = "Signed-off-by: Upstream Author <upstream@example.com>"
+LOCAL_SOB = "Signed-off-by: Local Author <local@example.com>"
+
+
+class ValidatePrPatchIdTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.repo = pathlib.Path(self._tmp.name) / "repo"
+        self.repo.mkdir()
+        self.real_git = shutil.which("git")
+        self.assertIsNotNone(self.real_git)
+
+        self._git("init")
+        self._set_identity("Fixture Author", "fixture@example.com")
+        self._write_fixture([
+            "first-before",
+            "anchor",
+            "first-after",
+            "spacer-1",
+            "spacer-2",
+            "spacer-3",
+            "spacer-4",
+            "second-before",
+            "anchor",
+            "second-after",
+        ])
+        self.base = self._commit("fixture: base", LOCAL_SOB)
+
+    def _relocate_repo(self, name):
+        relocated = self.repo.parent / name
+        self.repo.rename(relocated)
+        self.repo = relocated
+
+    def _git(self, *args, input_text=None):
+        result = subprocess.run(
+            ["git", *args],
+            cwd=self.repo,
+            input=input_text,
+            text=True,
+            capture_output=True,
+        )
+        if result.returncode:
+            self.fail(
+                "git {} failed ({}):\n{}{}".format(
+                    " ".join(args), result.returncode,
+                    result.stdout, result.stderr))
+        return result.stdout.strip()
+
+    def _set_identity(self, name, email):
+        self._git("config", "user.name", name)
+        self._git("config", "user.email", email)
+
+    def _write_fixture(self, lines):
+        (self.repo / "fixture.txt").write_text("\n".join(lines) + "\n")
+
+    def _read_fixture(self):
+        return (self.repo / "fixture.txt").read_text().splitlines()
+
+    def _use_identical_occurrence_fixture(self):
+        block = [
+            "same-before-4",
+            "same-before-3",
+            "same-before-2",
+            "same-before-1",
+            "anchor",
+            "same-after-1",
+            "same-after-2",
+            "same-after-3",
+            "same-after-4",
+        ]
+        separator = ["separator-{}".format(i) for i in range(1, 8)]
+        self._write_fixture(["prefix", *block, *separator, *block, "suffix"])
+        self.base = self._commit("fixture: duplicate context", LOCAL_SOB)
+
+    def _commit(self, subject, body):
+        self._git("add", "fixture.txt")
+        self._git("commit", "-F", "-",
+                  input_text="{}\n\n{}\n".format(subject, body))
+        return self._git("rev-parse", "HEAD")
+
+    def _patch_id(self, commit):
+        patch = self._git("show", commit)
+        output = self._git("patch-id", "--stable", input_text=patch)
+        return output.split()[0]
+
+    def _build_case(self, change, context_parent=True):
+        self._git("checkout", "-b", "upstream-topic", self.base)
+        self._set_identity("Upstream Author", "upstream@example.com")
+        lines = self._read_fixture()
+        lines.insert(lines.index("anchor") + 1, "payload")
+        self._write_fixture(lines)
+        upstream = self._commit(SUBJECT, UPSTREAM_SOB)
+        self._git("update-ref", "refs/remotes/upstream/linux", upstream)
+
+        self._git("checkout", "-b", "local", self.base)
+        self._set_identity("Local Author", "local@example.com")
+        if context_parent:
+            lines = self._read_fixture()
+            lines[0] = "local-first-before"
+            self._write_fixture(lines)
+            self._commit("fixture: adjust local context", LOCAL_SOB)
+        parent = self._git("rev-parse", "HEAD")
+
+        if change == "exact":
+            self._git("cherry-pick", "-x", "--signoff", upstream)
+        else:
+            lines = self._read_fixture()
+            anchors = [i for i, line in enumerate(lines) if line == "anchor"]
+            if change == "context":
+                lines.insert(anchors[0] + 1, "payload")
+            elif change == "mutated":
+                lines.insert(anchors[0] + 1, "payload-mutated")
+            elif change == "wrong-occurrence":
+                lines.insert(anchors[1] + 1, "payload")
+            else:
+                self.fail("unknown fixture change: {}".format(change))
+            self._write_fixture(lines)
+            self._commit(
+                SUBJECT,
+                "{}\n\n(cherry picked from commit {})\n{}".format(
+                    UPSTREAM_SOB, upstream, LOCAL_SOB))
+
+        local = self._git("rev-parse", "HEAD")
+        return parent, local
+
+    def _fake_git_env(self, mode):
+        fake_bin = self.repo / "fake-bin"
+        fake_bin.mkdir(exist_ok=True)
+        wrapper = fake_bin / "git"
+        wrapper.write_text("""#!/usr/bin/env python3
+import os
+import subprocess
+import sys
+
+real_git = os.environ["VALIDATE_PR_REAL_GIT"]
+mode = os.environ["VALIDATE_PR_FAKE_GIT_MODE"]
+args = sys.argv[1:]
+
+if mode == "show-failure" and args and args[0] == "show":
+    result = subprocess.run([real_git, *args], capture_output=True)
+    sys.stdout.buffer.write(result.stdout)
+    sys.stderr.buffer.write(result.stderr)
+    sys.exit(1)
+
+if (args[:2] == ["patch-id", "--stable"] and
+        mode in ("patch-id-malformed", "patch-id-extra-line")):
+    sys.stdin.buffer.read()
+    if mode == "patch-id-malformed":
+        sys.stdout.write("not-a-patch-id not-a-commit-id\\n")
+        sys.exit(0)
+    if mode == "patch-id-extra-line":
+        sys.stdout.write("{} {}\\n{} {}\\n".format(
+            "a" * 40, "b" * 40, "c" * 40, "d" * 40))
+        sys.exit(0)
+
+if (mode == "rev-parse-invalid-utf8" and
+        args[:3] == ["rev-parse", "--git-path", "objects"]):
+    sys.stdout.buffer.write(b"\\xff\\n")
+    sys.exit(0)
+
+if mode == "merge-tree-failure" and args and args[0] == "merge-tree":
+    sys.stderr.write("synthetic merge-tree failure\\n")
+    sys.exit(2)
+
+if mode == "merge-tree-extra-line" and args and args[0] == "merge-tree":
+    result = subprocess.run([real_git, *args], capture_output=True)
+    sys.stdout.buffer.write(result.stdout)
+    if result.stdout and not result.stdout.endswith(b"\\n"):
+        sys.stdout.buffer.write(b"\\n")
+    sys.stdout.buffer.write(b"unexpected-extra-line\\n")
+    sys.stderr.buffer.write(result.stderr)
+    sys.exit(result.returncode)
+
+os.execv(real_git, [real_git, *args])
+""")
+        wrapper.chmod(0o755)
+        env = os.environ.copy()
+        env["PATH"] = str(fake_bin) + os.pathsep + env.get("PATH", "")
+        env["VALIDATE_PR_REAL_GIT"] = self.real_git
+        env["VALIDATE_PR_FAKE_GIT_MODE"] = mode
+        return env
+
+    def _validate(self, parent, local, git_mode=None):
+        return subprocess.run(
+            [sys.executable, str(VALIDATE_PR),
+             "{}..{}".format(parent, local), "upstream", "linux",
+             "--no-update"],
+            cwd=self.repo,
+            env=self._fake_git_env(git_mode) if git_mode else None,
+            text=True,
+            capture_output=True,
+        )
+
+    @staticmethod
+    def _output(result):
+        return "stdout:\n{}\nstderr:\n{}".format(
+            result.stdout, result.stderr)
+
+    def _patch_id_status(self, result, local):
+        marker = "│ {} │".format(local[:12])
+        for line in result.stdout.splitlines():
+            if marker in line:
+                cells = line.split("│")
+                self.assertGreaterEqual(len(cells), 6, self._output(result))
+                return cells[3].strip()
+        self.fail("no digest row for {}:\n{}".format(
+            local[:12], self._output(result)))
+
+    def test_accepts_context_only_replay(self):
+        parent, local = self._build_case("context")
+
+        result = self._validate(parent, local)
+
+        self.assertEqual(result.returncode, 0, self._output(result))
+        self.assertEqual(self._patch_id_status(result, local), "context")
+
+    def test_accepts_context_only_replay_with_colon_in_object_path(self):
+        self._relocate_repo("repo:colon")
+        parent, local = self._build_case("context")
+
+        result = self._validate(parent, local)
+
+        self.assertEqual(result.returncode, 0, self._output(result))
+        self.assertEqual(self._patch_id_status(result, local), "context")
+
+    def test_accepts_exact_cherry_pick(self):
+        parent, local = self._build_case("exact", context_parent=False)
+
+        result = self._validate(parent, local)
+
+        self.assertEqual(result.returncode, 0, self._output(result))
+        self.assertEqual(self._patch_id_status(result, local), "match")
+
+    def test_rejects_git_show_failure_with_patch_output(self):
+        parent, local = self._build_case("exact", context_parent=False)
+
+        result = self._validate(parent, local, "show-failure")
+
+        self.assertEqual(result.returncode, 1, self._output(result))
+        self.assertIn("patch-ID mismatch with upstream", result.stdout)
+
+    def test_rejects_malformed_patch_id_output(self):
+        parent, local = self._build_case("exact", context_parent=False)
+
+        result = self._validate(parent, local, "patch-id-malformed")
+
+        self.assertEqual(result.returncode, 1, self._output(result))
+        self.assertIn("patch-ID mismatch with upstream", result.stdout)
+
+    def test_rejects_merge_tree_output_with_extra_line(self):
+        parent, local = self._build_case("context")
+
+        result = self._validate(parent, local, "merge-tree-extra-line")
+
+        self.assertEqual(result.returncode, 1, self._output(result))
+        self.assertIn("patch-ID mismatch with upstream", result.stdout)
+
+    def test_reports_replay_environment_failure(self):
+        parent, local = self._build_case("exact", context_parent=False)
+
+        result = self._validate(parent, local, "rev-parse-invalid-utf8")
+
+        self.assertEqual(result.returncode, 1, self._output(result))
+        self.assertIn("unable to verify patch replay", result.stderr)
+
+    def test_reports_merge_tree_failure(self):
+        parent, local = self._build_case("exact", context_parent=False)
+
+        result = self._validate(parent, local, "merge-tree-failure")
+
+        self.assertEqual(result.returncode, 1, self._output(result))
+        self.assertIn("synthetic merge-tree failure", result.stderr)
+
+    def test_rejects_multiple_patch_id_output_lines(self):
+        parent, local = self._build_case("exact", context_parent=False)
+
+        result = self._validate(parent, local, "patch-id-extra-line")
+
+        self.assertEqual(result.returncode, 1, self._output(result))
+        self.assertIn("patch-ID mismatch with upstream", result.stdout)
+
+    def test_rejects_mutated_payload(self):
+        parent, local = self._build_case("mutated")
+
+        result = self._validate(parent, local)
+
+        self.assertEqual(result.returncode, 1, self._output(result))
+        self.assertIn("patch-ID mismatch with upstream", result.stdout)
+
+    def test_rejects_same_change_at_different_occurrence(self):
+        parent, local = self._build_case("wrong-occurrence")
+
+        result = self._validate(parent, local)
+
+        self.assertEqual(result.returncode, 1, self._output(result))
+        self.assertIn("patch-ID mismatch with upstream", result.stdout)
+
+    def test_rejects_equal_patch_id_at_different_occurrence(self):
+        self._use_identical_occurrence_fixture()
+        parent, local = self._build_case(
+            "wrong-occurrence", context_parent=False)
+        upstream = self._git("rev-parse", "refs/remotes/upstream/linux")
+
+        self.assertEqual(self._patch_id(local), self._patch_id(upstream))
+        result = self._validate(parent, local)
+
+        self.assertEqual(result.returncode, 1, self._output(result))
+        self.assertIn("patch-ID mismatch with upstream", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/validate-pr
+++ b/.github/scripts/validate-pr
@@ -130,24 +130,114 @@ def describe_added_sob_order(message, added):
     return None
 
 
-def get_patch_id(commit):
+def get_patch_id(commit, zero_context=False):
     """Return the stable patch-ID string for a commit, or None on failure."""
-    show = subprocess.run(
-        ['git', 'show', commit.hexsha],
-        capture_output=True,
-        cwd=commit.repo.working_dir,
+    show_args = ['git', 'show']
+    if zero_context:
+        show_args.extend([
+            '--format=', '--no-color', '--no-ext-diff', '--no-textconv',
+            '--full-index', '--binary', '--unified=0',
+        ])
+    show_args.append(commit.hexsha)
+    try:
+        show = subprocess.run(
+            show_args,
+            capture_output=True,
+            cwd=commit.repo.working_dir,
+        )
+        if show.returncode != 0:
+            return None
+        pid = subprocess.run(
+            ['git', 'patch-id', '--stable'],
+            input=show.stdout,
+            capture_output=True,
+            cwd=commit.repo.working_dir,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    if pid.returncode != 0:
+        return None
+    match = re.fullmatch(
+        br'(?:(?P<sha1>[0-9a-f]{40}) [0-9a-f]{40}|'
+        br'(?P<sha256>[0-9a-f]{64}) [0-9a-f]{64})\n?',
+        pid.stdout,
     )
-    pid = subprocess.run(
-        ['git', 'patch-id', '--stable'],
-        input=show.stdout,
-        capture_output=True,
-        cwd=commit.repo.working_dir,
-    )
-    if pid.returncode == 0 and pid.stdout:
-        parts = pid.stdout.decode().strip().split()
-        if parts:
-            return parts[0]
-    return None
+    if match is None:
+        return None
+    return (match.group('sha1') or match.group('sha256')).decode('ascii')
+
+
+def is_equivalent_replay(local_commit, upstream_commit,
+                         local_patch_id, upstream_patch_id):
+    """Return whether the upstream change replays to the exact local tree."""
+    if not local_patch_id or not upstream_patch_id:
+        return False
+
+    try:
+        if local_patch_id != upstream_patch_id:
+            local_zero = get_patch_id(local_commit, zero_context=True)
+            upstream_zero = get_patch_id(upstream_commit, zero_context=True)
+            if not local_zero or local_zero != upstream_zero:
+                return False
+
+        if len(local_commit.parents) != 1 or len(upstream_commit.parents) != 1:
+            return False
+
+        object_path = subprocess.run(
+            ['git', 'rev-parse', '--git-path', 'objects'],
+            capture_output=True,
+            cwd=local_commit.repo.working_dir,
+            text=True,
+        )
+        if object_path.returncode != 0 or not object_path.stdout.strip():
+            return False
+        object_dir = object_path.stdout.strip()
+        if not os.path.isabs(object_dir):
+            object_dir = os.path.abspath(os.path.join(
+                local_commit.repo.working_dir, object_dir))
+
+        with tempfile.TemporaryDirectory() as replay_object_dir:
+            env = os.environ.copy()
+            # Git treats a double-quoted entry as a C-style quoted path, so
+            # separators in the object directory do not create extra entries.
+            quoted_object_dir = object_dir.replace('\\', '\\\\').replace(
+                '"', '\\"')
+            alternates = ['"{}"'.format(quoted_object_dir)]
+            if env.get('GIT_ALTERNATE_OBJECT_DIRECTORIES'):
+                alternates.append(env['GIT_ALTERNATE_OBJECT_DIRECTORIES'])
+            env['GIT_OBJECT_DIRECTORY'] = replay_object_dir
+            env['GIT_ALTERNATE_OBJECT_DIRECTORIES'] = os.pathsep.join(
+                alternates)
+            replay = subprocess.run(
+                [
+                    'git', 'merge-tree', '--write-tree',
+                    '--merge-base={}'.format(upstream_commit.parents[0].hexsha),
+                    local_commit.parents[0].hexsha,
+                    upstream_commit.hexsha,
+                ],
+                capture_output=True,
+                cwd=local_commit.repo.working_dir,
+                env=env,
+                text=True,
+            )
+        if replay.returncode != 0:
+            detail = replay.stderr.strip() or "git merge-tree exited {}".format(
+                replay.returncode)
+            print("W: unable to verify patch replay: {}".format(detail),
+                  file=sys.stderr)
+            return False
+        lines = replay.stdout.splitlines()
+        if len(lines) != 1:
+            return False
+        tree_oid = lines[0]
+        if not re.fullmatch(r'(?:[0-9a-f]{40}|[0-9a-f]{64})', tree_oid):
+            return False
+        return tree_oid == local_commit.tree.hexsha
+    except (OSError, subprocess.SubprocessError, UnicodeError) as error:
+        print("W: unable to verify patch replay: {}".format(error),
+              file=sys.stderr)
+        return False
 
 
 def describe_sob_chain(local_commit, upstream_commit):
@@ -497,8 +587,11 @@ def build_digest(commits, repo, upstream_remote=None):
         # Patch-ID
         local_pid    = get_patch_id(commit)
         upstream_pid = get_patch_id(upstream)
-        if local_pid and upstream_pid and local_pid == upstream_pid:
-            pid_status = 'match'
+        patch_ids_match = bool(
+            local_pid and upstream_pid and local_pid == upstream_pid)
+        if is_equivalent_replay(
+                commit, upstream, local_pid, upstream_pid):
+            pid_status = 'match' if patch_ids_match else 'context'
             pid_error  = False
         else:
             pid_status = 'MISMATCH'

--- a/.github/scripts/validate-pr
+++ b/.github/scripts/validate-pr
@@ -2,6 +2,7 @@
 from argparse import ArgumentParser
 from collections import Counter
 from colorama import Fore
+import difflib
 import git
 import hashlib
 import mailbox
@@ -168,6 +169,204 @@ def get_patch_id(commit, zero_context=False):
     return (match.group('sha1') or match.group('sha256')).decode('ascii')
 
 
+_OID_RE = re.compile(r'(?:[0-9a-f]{40}|[0-9a-f]{64})')
+_MERGE_TREE_CONFLICT_RE = re.compile(
+    r'^[0-7]{6} ' + _OID_RE.pattern + r' [1-3]\t.+$')
+_MAX_EQUIVALENCE_FILE_LINES = 20000
+_MAX_EQUIVALENCE_EDITS = 128
+_MAX_EQUIVALENCE_ANCHOR_LINES = 64
+
+
+def _parse_merge_tree_result(returncode, stdout):
+    """Classify merge-tree --write-tree output as clean, conflict, or error."""
+    lines = stdout.splitlines()
+    if not lines or not _OID_RE.fullmatch(lines[0]):
+        return 'error', None
+    tree_oid = lines[0]
+    if returncode == 0 and len(lines) == 1:
+        return 'clean', tree_oid
+    if returncode == 0:
+        return 'error', None
+    if returncode != 1:
+        return 'error', None
+    conflict_lines = 0
+    for line in lines[1:]:
+        if _MERGE_TREE_CONFLICT_RE.fullmatch(line):
+            conflict_lines += 1
+            continue
+        # merge-tree may append a blank line and informational messages
+        # after the NUL-less conflict stage records.
+        if conflict_lines and (line == '' or line.startswith('Auto-merging') or
+                               line.startswith('CONFLICT ') or
+                               line.startswith('CONFLICT(')):
+            continue
+        return 'error', None
+    if conflict_lines:
+        return 'conflict', tree_oid
+    return 'error', None
+
+
+def _commit_path_set(commit):
+    """Return the set of paths touched by a single-parent commit, or None."""
+    if len(commit.parents) != 1:
+        return None
+    result = subprocess.run(
+        [
+            'git', 'diff-tree', '--no-commit-id', '--name-only', '-r', '-z',
+            commit.hexsha,
+        ],
+        capture_output=True,
+        cwd=commit.repo.working_dir,
+    )
+    if result.returncode != 0:
+        return None
+    if not result.stdout:
+        return set()
+    if not result.stdout.endswith(b'\0'):
+        return None
+    parts = result.stdout.split(b'\0')
+    if parts[-1] != b'':
+        return None
+    try:
+        return {part.decode('utf-8') for part in parts[:-1]}
+    except UnicodeDecodeError:
+        return None
+
+
+def _blob_lines(commit, path):
+    """Return text lines with endings for path at commit, or None."""
+    result = subprocess.run(
+        ['git', 'cat-file', '-e', '{}:{}'.format(commit.hexsha, path)],
+        capture_output=True,
+        cwd=commit.repo.working_dir,
+    )
+    if result.returncode != 0:
+        return None
+    show = subprocess.run(
+        ['git', 'show', '{}:{}'.format(commit.hexsha, path)],
+        capture_output=True,
+        cwd=commit.repo.working_dir,
+    )
+    if show.returncode != 0:
+        return None
+    if b'\0' in show.stdout:
+        return None
+    try:
+        return show.stdout.decode('utf-8').splitlines(keepends=True)
+    except UnicodeDecodeError:
+        return None
+
+
+def _parent_to_result_edits(parent_lines, result_lines):
+    """Return ordered (removed, inserted, i1, i2) edits with autojunk disabled."""
+    if (len(parent_lines) > _MAX_EQUIVALENCE_FILE_LINES or
+            len(result_lines) > _MAX_EQUIVALENCE_FILE_LINES):
+        return None
+    edits = []
+    matcher = difflib.SequenceMatcher(
+        None, parent_lines, result_lines, autojunk=False)
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == 'equal':
+            continue
+        edits.append((parent_lines[i1:i2], result_lines[j1:j2], i1, i2))
+    return edits
+
+
+def _sequence_occurrences(lines, sequence):
+    """Return how many times sequence occurs contiguously in lines."""
+    length = len(sequence)
+    if length == 0 or length > len(lines):
+        return 0
+    return sum(
+        1 for index in range(len(lines) - length + 1)
+        if lines[index:index + length] == sequence)
+
+
+def _unique_adjacent_anchor(upstream_parent, local_parent,
+                            up_i1, up_i2, loc_i1, loc_i2):
+    """Return True when one immediately adjacent unique context proves placement.
+
+    Grow the shortest same-side neighbor sequence until it appears exactly once
+    in both parents. Reject the side as soon as neighbor content diverges.
+    """
+    for side in ('left', 'right'):
+        if side == 'left':
+            max_len = min(up_i1, loc_i1)
+        else:
+            max_len = min(len(upstream_parent) - up_i2,
+                          len(local_parent) - loc_i2)
+        max_len = min(max_len, _MAX_EQUIVALENCE_ANCHOR_LINES)
+        for length in range(1, max_len + 1):
+            if side == 'left':
+                up_seq = upstream_parent[up_i1 - length:up_i1]
+                loc_seq = local_parent[loc_i1 - length:loc_i1]
+            else:
+                up_seq = upstream_parent[up_i2:up_i2 + length]
+                loc_seq = local_parent[loc_i2:loc_i2 + length]
+            if up_seq != loc_seq:
+                break
+            if (_sequence_occurrences(upstream_parent, up_seq) == 1 and
+                    _sequence_occurrences(local_parent, loc_seq) == 1):
+                return True
+    return False
+
+
+def _edits_have_unique_placement(upstream_parent, upstream_result,
+                                 local_parent, local_result):
+    """Prove same ordered edit payload with unambiguous adjacent anchors."""
+    upstream_edits = _parent_to_result_edits(upstream_parent, upstream_result)
+    local_edits = _parent_to_result_edits(local_parent, local_result)
+    if (upstream_edits is None or local_edits is None or
+            len(upstream_edits) > _MAX_EQUIVALENCE_EDITS or
+            len(local_edits) > _MAX_EQUIVALENCE_EDITS):
+        return False
+    if not upstream_edits:
+        return False
+    if ([(removed, inserted) for removed, inserted, _, _ in upstream_edits] !=
+            [(removed, inserted) for removed, inserted, _, _ in local_edits]):
+        return False
+    for (_, _, up_i1, up_i2), (_, _, loc_i1, loc_i2) in zip(
+            upstream_edits, local_edits):
+        if not _unique_adjacent_anchor(
+                upstream_parent, local_parent, up_i1, up_i2, loc_i1, loc_i2):
+            return False
+    return True
+
+
+def is_equivalent_by_anchored_edits(local_commit, upstream_commit):
+    """Prove context-only equivalence when three-way replay conflicts.
+
+    Zero-context patch-ID equality is assumed by the caller. For every touched
+    path, require identical ordered removed/inserted edit payloads and at least
+    one immediately adjacent context sequence that is unique in both parents and
+    present on the same side of the matching local edit. Fail closed when
+    placement is ambiguous or blobs cannot be compared as text.
+    """
+    if len(local_commit.parents) != 1 or len(upstream_commit.parents) != 1:
+        return False
+    local_paths = _commit_path_set(local_commit)
+    upstream_paths = _commit_path_set(upstream_commit)
+    if local_paths is None or upstream_paths is None:
+        return False
+    if local_paths != upstream_paths or not local_paths:
+        return False
+
+    local_parent = local_commit.parents[0]
+    upstream_parent = upstream_commit.parents[0]
+    for path in sorted(local_paths):
+        up_before = _blob_lines(upstream_parent, path)
+        up_after = _blob_lines(upstream_commit, path)
+        loc_before = _blob_lines(local_parent, path)
+        loc_after = _blob_lines(local_commit, path)
+        # Fail closed on adds/deletes/renames/binary/undecodable blobs.
+        if None in (up_before, up_after, loc_before, loc_after):
+            return False
+        if not _edits_have_unique_placement(
+                up_before, up_after, loc_before, loc_after):
+            return False
+    return True
+
+
 def is_equivalent_replay(local_commit, upstream_commit,
                          local_patch_id, upstream_patch_id):
     """Return whether the upstream change replays to the exact local tree."""
@@ -175,7 +374,8 @@ def is_equivalent_replay(local_commit, upstream_commit,
         return False
 
     try:
-        if local_patch_id != upstream_patch_id:
+        context_only = local_patch_id != upstream_patch_id
+        if context_only:
             local_zero = get_patch_id(local_commit, zero_context=True)
             upstream_zero = get_patch_id(upstream_commit, zero_context=True)
             if not local_zero or local_zero != upstream_zero:
@@ -221,19 +421,21 @@ def is_equivalent_replay(local_commit, upstream_commit,
                 env=env,
                 text=True,
             )
-        if replay.returncode != 0:
+        status, tree_oid = _parse_merge_tree_result(
+            replay.returncode, replay.stdout)
+        if status == 'clean':
+            return tree_oid == local_commit.tree.hexsha
+        if status == 'conflict' and context_only:
+            return is_equivalent_by_anchored_edits(
+                local_commit, upstream_commit)
+        if status != 'clean':
             detail = replay.stderr.strip() or "git merge-tree exited {}".format(
                 replay.returncode)
+            if status == 'error' and not detail and replay.stdout.strip():
+                detail = "malformed git merge-tree output"
             print("W: unable to verify patch replay: {}".format(detail),
                   file=sys.stderr)
-            return False
-        lines = replay.stdout.splitlines()
-        if len(lines) != 1:
-            return False
-        tree_oid = lines[0]
-        if not re.fullmatch(r'(?:[0-9a-f]{40}|[0-9a-f]{64})', tree_oid):
-            return False
-        return tree_oid == local_commit.tree.hexsha
+        return False
     except (OSError, subprocess.SubprocessError, UnicodeError) as error:
         print("W: unable to verify patch replay: {}".format(error),
               file=sys.stderr)

--- a/.github/workflows/validate-pr-tests.yml
+++ b/.github/workflows/validate-pr-tests.yml
@@ -1,0 +1,35 @@
+name: Validate PR Tests
+
+'on':
+  pull_request:
+    branches:
+      - github-actions
+    paths:
+      - .github/scripts/validate-pr
+      - .github/scripts/test_validate_pr.py
+      - .github/scripts/requirements.txt
+      - .github/workflows/validate-pr-tests.yml
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Validate PR self-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR merge commit
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: python3 -m pip install -r .github/scripts/requirements.txt
+
+      - name: Run validate-pr tests
+        run: python3 .github/scripts/test_validate_pr.py -v


### PR DESCRIPTION
## Summary

- require native three-way replay to produce the exact local tree for ordinary matching and context-only patch IDs
- use zero-context patch IDs only to identify context-only candidates while keeping acceptance fail-closed
- when native replay conflicts, require identical ordered edit payloads plus same-side adjacent context unique in both parent files
- reject ambiguous placement, changed content, non-conflict tool errors, malformed Git output, oversized fallback inputs, and unequal trees
- C-style quote alternate object paths and report replay tool or environment failures
- add black-box regression tests and an unprivileged workflow with third-party actions pinned to immutable SHAs

## Root cause

[NVIDIA/NV-Kernels#476](https://github.com/NVIDIA/NV-Kernels/pull/476) applies two independent upstream commits that touch adjacent lines. The second local commit therefore has different diff context even though its changed lines are identical to upstream, causing `git patch-id --stable` to report a mismatch.

[NVIDIA/NV-Kernels#513](https://github.com/NVIDIA/NV-Kernels/pull/513) exposed a second case: the zero-context changes match upstream commit `12aab25ca56e`, but native `merge-tree` replay conflicts in `arch/arm64/tools/cpucaps` because the downstream capability list has different adjacent entries. The conflict fallback now compares exact ordered parent-to-result edits and requires every edit to have an immediately adjacent same-side context sequence that is unique in both parents.

Patch IDs also ignore hunk line numbers, so equality alone cannot prove that a change was applied to the correct one of two byte-identical occurrences. Ordinary matches still require exact tree replay. Conflict fallback rejects duplicate or ambiguous context rather than accepting an arbitrary alignment.

The check remains fail-closed: changed content, relocation to another occurrence, ambiguous anchors, replay conflicts without a unique placement proof, tool errors, malformed output, binary or add/delete/rename cases, files over 20,000 lines, more than 128 edits, and anchors requiring more than 64 lines all fail validation.

Commit-message policy remains unchanged: malformed cherry-pick trailers and unrecognized local-config prefixes are still lint errors.

## Validation

- `python3 .github/scripts/test_validate_pr.py -v` — 17/17 passed
- exact PR #513 code pair:
  - downstream `f220c0195dd9` versus upstream `12aab25ca56e`
  - standard patch IDs differ
  - zero-context patch ID matches (`38c6f199a327`)
  - native replay conflicts in `cpucaps`
  - anchored equivalence proof returns `context`
- regression coverage rejects the former duplicate-context false acceptance, equal patch IDs at different occurrences, wrong placement during conflicts, mutated content, exit-code-2 conflict-shaped output, malformed Git output, and replay failures
- `git diff --check eec9a13f8a13..140c6caec7cb` passed
- independent adversarial re-review found no blocking issue
- [post-push Validate PR self-tests](https://github.com/NVIDIA/NV-Kernels/actions/runs/30456445572) passed

## Fork workflow replay

- exact clone: [nirmoy/NV-Kernels#20](https://github.com/nirmoy/NV-Kernels/pull/20)
- workflow run: [PR Validation #28458780210](https://github.com/nirmoy/NV-Kernels/actions/runs/28458780210)
- report: [all checks passed](https://github.com/nirmoy/NV-Kernels/pull/20#issuecomment-4845674281)
- base/head: `daccaf10eb077` / `50594a932608`, matching upstream PR #476
- digest: `50594a932608` = `context`; `ddc654b5fbd0` = `match`
