### PR TITLE
[26.04_linux-nvidia-bos] NVIDIA: VR: SAUCE: Re-align Vera SMT handling with upstream NOHZ fix

### DIFF
--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -12520,29 +12520,67 @@ static inline int on_null_domain(struct rq *rq)
  */
 static inline int find_new_ilb(void)
 {
-	const struct cpumask *hk_mask;
-	int ilb_cpu;
+	int this_cpu = smp_processor_id();
+	struct cpumask *ilb_cpus;
+	int ilb_cpu, fallback = -1;
 
-	hk_mask = housekeeping_cpumask(HK_TYPE_KERNEL_NOISE);
+	lockdep_assert_irqs_disabled();
 
-	for_each_cpu_and(ilb_cpu, nohz.idle_cpus_mask, hk_mask) {
+	/*
+	 * Reuse the per-CPU select_rq_mask, which is protected from concurrent
+	 * use on this CPU by having interrupts disabled.
+	 */
+	ilb_cpus = this_cpu_cpumask_var_ptr(select_rq_mask);
+	cpumask_and(ilb_cpus, nohz.idle_cpus_mask,
+		    housekeeping_cpumask(HK_TYPE_KERNEL_NOISE));
 
-		if (ilb_cpu == smp_processor_id())
+	for_each_cpu(ilb_cpu, ilb_cpus) {
+		if (ilb_cpu == this_cpu)
 			continue;
 
-		if (idle_cpu(ilb_cpu))
-			return ilb_cpu;
+		if (!idle_cpu(ilb_cpu)) {
+			/*
+			 * Once an idle fallback exists, a busy CPU proves that
+			 * this core cannot be fully idle. Skip its siblings.
+			 */
+			if (sched_smt_active() && fallback >= 0)
+				cpumask_andnot(ilb_cpus, ilb_cpus,
+					       cpu_smt_mask(ilb_cpu));
+			continue;
+		}
+
+		/*
+		 * Running the idle load balancer on an idle sibling of a busy
+		 * SMT core can reduce the capacity available to its sibling. Prefer
+		 * a CPU whose entire core is idle, but retain the first idle CPU as
+		 * a fallback so idle balancing can still make progress when no fully
+		 * idle core exists.
+		 */
+		if (sched_smt_active() && !is_core_idle(ilb_cpu)) {
+			if (fallback < 0)
+				fallback = ilb_cpu;
+
+			/*
+			 * The core is not idle, so there is no need to check
+			 * any of its other SMT siblings.
+			 */
+			cpumask_andnot(ilb_cpus, ilb_cpus,
+				       cpu_smt_mask(ilb_cpu));
+			continue;
+		}
+
+		return ilb_cpu;
 	}
 
-	return -1;
+	return fallback;
 }
 
 /*
  * Kick a CPU to do the NOHZ balancing, if it is time for it, via a cross-CPU
  * SMP function call (IPI).
  *
- * We pick the first idle CPU in the HK_TYPE_KERNEL_NOISE housekeeping set
- * (if there is one).
+ * Prefer a CPU on a fully idle core in the HK_TYPE_KERNEL_NOISE housekeeping
+ * set. Fall back to the first idle CPU when no fully idle core exists.
  */
 static void kick_ilb(unsigned int flags)
 {

--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -7774,16 +7774,6 @@ enum asym_fits_state {
 };
 
 /*
- * Return a stable CPU representative of @cpu's SMT core within @cpus.
- */
-static int select_idle_core_cpu(int cpu, const struct cpumask *cpus)
-{
-	int sibling = cpumask_first_and(cpu_smt_mask(cpu), cpus);
-
-	return sibling < nr_cpu_ids ? sibling : cpu;
-}
-
-/*
  * Scan the asym_capacity domain for idle CPUs; pick the first idle one on which
  * the task fits. If no CPU is big enough, but there are idle ones, try to
  * maximize capacity.
@@ -7792,7 +7782,6 @@ static int
 select_idle_capacity(struct task_struct *p, struct sched_domain *sd, int target)
 {
 	bool prefers_idle_core = sched_smt_active() && test_idle_cores(target);
-	bool best_idle_core = false;
 	unsigned long task_util, util_min, util_max, best_cap = 0;
 	int fits, best_fits = ASYM_IDLE_COMPLETE_MISFIT;
 	int cpu, best_cpu = -1;
@@ -7818,8 +7807,7 @@ select_idle_capacity(struct task_struct *p, struct sched_domain *sd, int target)
 	}
 
 	for_each_cpu_wrap(cpu, cpus, target) {
-		bool idle_core = !sched_smt_active() || is_core_idle(cpu);
-		bool preferred_core = !prefers_idle_core || idle_core;
+		bool preferred_core = !prefers_idle_core || is_core_idle(cpu);
 		unsigned long cpu_cap = capacity_of(cpu);
 
 		/*
@@ -7836,7 +7824,7 @@ select_idle_capacity(struct task_struct *p, struct sched_domain *sd, int target)
 
 		/* This CPU fits with all requirements */
 		if (fits > 0 && preferred_core)
-			return idle_core ? select_idle_core_cpu(cpu, cpus) : cpu;
+			return cpu;
 		/*
 		 * Only the min performance hint (i.e. uclamp_min) doesn't fit.
 		 * Look for the CPU with best capacity.
@@ -7877,7 +7865,6 @@ select_idle_capacity(struct task_struct *p, struct sched_domain *sd, int target)
 			best_cap = cpu_cap;
 			best_cpu = cpu;
 			best_fits = fits;
-			best_idle_core = idle_core;
 		}
 	}
 
@@ -7893,8 +7880,6 @@ select_idle_capacity(struct task_struct *p, struct sched_domain *sd, int target)
 	 */
 	if (prefers_idle_core && best_fits > ASYM_IDLE_CORE_BIAS)
 		set_idle_cores(target, false);
-	else if (best_idle_core)
-		best_cpu = select_idle_core_cpu(best_cpu, cpus);
 
 	return best_cpu;
 }


### PR DESCRIPTION
Re-align Vera SMT scheduling with the latest upstream approach. Prefer fully idle cores for NOHZ idle load balancing, then revert the earlier asym-capacity SMT-core normalization, which showed worse performance with the new fix applied. Testing on Vera shows improved CPU-intensive workload performance.

Latest upstream patch: https://lore.kernel.org/r/20260731191957.3199642-1-arighi@nvidia.com

LP: https://bugs.launchpad.net/bugs/2162749