### PR TITLE
Please pull Grace fix: NVIDIA: SAUCE: arm_mpam: Apply T241-MPAM-6 to 63-bit counters

### DIFF
--- a/drivers/resctrl/mpam_devices.c
+++ b/drivers/resctrl/mpam_devices.c
@@ -1179,8 +1179,7 @@ static u64 mpam_msmon_overflow_val(enum mpam_device_features type,
 {
 	u64 overflow_val = __mpam_msmon_overflow_val(type);
 
-	if (mpam_has_quirk(T241_MBW_COUNTER_SCALE_64, msc) &&
-	    type != mpam_feat_msmon_mbwu_63counter)
+	if (mpam_has_quirk(T241_MBW_COUNTER_SCALE_64, msc))
 		overflow_val *= 64;
 
 	return overflow_val;
@@ -1276,8 +1275,7 @@ static void __ris_msmon_read(void *arg)
 			now = FIELD_GET(MSMON___VALUE, now);
 		}
 
-		if (mpam_has_quirk(T241_MBW_COUNTER_SCALE_64, msc) &&
-		    m->type != mpam_feat_msmon_mbwu_63counter)
+		if (mpam_has_quirk(T241_MBW_COUNTER_SCALE_64, msc))
 			now *= 64;
 
 		if (nrdy)


### PR DESCRIPTION
T241-MPAM-6 hardware quirk in upstream times mbwu counter by 64 to workaround hw issue. But the upstream doesn't apply this quirk to 63-bit mbwu counter which is supported on Grace. Then the mbm_total_bytes on Grace is mbwu requests instead of bytes. The patch on lkml fixes this issue:

T241-MPAM-6 causes all MBWU counter formats to count 64-byte requests instead of bytes. Commit dc48eb1ff27c excluded the 63-bit MSMON_MBWU_LWD format while scaling the shorter counters. Systems selecting the preferred 63-bit counter consequently report bandwidth values that are 64 times too small.

Apply the scale to both the sampled value and overflow correction for the 63-bit format. Unsigned arithmetic retains modulo-u64 behavior when the scaled counter range exceeds u64.

Fixes: dc48eb1ff27c ("arm_mpam: Add workaround for T241-MPAM-6")
Link: https://lore.kernel.org/lkml/20240816131432.993859-1-sdonthineni@nvidia.com/

Reviewed-by: Fenghua Yu <fenghuay@nvidia.com>
Tested-by: Fenghua Yu <fenghuay@nvidia.com>
Reviewed-by: Ben Horgan <ben.horgan@arm.com>
(cherry picked from https://lore.kernel.org/lkml/20260727191326.2202616-1-sdonthineni@nvidia.com/)