### PR TITLE
[26.04_linux-nvidia-bos]: firmware: arm_ffa: Respect firmware advertised RX/TX buffer size limits

### DIFF
--- a/drivers/firmware/arm_ffa/driver.c
+++ b/drivers/firmware/arm_ffa/driver.c
@@ -32,6 +32,7 @@
 #include <linux/interrupt.h>
 #include <linux/io.h>
 #include <linux/kernel.h>
+#include <linux/minmax.h>
 #include <linux/module.h>
 #include <linux/mm.h>
 #include <linux/mutex.h>
@@ -55,7 +56,9 @@
 	(FIELD_PREP(SENDER_ID_MASK, (s)) | FIELD_PREP(RECEIVER_ID_MASK, (r)))
 
 #define RXTX_MAP_MIN_BUFSZ_MASK	GENMASK(1, 0)
-#define RXTX_MAP_MIN_BUFSZ(x)	((x) & RXTX_MAP_MIN_BUFSZ_MASK)
+#define RXTX_MAP_MAX_BUFSZ_MASK	GENMASK(31, 16)
+#define RXTX_MAP_MIN_BUFSZ(x)	(FIELD_GET(RXTX_MAP_MIN_BUFSZ_MASK, (x)))
+#define RXTX_MAP_MAX_BUFSZ(x)	(FIELD_GET(RXTX_MAP_MAX_BUFSZ_MASK, (x)))
 
 #define FFA_MAX_NOTIFICATIONS		64
 
@@ -2092,7 +2095,7 @@ static int __init ffa_init(void)
 {
 	int ret;
 	u32 buf_sz;
-	size_t rxtx_bufsz = SZ_4K;
+	size_t rxtx_min_bufsz = SZ_4K, rxtx_max_bufsz = 0, rxtx_bufsz;
 
 	ret = ffa_transport_init(&invoke_ffa_fn);
 	if (ret)
@@ -2115,15 +2118,18 @@ static int __init ffa_init(void)
 	ret = ffa_features(FFA_FN_NATIVE(RXTX_MAP), 0, &buf_sz, NULL);
 	if (!ret) {
 		if (RXTX_MAP_MIN_BUFSZ(buf_sz) == 1)
-			rxtx_bufsz = SZ_64K;
+			rxtx_min_bufsz = SZ_64K;
 		else if (RXTX_MAP_MIN_BUFSZ(buf_sz) == 2)
-			rxtx_bufsz = SZ_16K;
+			rxtx_min_bufsz = SZ_16K;
 		else
-			rxtx_bufsz = SZ_4K;
+			rxtx_min_bufsz = SZ_4K;
+
+		rxtx_max_bufsz = RXTX_MAP_MAX_BUFSZ(buf_sz) * SZ_4K;
+		if (rxtx_max_bufsz != 0 && rxtx_max_bufsz < rxtx_min_bufsz)
+			rxtx_max_bufsz = rxtx_min_bufsz;
 	}
 
-	rxtx_bufsz = PAGE_ALIGN(rxtx_bufsz);
-	drv_info->rxtx_bufsz = rxtx_bufsz;
+	rxtx_bufsz = min_not_zero(PAGE_ALIGN(rxtx_min_bufsz), rxtx_max_bufsz);
 	drv_info->rx_buffer = alloc_pages_exact(rxtx_bufsz, GFP_KERNEL);
 	if (!drv_info->rx_buffer) {
 		ret = -ENOMEM;
@@ -2139,10 +2145,17 @@ static int __init ffa_init(void)
 	ret = ffa_rxtx_map(virt_to_phys(drv_info->tx_buffer),
 			   virt_to_phys(drv_info->rx_buffer),
 			   rxtx_bufsz / FFA_PAGE_SIZE);
+	if (ret == -EINVAL && !rxtx_max_bufsz && rxtx_min_bufsz < rxtx_bufsz) {
+		rxtx_bufsz = rxtx_min_bufsz;
+		ret = ffa_rxtx_map(virt_to_phys(drv_info->tx_buffer),
+				   virt_to_phys(drv_info->rx_buffer),
+				   rxtx_bufsz / FFA_PAGE_SIZE);
+	}
 	if (ret) {
 		pr_err("failed to register FFA RxTx buffers\n");
 		goto free_pages;
 	}
+	drv_info->rxtx_bufsz = rxtx_bufsz;
 
 	mutex_init(&drv_info->rx_lock);
 	mutex_init(&drv_info->tx_lock);


### PR DESCRIPTION
BugLink: https://bugs.launchpad.net/bugs/2162012

Targets **26.04_linux-nvidia-bos**.

### Summary

A stable update introduced two FF-A commits into linux-nvidia 7.0 branches
without the third commit in the sequence. This causes FF-A initialization
failure on 64K page kernels when firmware rejects the 64K RX/TX buffer size.

### The Regression

Two v7.1 commits were backported, landing in `Ubuntu-nvidia-bos-7.0.0-2016.16`:
- `7bfaed6b412b` (firmware: arm_ffa: Use the correct buffer size during RXTX_MAP)
- `105dac1d2c92` (firmware: arm_ffa: Align RxTx buffer size before mapping)

The third essential commit only landed in v7.2-rc4:
`53716a4d745f firmware: arm_ffa: Respect firmware advertised RX/TX buffer size limits`

### Symptom

On 64K page kernels, the driver rounds the firmware-advertised minimum RX/TX
buffer size to PAGE_SIZE. FF-A implementations before v1.2 may reject this
rounded size, causing probe failure with no FF-A devices registered, including
TPM over FF-A.

    ARM FF-A: failed to register FFA RxTx buffers

### The Fix

Backport commit `53716a4d745f`, which decodes maximum buffer sizes for FF-A
v1.2+, clamps page-aligned minimums accordingly, and retries RXTX_MAP at
advertised minimums when rounded sizes are rejected.

Applied to `ffa_init()` rather than `ffa_probe()`, as this tree predates the
FF-A platform driver conversion. No functional difference. One file, +20/-7,
`checkpatch --strict` clean.

### Testing

Tested on an Arm server with FF-A v1.1 firmware, on a 64K page kernel built
from this branch's `nvidia-bos-64k` flavour annotations. Before: no FF-A
devices. After: all five partitions enumerate successfully.

The booted kernel also carried unrelated in-progress work; the resulting
`drivers/firmware/arm_ffa/driver.c` was SHA256 matched against a tree of this
branch alone, confirming the FF-A change under test was byte identical to what
is proposed here.