### PR TITLE
[26.04_linux-nvidia] apparmor/Kconfig: Fix warning and a typo

### DIFF
--- a/security/apparmor/Kconfig
+++ b/security/apparmor/Kconfig
@@ -117,7 +117,7 @@ config SECURITY_APPARMOR_RESTRICT_USERNS
 	  by their profile.
 
 config SECURITY_APPARMOR_PACKET_MEDIATION_ENABLED
-	bool "Enable AppArmor packet mediation by defauit
+	bool "Enable AppArmor packet mediation by default"
 	depends on SECURITY_APPARMOR && NETWORK_SECMARK
 	default n
 	help


### PR DESCRIPTION
While building the kernel, the following warning is emitted:

security/apparmor/Kconfig:120:warning: multi-line strings not supported

Also, a minor typo has been fixed - s/defauit/default.

Launchpad: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-6.17/+bug/2161703