### PR TITLE
[26.04_linux-nvidia-bos] NVIDIA: VR: SAUCE: cxl: guard unlinked memdev endpoints

### DIFF
--- a/drivers/cxl/core/hdm.c
+++ b/drivers/cxl/core/hdm.c
@@ -3,6 +3,7 @@
 #include <linux/seq_file.h>
 #include <linux/device.h>
 #include <linux/delay.h>
+#include <linux/err.h>
 
 #include "cxlmem.h"
 #include "core.h"
@@ -617,6 +618,9 @@ cxl_find_free_decoder(struct cxl_memdev *cxlmd)
 	struct cxl_port *endpoint = cxlmd->endpoint;
 	struct device *dev;
 
+	if (IS_ERR_OR_NULL(endpoint))
+		return NULL;
+
 	guard(rwsem_read)(&cxl_rwsem.dpa);
 	dev = device_find_child(&endpoint->dev, NULL, find_free_decoder);
 	if (!dev)
@@ -759,7 +763,7 @@ struct cxl_endpoint_decoder *cxl_get_committed_decoder(struct cxl_memdev *cxlmd,
 	struct cxl_endpoint_decoder *cxled;
 	struct device *cxled_dev;
 
-	if (!endpoint)
+	if (IS_ERR_OR_NULL(endpoint))
 		return NULL;
 
 	guard(rwsem_read)(&cxl_rwsem.dpa);

--- a/drivers/cxl/core/region.c
+++ b/drivers/cxl/core/region.c
@@ -4,6 +4,7 @@
 #include <linux/genalloc.h>
 #include <linux/debugfs.h>
 #include <linux/device.h>
+#include <linux/err.h>
 #include <linux/module.h>
 #include <linux/memory.h>
 #include <linux/slab.h>
@@ -814,7 +815,7 @@ struct cxl_root_decoder *cxl_get_hpa_freespace(struct cxl_memdev *cxlmd,
 	struct cxl_port *endpoint;
 
 	endpoint = cxlmd->endpoint;
-	if (!endpoint) {
+	if (IS_ERR_OR_NULL(endpoint)) {
 		dev_dbg(&cxlmd->dev, "endpoint not linked to memdev\n");
 		return ERR_PTR(-ENXIO);
 	}
@@ -3172,7 +3173,8 @@ struct cxl_region *cxl_dpa_to_region(const struct cxl_memdev *cxlmd, u64 dpa)
 		.dpa = dpa,
 	};
 	port = cxlmd->endpoint;
-	if (port && is_cxl_endpoint(port) && cxl_num_decoders_committed(port))
+	if (!IS_ERR_OR_NULL(port) && is_cxl_endpoint(port) &&
+	    cxl_num_decoders_committed(port))
 		device_for_each_child(&port->dev, &ctx, __cxl_dpa_to_region);
 
 	return ctx.cxlr;


### PR DESCRIPTION
## Summary

- Treat both `NULL` and error-valued `cxlmd->endpoint` pointers as unlinked before entering CXL HDM and region helper paths.
- Port the functional `hdm.c` and `region.c` changes from `aff4ccee4530` onto BOS/Resolute.
- Omit the source `drivers/cxl/pci.c` hunk because this branch already guards `cxl_reset_done()` against both `NULL` and `ERR_PTR` endpoints.

## Root cause

`cxlmd->endpoint` starts as `ERR_PTR(-ENXIO)` until endpoint-port registration links the memdev to a real `cxl_port`. The affected helpers checked only for `NULL`, allowing early CXL consumers to pass the error pointer into functions such as `device_find_child()`.

The BOS region-management backport exposes these helpers before endpoint linkage, producing the observed NVIDIA probe failure and boot delay.

## Validation

- Verified the guard source check fails on the unmodified BOS branch and passes after the port.
- `git diff --check`: pass.
- Strict `checkpatch.pl`: 0 errors, 0 warnings.
- Zero-context patch ID for the two changed files matches the corresponding subset of `aff4ccee4530`.
- Confirmed `CONFIG_CXL_BUS`, `CONFIG_CXL_MEM`, `CONFIG_CXL_PCI`, and `CONFIG_CXL_REGION` are enabled in the generated amd64 BOS configuration.
- Forced amd64 rebuild of `drivers/cxl/core/hdm.o`, `region.o`, and `drivers/cxl/core/built-in.a`: pass.



## Tracking

- [NVBug 6274048](https://nvbugspro.nvidia.com/bug/6274048)
- https://bugs.launchpad.net/ubuntu/resolute/+source/linux-nvidia-bos/+bug/2153819
