### PR TITLE
[26.04_linux-nvidia] selftests: tls: size splice_short pipe by page size

### DIFF
--- a/tools/testing/selftests/net/tls.c
+++ b/tools/testing/selftests/net/tls.c
@@ -896,6 +896,8 @@ TEST_F(tls, splice_short)
 	char sendbuf[0x100];
 	char sendchar = 'S';
 	int pipefds[2];
+	int pipe_sz;
+	int ret;
 	int i;
 
 	sendchar_iov.iov_base = &sendchar;
@@ -904,7 +906,11 @@ TEST_F(tls, splice_short)
 	memset(sendbuf, 's', sizeof(sendbuf));
 
 	ASSERT_GE(pipe2(pipefds, O_NONBLOCK), 0);
-	ASSERT_GE(fcntl(pipefds[0], F_SETPIPE_SZ, (MAX_FRAGS + 1) * 0x1000), 0);
+	pipe_sz = (MAX_FRAGS + 1) * getpagesize();
+	ret = fcntl(pipefds[0], F_SETPIPE_SZ, pipe_sz);
+	if (ret < 0 && errno == EPERM)
+		SKIP(return, "insufficient pipe capacity");
+	ASSERT_GE(ret, pipe_sz);
 
 	for (i = 0; i < MAX_FRAGS; i++)
 		ASSERT_GE(vmsplice(pipefds[1], &sendchar_iov, 1, 0), 0);


### PR DESCRIPTION
## Summary

Backport upstream commit `3e52f56875c6fafee619b5c2b4ded25f2efbd2ec` to `26.04_linux-nvidia`.

Size the `splice_short` selftest pipe using the runtime page size so the test works on both 4K and 64K page-size kernels. The rewritten base already contains upstream production fixes `285943c6e7ca309bbea84b253745154241d9788a` and `ff26a0e8377dec07e4a7230db7675bed1b9a6d03` by patch ID.

NVBug: https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/6203697
Launchpad: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-6.17/+bug/2161746
Companion: #503

## Validation

- Stable patch ID matches upstream
- `git diff --check`
- `make headers_install`
- `make -C tools/testing/selftests/net tls`
- `tls.12_aes_gcm.splice_short`: 1/1 passed