### PR TITLE
[26.04_linux-nvidia-bos] linux-nvidia-7.0-bos: Reduce SMT contention on Vera

### DIFF
--- a/include/linux/topology.h
+++ b/include/linux/topology.h
@@ -230,10 +230,23 @@ static inline int cpu_to_mem(int cpu)
 #define topology_drawer_cpumask(cpu)		cpumask_of(cpu)
 #endif
 
-#if defined(CONFIG_SCHED_SMT) && !defined(cpu_smt_mask)
+/*
+ * Defining cpu_smt_mask as cpumask_of that CPU helps to get
+ * rid of lot of ifdeffery all around the codebase in case of
+ * CONFIG_SCHED_SMT=n. It just means there are no other siblings, which
+ * is what is expected.
+ */
+#if defined(CONFIG_SCHED_SMT)
+# if !defined(cpu_smt_mask)
 static inline const struct cpumask *cpu_smt_mask(int cpu)
 {
 	return topology_sibling_cpumask(cpu);
+}
+# endif
+#else	/* !CONFIG_SCHED_SMT */
+static inline const struct cpumask *cpu_smt_mask(int cpu)
+{
+	return cpumask_of(cpu);
 }
 #endif
 

--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -7779,6 +7779,16 @@ enum asym_fits_state {
 };
 
 /*
+ * Return a stable CPU representative of @cpu's SMT core within @cpus.
+ */
+static int select_idle_core_cpu(int cpu, const struct cpumask *cpus)
+{
+	int sibling = cpumask_first_and(cpu_smt_mask(cpu), cpus);
+
+	return sibling < nr_cpu_ids ? sibling : cpu;
+}
+
+/*
  * Scan the asym_capacity domain for idle CPUs; pick the first idle one on which
  * the task fits. If no CPU is big enough, but there are idle ones, try to
  * maximize capacity.
@@ -7787,6 +7797,7 @@ static int
 select_idle_capacity(struct task_struct *p, struct sched_domain *sd, int target)
 {
 	bool prefers_idle_core = sched_smt_active() && test_idle_cores(target);
+	bool best_idle_core = false;
 	unsigned long task_util, util_min, util_max, best_cap = 0;
 	int fits, best_fits = ASYM_IDLE_COMPLETE_MISFIT;
 	int cpu, best_cpu = -1;
@@ -7812,7 +7823,8 @@ select_idle_capacity(struct task_struct *p, struct sched_domain *sd, int target)
 	}
 
 	for_each_cpu_wrap(cpu, cpus, target) {
-		bool preferred_core = !prefers_idle_core || is_core_idle(cpu);
+		bool idle_core = !sched_smt_active() || is_core_idle(cpu);
+		bool preferred_core = !prefers_idle_core || idle_core;
 		unsigned long cpu_cap = capacity_of(cpu);
 
 		/*
@@ -7829,7 +7841,7 @@ select_idle_capacity(struct task_struct *p, struct sched_domain *sd, int target)
 
 		/* This CPU fits with all requirements */
 		if (fits > 0 && preferred_core)
-			return cpu;
+			return idle_core ? select_idle_core_cpu(cpu, cpus) : cpu;
 		/*
 		 * Only the min performance hint (i.e. uclamp_min) doesn't fit.
 		 * Look for the CPU with best capacity.
@@ -7870,6 +7882,7 @@ select_idle_capacity(struct task_struct *p, struct sched_domain *sd, int target)
 			best_cap = cpu_cap;
 			best_cpu = cpu;
 			best_fits = fits;
+			best_idle_core = idle_core;
 		}
 	}
 
@@ -7885,6 +7898,8 @@ select_idle_capacity(struct task_struct *p, struct sched_domain *sd, int target)
 	 */
 	if (prefers_idle_core && best_fits > ASYM_IDLE_CORE_BIAS)
 		set_idle_cores(target, false);
+	else if (best_idle_core)
+		best_cpu = select_idle_core_cpu(best_cpu, cpus);
 
 	return best_cpu;
 }


### PR DESCRIPTION
On Vera systems, concurrent task wakeups can place CPU-intensive work on sibling threads of the same SMT core while other physical cores remain idle. This SMT contention can reduce performance for workloads intended to run one thread per core.

We can prevent such contention stabilizing the idle-core CPU selection, so that concurrent wakeups consistently select the same SMT-core representative, allowing the scheduler to avoid unintended sibling placement.

This approach has been proposed upstream:
https://lore.kernel.org/all/20260630152747.128746-1-arighi@nvidia.com/

We may have more follow-ups on this, but for now applying this patch seems to fix the issue and can significantly improve performance of CPU-bound workloads.

---

LP: https://bugs.launchpad.net/ubuntu/+bug/2158811