### PR TITLE
[26.04_linux-nvidia-bos] Fix logic mistake in arm_mpam: Avoid MSC teardown for the SW programming errors

### DIFF
--- a/drivers/resctrl/mpam_devices.c
+++ b/drivers/resctrl/mpam_devices.c
@@ -2579,6 +2579,11 @@ static irqreturn_t __mpam_irq_handler(int irq, struct mpam_msc *msc)
 			   msc->id, mpam_errcode_names[errcode], partid, pmg,
 			   ris);
 
+	/* No action is required for the MPAM programming errors */
+	if (errcode == MPAM_ERRCODE_REQ_PARTID_RANGE ||
+	    errcode == MPAM_ERRCODE_REQ_PMG_RANGE)
+		return IRQ_HANDLED;
+
 	/* Disable this interrupt. */
 	mpam_disable_msc_ecr(msc);
 

--- a/drivers/resctrl/mpam_devices.c
+++ b/drivers/resctrl/mpam_devices.c
@@ -2579,12 +2579,6 @@ static irqreturn_t __mpam_irq_handler(int irq, struct mpam_msc *msc)
 			   msc->id, mpam_errcode_names[errcode], partid, pmg,
 			   ris);
 
-	/* No action is required for the MPAM programming errors */
-	if ((errcode != MPAM_ERRCODE_REQ_PARTID_RANGE) &&
-	    (errcode != MPAM_ERRCODE_REQ_PMG_RANGE)) {
-		return IRQ_HANDLED;
-	}
-
 	/* Disable this interrupt. */
 	mpam_disable_msc_ecr(msc);
 


### PR DESCRIPTION
# Overview

During review of the backport of [MPAM to 6.18-nvidia-next](https://github.com/NVIDIA/NV-Kernels/pull/487) @jamieNguyenNVIDIA [discovered a logic flaw in](https://github.com/NVIDIA/NV-Kernels/pull/487#issuecomment-4964012344) `arm_mpam: Avoid MSC teardown for the SW programming errors`. Revert the old fix and apply a corrected version.

# Testing

Note: Claude helped me come up with this based on the original bug report. Please let me know if I missed anything

```
root@lego-cg1-qct-053:~# mount -t resctrl resctrl /sys/fs/resctrl
root@lego-cg1-qct-053:~# mkdir -p /sys/fs/resctrl/pretest
root@lego-cg1-qct-053:~# cat /sys/fs/resctrl/pretest/schemata
MB_HLIM:1=0
 L3_MAX:1=100
     MB:1=100
     L3:1=fff
root@lego-cg1-qct-053:~# grep -i mpam /proc/iomem
670010088000-67001008bfff : MPAM:MSC
  670010088000-67001008bfff : mpam_msc.183 MPAM:MSC
root@lego-cg1-qct-053:~# cat /sys/kernel/security/lockdown
[none] integrity confidentiality
root@lego-cg1-qct-053:~# BASE=0x670010088000
root@lego-cg1-qct-053:~# busybox devmem $((BASE + 0xF8)) 32 0x02000000
root@lego-cg1-qct-053:~# sudo dmesg | grep "error irq"
[  449.227177] mpam:__mpam_irq_handler: error irq from msc:183 'Req_PARTID_Range', partid:0, pmg: 0, ris: 0
root@lego-cg1-qct-053:~# sudo dmesg | grep "MPAM disabled"
root@lego-cg1-qct-053:~# mkdir /sys/fs/resctrl/posttest
root@lego-cg1-qct-053:~# cat /sys/fs/resctrl/posttest/schemata
MB_HLIM:1=0
 L3_MAX:1=100
     MB:1=100
     L3:1=fff
root@lego-cg1-qct-053:~# busybox devmem $((BASE + 0xF0)) 32
0x00000001
root@lego-cg1-qct-053:~#  busybox devmem $((BASE + 0xF8)) 32
0x00000000
root@lego-cg1-qct-053:~# grep "mpam:msc:error" /proc/interrupts
 68:          1          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0    GICv3 327 Level     mpam:msc:error
root@lego-cg1-qct-053:~# busybox devmem $((BASE + 0xF8)) 32 0x04000000
root@lego-cg1-qct-053:~# dmesg | tail -3
[  355.025476] audit: type=1400 audit(1784230075.864:348): apparmor="DENIED" operation="getattr" class="file" info="Failed name lookup - disconnected path" error=-13 profile="unprivileged_userns" name="" pid=9935 comm="systemd-detect-" requested_mask="r" denied_mask="r" fsuid=60578 ouid=0
[  449.227177] mpam:__mpam_irq_handler: error irq from msc:183 'Req_PARTID_Range', partid:0, pmg: 0, ris: 0
[  505.653462] mpam:__mpam_irq_handler: error irq from msc:183 'Req_PMG_Range', partid:0, pmg: 0, ris: 0
root@lego-cg1-qct-053:~# busybox devmem $((BASE + 0xF8)) 32 0x02000000
root@lego-cg1-qct-053:~# dmesg | tail -3
[  449.227177] mpam:__mpam_irq_handler: error irq from msc:183 'Req_PARTID_Range', partid:0, pmg: 0, ris: 0
[  505.653462] mpam:__mpam_irq_handler: error irq from msc:183 'Req_PMG_Range', partid:0, pmg: 0, ris: 0
[  518.138938] mpam:__mpam_irq_handler: error irq from msc:183 'Req_PARTID_Range', partid:0, pmg: 0, ris: 0
```