### PR TITLE
[26.04_linux-nvidia] selftests: net: make busywait timeout clock portable

### DIFF
--- a/tools/testing/selftests/net/lib.sh
+++ b/tools/testing/selftests/net/lib.sh
@@ -70,12 +70,33 @@ ksft_exit_status_merge()
 		$ksft_xfail $ksft_pass $ksft_skip $ksft_fail
 }
 
+timestamp_ms()
+{
+	local now
+	local seconds
+	local nanoseconds
+
+	now=$(date -u +%s:%N) || return
+	seconds=${now%:*}
+	nanoseconds=${now#*:}
+
+	if [[ $nanoseconds =~ ^[0-9]+$ ]]; then
+		nanoseconds=${nanoseconds:0:9}
+	else
+		nanoseconds=0
+	fi
+
+	echo $((seconds * 1000 + 10#$nanoseconds / 1000000))
+}
+
 loopy_wait()
 {
 	local sleep_cmd=$1; shift
 	local timeout_ms=$1; shift
+	local start_time
+	local current_time
 
-	local start_time="$(date -u +%s%3N)"
+	start_time=$(timestamp_ms) || return
 	while true
 	do
 		local out
@@ -84,7 +105,7 @@ loopy_wait()
 			return 0
 		fi
 
-		local current_time="$(date -u +%s%3N)"
+		current_time=$(timestamp_ms) || return
 		if ((current_time - start_time > timeout_ms)); then
 			echo -n "$out"
 			return 1


### PR DESCRIPTION
## Summary

Backport upstream commit `dd6a23bac306b7aa322e0aaccb60c6e32a198fb3` to `26.04_linux-nvidia`.

Use a portable millisecond timestamp for the network selftest busywait helper. This avoids premature timeouts with uutils `date` on Ubuntu Resolute.

NVBug: https://nvbugspro.nvidia.com/bug/6381089
Launchpad: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-6.17/+bug/2161742
Companion: #502

## Validation

- `git diff --check`
- `bash -n tools/testing/selftests/net/lib.sh`
- Stable patch ID matches upstream