### PR TITLE
[26.04_linux-nvidia-bos] NVIDIA: SAUCE: usb: misc: add LSTP adapter support

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -15113,6 +15113,12 @@ L:	linux-scsi@vger.kernel.org
 S:	Maintained
 F:	drivers/scsi/sym53c8xx_2/
 
+LOW-SPEED TRANSPORT PROTOCOL (LSTP) USB DRIVER
+M:	Adrian Ambrozewicz <aambrozewicz@nvidia.com>
+L:	linux-usb@vger.kernel.org
+S:	Supported
+F:	drivers/usb/misc/lstp/
+
 LT3074 HARDWARE MONITOR DRIVER
 M:	Cedric Encarnacion <cedricjustine.encarnacion@analog.com>
 L:	linux-hwmon@vger.kernel.org

--- a/debian.nvidia-bos/config/annotations
+++ b/debian.nvidia-bos/config/annotations
@@ -273,6 +273,9 @@ CONFIG_SENSORS_AAEON                            note<'Disable all Ubuntu ODM dri
 CONFIG_SENSORS_SPD5118                          policy<{'amd64': 'm', 'arm64': 'm'}>
 CONFIG_SENSORS_SPD5118                          note<'Enable SPD5118 temperature sensor support for DDR5 memory modules'>
 
+CONFIG_SEPARATE_LSTP_IPMI_POSTCODES             policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_SEPARATE_LSTP_IPMI_POSTCODES             note<'Keep LSTP IPMI POST codes on the standard message path'>
+
 CONFIG_SFC_CXL                                  policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_SFC_CXL                                  note<'Solarflare SFC9100-family CXL Type-2 device support; not needed for NVIDIA platforms'>
 
@@ -293,6 +296,12 @@ CONFIG_UBUNTU_ODM_DRIVERS                       note<'Disable all Ubuntu ODM dri
 
 CONFIG_ULTRASOC_SMB                             policy<{'arm64': 'n'}>
 CONFIG_ULTRASOC_SMB                             note<'Required for Grace enablement'>
+
+CONFIG_USB_LSTP                                 policy<{'amd64': 'm', 'arm64': 'm'}>
+CONFIG_USB_LSTP                                 note<'Enable the LSTP USB multi-function device for supported platforms'>
+
+CONFIG_USB_LSTP_SPI_SPIDEV                      policy<{'amd64': 'y', 'arm64': 'y'}>
+CONFIG_USB_LSTP_SPI_SPIDEV                      note<'Create spidev devices for LSTP SPI channels without firmware descriptions'>
 
 CONFIG_VFIO_CONTAINER                           policy<{'amd64': 'y', 'arm64': 'n'}>
 CONFIG_VFIO_CONTAINER                           note<'LP: #2095028'>

--- a/drivers/usb/misc/Kconfig
+++ b/drivers/usb/misc/Kconfig
@@ -194,6 +194,8 @@ config USB_USBIO
 	  This driver can also be built as a module. If so, the module
 	  will be called usbio.
 
+source "drivers/usb/misc/lstp/Kconfig"
+
 source "drivers/usb/misc/sisusbvga/Kconfig"
 
 config USB_LD

--- a/drivers/usb/misc/Makefile
+++ b/drivers/usb/misc/Makefile
@@ -13,6 +13,7 @@ obj-$(CONFIG_USB_EZUSB_FX2)		+= ezusb.o
 obj-$(CONFIG_APPLE_MFI_FASTCHARGE)	+= apple-mfi-fastcharge.o
 obj-$(CONFIG_USB_LJCA)			+= usb-ljca.o
 obj-$(CONFIG_USB_USBIO)			+= usbio.o
+obj-$(CONFIG_USB_LSTP)			+= lstp/
 obj-$(CONFIG_USB_IDMOUSE)		+= idmouse.o
 obj-$(CONFIG_USB_IOWARRIOR)		+= iowarrior.o
 obj-$(CONFIG_USB_ISIGHTFW)		+= isight_firmware.o

--- a/drivers/usb/misc/lstp/Kconfig
+++ b/drivers/usb/misc/lstp/Kconfig
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+config USB_LSTP
+	tristate "LSTP USB adapter support"
+	depends on USB
+	depends on I2C
+	depends on SPI_MASTER
+	depends on GPIOLIB
+	depends on LEDS_CLASS
+	depends on TTY
+	select GPIOLIB_IRQCHIP
+	help
+	  This adds support for the Low-Speed Transport Protocol (LSTP)
+	  USB adapter. The LSTP adapter exposes firmware-configured I2C, SPI,
+	  GPIO, UART, IPMI, and MMIO channels over a single USB interface.
+
+	  This driver can also be built as a module. If so, the module will be
+	  called lstp.
+
+	  If unsure, say N.
+
+config USB_LSTP_SPI_SPIDEV
+	bool "Auto-create spidev devices for LSTP SPI channels"
+	depends on USB_LSTP
+	depends on SPI_SPIDEV
+	help
+	  Enable this option to make the lstp module default to creating spidev
+	  child devices for SPI channels that do not have firmware-described
+	  child devices.
+
+	  This only sets the compile-time default for the auto_bind_spidev module
+	  parameter. The default can still be overridden at module load time.
+
+	  If unsure, say N.
+
+config SEPARATE_LSTP_IPMI_POSTCODES
+	bool "Separate LSTP IPMI post code writes to separate miscdevice"
+	depends on USB_LSTP
+	help
+	  Enable this option to route IPMI post code writes to a separate
+	  miscdevice instead of the main IPMI message path. Since POST codes
+	  do not require a response, this allows faster processing by
+	  bypassing the standard IPMI request-response handling.
+
+	  If unsure, say N.

--- a/drivers/usb/misc/lstp/Makefile
+++ b/drivers/usb/misc/lstp/Makefile
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+
+obj-$(CONFIG_USB_LSTP) += lstp.o
+lstp-y := lstp-main.o lstp-spi.o lstp-gpio.o lstp-i2c.o lstp-ipmi.o lstp-uart.o \
+	lstp-mmio.o

--- a/drivers/usb/misc/lstp/lstp-gpio.c
+++ b/drivers/usb/misc/lstp/lstp-gpio.c
@@ -1,0 +1,1557 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * GPIO driver for LSTP USB interface.
+ *
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+#include <linux/bitmap.h>
+#include <linux/device.h>
+#include <linux/err.h>
+#include <linux/gpio/consumer.h>
+#include <linux/gpio/driver.h>
+#include <linux/irq.h>
+#include <linux/kernel.h>
+#include <linux/leds.h>
+#include <linux/seq_file.h>
+#include <linux/string.h>
+#include <linux/workqueue.h>
+#include <uapi/linux/gpio.h>
+
+#include "lstp-main.h"
+
+#define LSTP_GPIO_PIN_NAME_LEN 32
+#define LSTP_LED_REPEAT_FOREVER 0 /* wire: repeats == 0 plays forever */
+#define LSTP_LED_LINUX_REPEAT_FOREVER (-1) /* LED-class pattern_set: repeat == -1 plays forever */
+#define LSTP_LED_DEFAULT_HOLD_TIME_MS 1 /* delta_t for single-step holds */
+#define LSTP_LED_DEFAULT_BLINK_MS 500 /* LED-class default when delay_on/off are both 0 */
+
+enum lstp_gpio_cmd {
+	LSTP_GPIO_CMD_GET_VALUE = 0x00,
+	LSTP_GPIO_CMD_SET_VALUE = 0x01,
+	LSTP_GPIO_CMD_GET_IRQ_CONFIG = 0x02,
+	LSTP_GPIO_CMD_SET_IRQ_CONFIG = 0x03,
+	LSTP_GPIO_CMD_IRQ_EVENT = 0x04,
+	LSTP_GPIO_CMD_SET_LED_PATTERN = 0x05,
+} __packed;
+
+struct lstp_led_pattern {
+	u8 brightness;
+	__le32 time_ms;
+} __packed;
+
+struct lstp_gpio_get_value_req {
+	__le16 pin;
+} __packed;
+
+struct lstp_gpio_set_value_req {
+	__le16 pin;
+	u8 value;
+} __packed;
+
+struct lstp_gpio_get_irq_config_req {
+	__le16 pin;
+} __packed;
+
+struct lstp_gpio_set_irq_config_req {
+	__le16 pin;
+	u8 irq_type;
+} __packed;
+
+struct lstp_gpio_irq_event_req {
+	__le16 pin;
+	u8 value;
+} __packed;
+
+struct lstp_gpio_set_led_pattern_req {
+	__le16 pin;
+	__le32 repeats;
+	u8 num_steps;
+	struct lstp_led_pattern pattern[];
+} __packed;
+
+struct lstp_gpio_get_value_resp {
+	u8 value;
+} __packed;
+
+struct lstp_gpio_get_irq_config_resp {
+	u8 irq_type;
+} __packed;
+
+enum lstp_gpio_irq_type {
+	LSTP_GPIO_IRQ_NONE = 0x00,
+	LSTP_GPIO_IRQ_RISING = 0x01,
+	LSTP_GPIO_IRQ_FALLING = 0x02,
+	LSTP_GPIO_IRQ_BOTH = 0x03,
+	LSTP_GPIO_IRQ_HIGH = 0x04,
+	LSTP_GPIO_IRQ_LOW = 0x05,
+	LSTP_GPIO_IRQ_MAX = LSTP_GPIO_IRQ_LOW,
+} __packed;
+
+struct lstp_gpio_pin_config {
+	u8 direction;
+	u8 default_output;
+	u8 output_drive_config;
+	u8 output_persist_state; /* bool */
+	u8 bias_pull_config;
+	__le16 bias_pull_strength; /* 16 ohm increments */
+	__le16 output_drive_strength; /* in mA */
+	__le16 slew_rate; /* in 100 ps (0.1 ns) increments */
+	__le16 input_debounce_time; /* in us */
+	u8 led_support;
+	u8 reserved_0xE;
+	u8 reserved_0xF;
+} __packed;
+
+struct lstp_gpio_pin {
+	char pin_name[LSTP_GPIO_PIN_NAME_LEN];
+	struct lstp_gpio_pin_config config;
+} __packed;
+
+struct lstp_gpio_config {
+	u8 npins;
+	struct lstp_gpio_pin pin_info[];
+} __packed;
+
+/* clang-format off */
+enum lstp_gpio_direction {
+	LSTP_GPIO_OUTPUT = 0x00,
+	LSTP_GPIO_INPUT = 0x01
+} __packed;
+enum lstp_gpio_pin_state {
+	LSTP_GPIO_LOW = 0x00,
+	LSTP_GPIO_HIGH = 0x01
+} __packed;
+enum lstp_gpio_drive_config {
+	LSTP_GPIO_PUSH_PULL = 0x00,
+	LSTP_GPIO_OPEN_DRAIN = 0x01,
+	LSTP_GPIO_OPEN_SOURCE = 0x02
+} __packed;
+enum lstp_gpio_bias_config {
+	LSTP_GPIO_NO_PULL = 0x00,
+	LSTP_GPIO_PULL_UP = 0x01,
+	LSTP_GPIO_PULL_DOWN = 0x02
+} __packed;
+enum lstp_gpio_led_support {
+	LSTP_GPIO_NOT_LED = 0x00,
+	LSTP_GPIO_LED_MODE_HOLD = 0x01, /* pattern brightness jumps between steps */
+	LSTP_GPIO_LED_MODE_INTERPOLATE = 0x02, /* pattern brightness interpolates between steps */
+} __packed; /* clang-format on */
+
+/* Private data for GPIO channel */
+struct lstp_gpio_priv {
+	struct lstp_channel *ch;
+	struct gpio_chip gc;
+	struct workqueue_struct *wq; /* Ordered workqueue for IRQ event handling, FIFO */
+	struct mutex irq_lock; /* Serializes irq_chip callbacks (irq_bus_lock/sync_unlock) */
+	u8 *shadow_irq_type; /* Pending IRQ type per pin [npins] */
+	u8 *hw_irq_type; /* Last successfully committed IRQ type per pin [npins] */
+	const char **pin_names; /* Line names [npins] */
+	struct lstp_gpio_led **leds; /* [npins], NULL if not an LED pin */
+	u16 npins; /* Pin count from device config */
+	u16 ngpio; /* Non-LED GPIO pin count */
+	u16 nleds; /* LED class device count */
+};
+
+/* One work item per unsolicited RX batch; raw payload parsed in process context */
+struct lstp_gpio_irq_event_work {
+	struct work_struct work;
+	struct lstp_gpio_priv *priv;
+	u16 payload_len;
+	u8 payload[];
+};
+
+/* Per-LED wrapper around led_classdev for a single LED pin */
+struct lstp_gpio_led {
+	struct led_classdev cdev;
+	struct lstp_gpio_priv *priv; /* Back-pointer to owning GPIO channel */
+	u16 pin;
+};
+
+/**
+ * lstp_gpio_read_direction() - Read @pin's direction from device config.
+ * @priv:      GPIO channel private data
+ * @pin:       Pin index
+ * @direction: Out: LSTP_GPIO_INPUT or LSTP_GPIO_OUTPUT
+ *
+ * Tries a partial read of the direction byte first; falls back to a whole-pin
+ * read on firmware that rejects partial config reads.
+ *
+ * Return: 0 on success, -EINVAL if @pin invalid, or other negative errno.
+ */
+static int lstp_gpio_read_direction(struct lstp_gpio_priv *priv, unsigned int pin, u8 *direction)
+{
+	struct lstp_channel *ch = priv->ch;
+	struct lstp_ch0_read_resp *resp __free(kfree) = NULL;
+	u16 pin_offset = sizeof(struct lstp_gpio_config) + pin * sizeof(struct lstp_gpio_pin);
+	u16 offset = pin_offset + offsetof(struct lstp_gpio_pin, config) +
+		     offsetof(struct lstp_gpio_pin_config, direction);
+	size_t actual;
+	int lstp_status;
+	int ret;
+
+	if (pin >= priv->npins)
+		return -EINVAL;
+
+	ret = lstp_ch0_read_config(ch, offset, sizeof(*direction), &resp, &actual, &lstp_status);
+	if (lstp_status == LSTP_ERROR || lstp_status == LSTP_NOT_SUPP) {
+		/*
+		 * TODO: Legacy support - remove this at some point
+		 * Fallback for firmware that only supports whole pin reads.
+		 */
+		dev_warn_ratelimited(ch->dev, "%s: ch_%d: Partial pin config read rejected.\n",
+				     __func__, ch->ch_id);
+		ret = lstp_ch0_read_config(ch, pin_offset, sizeof(struct lstp_gpio_pin), &resp,
+					   &actual, NULL);
+		if (ret)
+			return ret;
+		*direction = ((const struct lstp_gpio_pin *)resp->ch_config)->config.direction;
+		return 0;
+	} else if (ret) {
+		dev_err(ch->dev, "%s: ch_%d: Failed to read direction config for pin %u (%pe)\n",
+			__func__, ch->ch_id, pin, ERR_PTR(ret));
+		return ret;
+	}
+
+	*direction = *(const u8 *)resp->ch_config;
+	return 0;
+}
+
+/**
+ * lstp_gpio_get_value() - Read GPIO pin value. (blocking)
+ * @gc:  GPIO chip
+ * @pin: Pin index
+ *
+ * Return: 1 for logical high, 0 for logical low, negative errno on failure.
+ */
+static int lstp_gpio_get_value(struct gpio_chip *gc, unsigned int pin)
+{
+	struct lstp_gpio_priv *priv = gpiochip_get_data(gc);
+	struct lstp_channel *ch = priv->ch;
+	struct lstp_gpio_get_value_req req = { .pin = cpu_to_le16(pin) };
+	struct lstp_gpio_get_value_resp resp;
+	int ret;
+
+	ret = lstp_request(ch, LSTP_GPIO_CMD_GET_VALUE, &req, sizeof(req), &resp, sizeof(resp),
+			   NULL, NULL);
+	if (ret) {
+		dev_err(ch->dev, "%s: ch_%d: Could not get value for pin %u (%pe)\n", __func__,
+			ch->ch_id, pin, ERR_PTR(ret));
+		return ret;
+	}
+
+	dev_dbg(ch->dev, "%s: ch_%d: pin=%u, value=%d\n", __func__, ch->ch_id, pin, resp.value);
+	return resp.value;
+}
+
+/**
+ * lstp_gpio_set_value() - Set GPIO pin output value. (blocking)
+ * @gc:    GPIO chip
+ * @pin:   Pin index
+ * @value: Logical output value (0 = low, non-zero = high)
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_gpio_set_value(struct gpio_chip *gc, unsigned int pin, int value)
+{
+	struct lstp_gpio_priv *priv = gpiochip_get_data(gc);
+	struct lstp_channel *ch = priv->ch;
+	struct lstp_gpio_set_value_req req = {
+		.pin = cpu_to_le16(pin),
+		.value = !!value,
+	};
+	int ret;
+
+	ret = lstp_request(ch, LSTP_GPIO_CMD_SET_VALUE, &req, sizeof(req), NULL, 0, NULL, NULL);
+	if (ret)
+		dev_err(ch->dev, "%s: ch_%d: Could not set value %d for pin %u (%pe)\n", __func__,
+			ch->ch_id, value, pin, ERR_PTR(ret));
+	else
+		dev_dbg(ch->dev, "%s: ch_%d: pin=%u, value=%d\n", __func__, ch->ch_id, pin, value);
+	return ret;
+}
+
+/**
+ * lstp_gpio_get_multiple() - Read multiple GPIO pin values. (blocking)
+ * @gc:   GPIO chip
+ * @mask: Bitmask of pins to read
+ * @bits: Pointer to store logical values (bitmask)
+ *
+ * Sends GET_VALUE payloads, chunked across multiple packets if the number of
+ * pins exceeds what fits in one request. Fills @bits from responses. Each
+ * chunk is one LSTP exchange that serializes on the per-channel TX mutex
+ * via lstp_request(); the framework does not bracket the chunks under a
+ * shared lock, so a concurrent reader or writer may observe state from
+ * between two chunks. Matches the gpiolib per-pin fallback contract; the
+ * gpiolib API is silent on cross-call atomicity.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_gpio_get_multiple(struct gpio_chip *gc, unsigned long *mask, unsigned long *bits)
+{
+	struct lstp_gpio_priv *priv = gpiochip_get_data(gc);
+	struct lstp_channel *ch = priv->ch;
+	struct lstp_gpio_get_value_req *req = NULL;
+	struct lstp_gpio_get_value_resp *resp = NULL;
+	int max_pins_per_tx = ch->max_tx_payload / sizeof(*req);
+	int max_pins_per_rx = ch->max_rx_payload / sizeof(*resp);
+	int max_pins_per_pkt = min(max_pins_per_tx, max_pins_per_rx);
+	int total_pins = bitmap_weight(mask, gc->ngpio);
+	unsigned int bit_off = 0;
+	int pins_sent = 0;
+	int pins_in_pkt;
+	int ret;
+
+	/* Probe enforces bulk_*_size >= LSTP_USB_EP_MIN_SIZE; anchor it here. */
+	BUILD_BUG_ON(sizeof(struct lstp_header) + sizeof(*req) > LSTP_USB_EP_MIN_SIZE);
+	BUILD_BUG_ON(sizeof(struct lstp_header) + sizeof(*resp) > LSTP_USB_EP_MIN_SIZE);
+
+	if (total_pins == 0)
+		return 0;
+
+	if (max_pins_per_pkt < 1) {
+		dev_err(ch->dev, "%s: ch_%d: Payload capacity too small for a single pin\n",
+			__func__, ch->ch_id);
+		return -EINVAL;
+	}
+
+	req = kmalloc_array(max_pins_per_pkt, sizeof(*req), GFP_KERNEL);
+	if (!req) {
+		ret = -ENOMEM;
+		goto out_free;
+	}
+	resp = kmalloc_array(max_pins_per_pkt, sizeof(*resp), GFP_KERNEL);
+	if (!resp) {
+		ret = -ENOMEM;
+		goto out_free;
+	}
+
+	bitmap_zero(bits, gc->ngpio);
+
+	while (pins_sent < total_pins) {
+		pins_in_pkt = min(max_pins_per_pkt, total_pins - pins_sent);
+
+		for (int i = 0; i < pins_in_pkt; i++) {
+			bit_off = find_next_bit(mask, gc->ngpio, bit_off);
+			req[i].pin = cpu_to_le16(bit_off);
+			bit_off++;
+		}
+
+		ret = lstp_request(ch, LSTP_GPIO_CMD_GET_VALUE, req, pins_in_pkt * sizeof(*req),
+				   resp, pins_in_pkt * sizeof(*resp), NULL, NULL);
+		if (ret) {
+			dev_err(ch->dev, "%s: ch_%d: Could not get values for %d pins (%pe)\n",
+				__func__, ch->ch_id, pins_in_pkt, ERR_PTR(ret));
+			goto out_free;
+		}
+
+		for (int i = 0; i < pins_in_pkt; i++) {
+			if (resp[i].value)
+				__set_bit(le16_to_cpu(req[i].pin), bits);
+		}
+		pins_sent += pins_in_pkt;
+	}
+
+	dev_dbg(ch->dev, "%s: ch_%d: Get %d pins, mask=%*pb, bits=%*pb\n", __func__, ch->ch_id,
+		total_pins, gc->ngpio, mask, gc->ngpio, bits);
+	ret = 0;
+
+out_free:
+	kfree(resp);
+	kfree(req);
+	return ret;
+}
+
+/**
+ * lstp_gpio_set_multiple() - Set multiple GPIO pin output values. (blocking)
+ * @gc:   GPIO chip
+ * @mask: Bitmask of pins to set
+ * @bits: Bitmask of logical output values (0 = low, 1 = high)
+ *
+ * Sends SET_VALUE payloads (pin + logical value per pin), chunked across
+ * multiple packets if the number of pins exceeds what fits in one request.
+ * Each chunk is one LSTP exchange that serializes on the per-channel TX
+ * mutex via lstp_request(); the framework does not bracket the chunks
+ * under a shared lock, so a concurrent reader or writer may observe state
+ * from between two chunks. Matches the gpiolib per-pin fallback contract;
+ * the gpiolib API is silent on cross-call atomicity.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_gpio_set_multiple(struct gpio_chip *gc, unsigned long *mask, unsigned long *bits)
+{
+	struct lstp_gpio_priv *priv = gpiochip_get_data(gc);
+	struct lstp_channel *ch = priv->ch;
+	struct lstp_gpio_set_value_req *req = NULL;
+	int max_pins_per_pkt = ch->max_tx_payload / sizeof(*req);
+	int total_pins = bitmap_weight(mask, gc->ngpio);
+	unsigned int bit_off = 0;
+	int pins_sent = 0;
+	int pins_in_pkt;
+	int ret = 0;
+
+	/* Probe enforces bulk_tx_size >= LSTP_USB_EP_MIN_SIZE; anchor it here. */
+	BUILD_BUG_ON(sizeof(struct lstp_header) + sizeof(*req) > LSTP_USB_EP_MIN_SIZE);
+
+	if (total_pins == 0)
+		goto done;
+
+	if (max_pins_per_pkt < 1) {
+		dev_err(ch->dev, "%s: ch_%d: Payload capacity too small for a single pin\n",
+			__func__, ch->ch_id);
+		ret = -EINVAL;
+		goto done;
+	}
+
+	req = kmalloc_array(max_pins_per_pkt, sizeof(*req), GFP_KERNEL);
+	if (!req) {
+		ret = -ENOMEM;
+		goto done;
+	}
+
+	while (pins_sent < total_pins) {
+		pins_in_pkt = min(max_pins_per_pkt, total_pins - pins_sent);
+
+		for (int i = 0; i < pins_in_pkt; i++) {
+			bit_off = find_next_bit(mask, gc->ngpio, bit_off);
+			req[i].pin = cpu_to_le16(bit_off);
+			req[i].value = test_bit(bit_off, bits) ? 1 : 0;
+			bit_off++;
+		}
+
+		ret = lstp_request(ch, LSTP_GPIO_CMD_SET_VALUE, req, pins_in_pkt * sizeof(*req),
+				   NULL, 0, NULL, NULL);
+		if (ret) {
+			dev_err(ch->dev,
+				"%s: ch_%d: Could not set values for pins (mask=%*pb) (%pe)\n",
+				__func__, ch->ch_id, gc->ngpio, mask, ERR_PTR(ret));
+			goto out_free;
+		}
+		pins_sent += pins_in_pkt;
+	}
+
+	dev_dbg(ch->dev, "%s: ch_%d: Set %d pins, mask=%*pb, bits=%*pb\n", __func__, ch->ch_id,
+		total_pins, gc->ngpio, mask, gc->ngpio, bits);
+
+out_free:
+	kfree(req);
+done:
+	return ret;
+}
+
+/**
+ * lstp_gpio_get_irq_config() - Query IRQ config of a single GPIO. (blocking)
+ * @priv: GPIO channel private data
+ * @pin:  Pin index
+ *
+ * Return: IRQ type on success, negative errno on failure.
+ */
+static int lstp_gpio_get_irq_config(struct lstp_gpio_priv *priv, u16 pin)
+{
+	struct lstp_channel *ch = priv->ch;
+	struct lstp_gpio_get_irq_config_req req = { .pin = cpu_to_le16(pin) };
+	struct lstp_gpio_get_irq_config_resp resp;
+	int ret;
+
+	ret = lstp_request(ch, LSTP_GPIO_CMD_GET_IRQ_CONFIG, &req, sizeof(req), &resp, sizeof(resp),
+			   NULL, NULL);
+	if (ret) {
+		dev_err(ch->dev, "%s: ch_%d: GET_IRQ_CONFIG failed for pin %u (%pe)\n", __func__,
+			ch->ch_id, pin, ERR_PTR(ret));
+		return ret;
+	}
+
+	return resp.irq_type;
+}
+
+/**
+ * lstp_gpio_set_irq_config() - Set IRQ config of a single GPIO. (blocking)
+ * @priv:     GPIO channel private data
+ * @pin:      Pin index
+ * @irq_type: Interrupt type (LSTP_GPIO_IRQ_* constants)
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_gpio_set_irq_config(struct lstp_gpio_priv *priv, u16 pin, u8 irq_type)
+{
+	struct lstp_channel *ch = priv->ch;
+	struct lstp_gpio_set_irq_config_req req = {
+		.pin = cpu_to_le16(pin),
+		.irq_type = irq_type,
+	};
+	int ret;
+
+	ret = lstp_request(ch, LSTP_GPIO_CMD_SET_IRQ_CONFIG, &req, sizeof(req), NULL, 0, NULL,
+			   NULL);
+	if (ret)
+		dev_err(ch->dev, "%s: ch_%d: SET_IRQ_CONFIG failed for pin %u (%pe)\n", __func__,
+			ch->ch_id, pin, ERR_PTR(ret));
+	return ret;
+}
+
+/**
+ * lstp_led_set_pattern() - SET_LED_PATTERN. (blocking)
+ * @led:       LED instance
+ * @repeats:   LSTP_LED_REPEAT_FOREVER or N (play N times, then hold last brightness)
+ * @pattern:   Steps array (NULL iff @num_steps == 0); step.delta_t in ms
+ * @num_steps: Element count of @pattern. 0 clears; 1 holds forever
+ *
+ * Return: 0 on success, negative errno on failure. Returns 0 without I/O when
+ * LED_UNREGISTERING is set (avoids LED-core warnings during unregister).
+ */
+static int lstp_led_set_pattern(struct lstp_gpio_led *led, u32 repeats,
+				const struct led_pattern *pattern, u8 num_steps)
+{
+	struct lstp_gpio_priv *priv = led->priv;
+	struct lstp_channel *ch = priv->ch;
+	struct lstp_gpio_set_led_pattern_req *req;
+	size_t req_len = struct_size(req, pattern, num_steps);
+	unsigned int max_brightness = led->cdev.max_brightness;
+	int ret;
+	u8 i;
+
+	/* Probe enforces bulk_tx_size >= LSTP_USB_EP_MIN_SIZE; anchor base here. */
+	BUILD_BUG_ON(sizeof(struct lstp_header) + sizeof(*req) > LSTP_USB_EP_MIN_SIZE);
+
+	if (led->cdev.flags & LED_UNREGISTERING)
+		return 0;
+
+	for (i = 0; i < num_steps; i++) {
+		if (pattern[i].brightness > max_brightness)
+			return -EINVAL;
+	}
+
+	if (req_len > ch->max_tx_payload) {
+		dev_err(ch->dev,
+			"%s: ch_%d: SET_LED_PATTERN too long for led '%s' (%zu bytes, max %zu)\n",
+			__func__, ch->ch_id, led->cdev.name, req_len, ch->max_tx_payload);
+		return -EMSGSIZE;
+	}
+
+	req = kmalloc(req_len, GFP_KERNEL);
+	if (!req)
+		return -ENOMEM;
+
+	req->pin = cpu_to_le16(led->pin);
+	req->repeats = cpu_to_le32(repeats);
+	req->num_steps = num_steps;
+	for (i = 0; i < num_steps; i++) {
+		req->pattern[i].brightness = (u8)pattern[i].brightness;
+		req->pattern[i].time_ms = cpu_to_le32(pattern[i].delta_t);
+	}
+
+	ret = lstp_request(ch, LSTP_GPIO_CMD_SET_LED_PATTERN, req, req_len, NULL, 0, NULL, NULL);
+	if (ret)
+		dev_err(ch->dev,
+			"%s: ch_%d: SET_LED_PATTERN failed for led '%s' (repeats=%u, num_steps=%u) (%pe)\n",
+			__func__, ch->ch_id, led->cdev.name, repeats, num_steps, ERR_PTR(ret));
+
+	kfree(req);
+	return ret;
+}
+
+/*******************************************************************************
+ * General GPIO functions
+ ******************************************************************************/
+
+/**
+ * lstp_gpio_require_direction() - Require @pin's current device direction.
+ * @priv:      GPIO channel private data
+ * @pin:       Pin index (already bounds-checked by gpiolib via gpio_chip
+ *             ->direction_input/output callers)
+ * @direction: LSTP_GPIO_INPUT or LSTP_GPIO_OUTPUT
+ *
+ * Return: 0 if the current direction matches, -EOPNOTSUPP if the current
+ * direction differs, or another negative errno on transport failure.
+ */
+static int lstp_gpio_require_direction(struct lstp_gpio_priv *priv, unsigned int pin, u8 direction)
+{
+	u8 cur_direction;
+	int ret;
+
+	ret = lstp_gpio_read_direction(priv, pin, &cur_direction);
+	if (ret)
+		return ret;
+
+	if (cur_direction == direction)
+		return 0;
+
+	return -EOPNOTSUPP;
+}
+
+/**
+ * lstp_gpio_get_direction() - Query GPIO pin direction.
+ * @gc:  GPIO chip
+ * @pin: Pin index
+ *
+ * Return: GPIO_LINE_DIRECTION_IN or GPIO_LINE_DIRECTION_OUT on success,
+ * -EINVAL if @pin invalid, or other negative errno on transport failure.
+ */
+static int lstp_gpio_get_direction(struct gpio_chip *gc, unsigned int pin)
+{
+	struct lstp_gpio_priv *priv = gpiochip_get_data(gc);
+	u8 direction;
+	int ret;
+
+	ret = lstp_gpio_read_direction(priv, pin, &direction);
+	if (ret)
+		return ret;
+
+	if (direction == LSTP_GPIO_INPUT)
+		return GPIO_LINE_DIRECTION_IN;
+
+	return GPIO_LINE_DIRECTION_OUT;
+}
+
+/**
+ * lstp_gpio_direction_input() - Accept GPIO as input if already configured so.
+ * @gc:  GPIO chip
+ * @pin: Pin index
+ *
+ * Return: 0 on success, -EINVAL if @pin invalid, -EOPNOTSUPP if the current
+ * device direction differs, or other negative errno on transport failure.
+ */
+static int lstp_gpio_direction_input(struct gpio_chip *gc, unsigned int pin)
+{
+	struct lstp_gpio_priv *priv = gpiochip_get_data(gc);
+
+	return lstp_gpio_require_direction(priv, pin, LSTP_GPIO_INPUT);
+}
+
+/**
+ * lstp_gpio_direction_output() - Accept GPIO as output and set initial value.
+ * @gc:    GPIO chip
+ * @pin:   Pin index
+ * @value: Initial logical output value (0 = low, non-zero = high)
+ *
+ * Return: 0 on success, -EINVAL if @pin invalid, -EOPNOTSUPP if the current
+ * device direction differs, or other negative errno on transport failure.
+ */
+static int lstp_gpio_direction_output(struct gpio_chip *gc, unsigned int pin, int value)
+{
+	struct lstp_gpio_priv *priv = gpiochip_get_data(gc);
+	int ret;
+
+	ret = lstp_gpio_require_direction(priv, pin, LSTP_GPIO_OUTPUT);
+	if (ret)
+		return ret;
+
+	return lstp_gpio_set_value(gc, pin, value);
+}
+
+/*******************************************************************************
+ * GPIO IRQ functions
+ ******************************************************************************/
+
+/**
+ * lstp_gpio_linux_irq_to_lstp() - Map Linux IRQ type to LSTP IRQ type.
+ * @type:     Linux IRQ type (IRQ_TYPE_EDGE_*, IRQ_TYPE_LEVEL_*)
+ * @irq_type: Output LSTP IRQ type
+ *
+ * Return: 0 on success, -EINVAL if type unsupported.
+ */
+static int lstp_gpio_linux_irq_to_lstp(unsigned int type, u8 *irq_type)
+{
+	switch (type & IRQ_TYPE_SENSE_MASK) {
+	case IRQ_TYPE_NONE:
+		*irq_type = LSTP_GPIO_IRQ_NONE;
+		break;
+	case IRQ_TYPE_EDGE_RISING:
+		*irq_type = LSTP_GPIO_IRQ_RISING;
+		break;
+	case IRQ_TYPE_EDGE_FALLING:
+		*irq_type = LSTP_GPIO_IRQ_FALLING;
+		break;
+	case IRQ_TYPE_EDGE_BOTH:
+		*irq_type = LSTP_GPIO_IRQ_BOTH;
+		break;
+	case IRQ_TYPE_LEVEL_HIGH:
+		*irq_type = LSTP_GPIO_IRQ_HIGH;
+		break;
+	case IRQ_TYPE_LEVEL_LOW:
+		*irq_type = LSTP_GPIO_IRQ_LOW;
+		break;
+	default:
+		return -EINVAL;
+	}
+	return 0;
+}
+
+/**
+ * lstp_gpio_irq_event_matches() - Check whether a wire event matches IRQ config.
+ * @irq_type: Committed LSTP_GPIO_IRQ_* type for the pin (hw_irq_type)
+ * @value:    Logical line level reported with the event
+ *
+ * Host-side defense against stale batches or firmware that skips filtering.
+ */
+static bool lstp_gpio_irq_event_matches(u8 irq_type, u8 value)
+{
+	switch (irq_type) {
+	case LSTP_GPIO_IRQ_NONE:
+		return false;
+	case LSTP_GPIO_IRQ_RISING:
+		return value == LSTP_GPIO_HIGH;
+	case LSTP_GPIO_IRQ_FALLING:
+		return value == LSTP_GPIO_LOW;
+	case LSTP_GPIO_IRQ_BOTH:
+		return true;
+	case LSTP_GPIO_IRQ_HIGH:
+		return value == LSTP_GPIO_HIGH;
+	case LSTP_GPIO_IRQ_LOW:
+		return value == LSTP_GPIO_LOW;
+	default:
+		return false;
+	}
+}
+
+/**
+ * lstp_gpio_sync_hw_irq_state() - Read device IRQ state for all GPIO lines at probe time.
+ * @priv: GPIO channel private data (shadow_irq_type and hw_irq_type must be
+ *        allocated)
+ *
+ * Queries GET_IRQ_CONFIG for each gpiochip line and populates both hw_irq_type
+ * and shadow_irq_type so the driver starts in sync with the device, even after
+ * a module reload without a device reset.
+ *
+ * Return: 0 on success, negative errno on first failure.
+ */
+static int lstp_gpio_sync_hw_irq_state(struct lstp_gpio_priv *priv)
+{
+	struct lstp_channel *ch = priv->ch;
+	unsigned int active = 0;
+	unsigned int pin;
+	int ret;
+
+	for (pin = 0; pin < priv->npins; pin++) {
+		if (priv->leds[pin])
+			continue;
+
+		ret = lstp_gpio_get_irq_config(priv, pin);
+		if (ret < 0)
+			return ret;
+		if (ret > LSTP_GPIO_IRQ_MAX)
+			dev_warn(ch->dev, "%s: ch_%d: pin %u has unknown IRQ type %u\n", __func__,
+				 ch->ch_id, pin, ret);
+		priv->hw_irq_type[pin] = ret;
+		priv->shadow_irq_type[pin] = ret;
+		if (ret != LSTP_GPIO_IRQ_NONE)
+			active++;
+	}
+
+	if (active)
+		dev_info(ch->dev,
+			 "%s: ch_%d: Synced IRQ state, %u/%u pins with active IRQ config\n",
+			 __func__, ch->ch_id, active, priv->ngpio);
+
+	return 0;
+}
+
+/**
+ * lstp_gpio_irq_mask() - Mask (disable) a GPIO interrupt.
+ * @d: IRQ data
+ *
+ * Sets shadow to IRQ_NONE; SET_IRQ_CONFIG sent in irq_bus_sync_unlock().
+ */
+static void lstp_gpio_irq_mask(struct irq_data *d)
+{
+	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+	struct lstp_gpio_priv *priv = gpiochip_get_data(gc);
+	unsigned int pin = irqd_to_hwirq(d);
+
+	priv->shadow_irq_type[pin] = LSTP_GPIO_IRQ_NONE;
+	gpiochip_disable_irq(gc, pin);
+}
+
+/**
+ * lstp_gpio_irq_unmask() - Unmask (enable) a GPIO interrupt.
+ * @d: IRQ data
+ *
+ * Restores shadow to trigger type from IRQ descriptor.
+ * SET_IRQ_CONFIG sent in irq_bus_sync_unlock().
+ */
+static void lstp_gpio_irq_unmask(struct irq_data *d)
+{
+	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+	struct lstp_gpio_priv *priv = gpiochip_get_data(gc);
+	unsigned int pin = irqd_to_hwirq(d);
+	unsigned int type = irqd_get_trigger_type(d);
+	u8 irq_type;
+
+	if (lstp_gpio_linux_irq_to_lstp(type, &irq_type)) {
+		dev_err(gc->parent, "%s: Invalid trigger type %u for gpio %u\n", __func__, type,
+			pin);
+		return;
+	}
+
+	gpiochip_enable_irq(gc, pin);
+	priv->shadow_irq_type[pin] = irq_type;
+}
+
+/**
+ * lstp_gpio_irq_set_type() - Set GPIO interrupt trigger type.
+ * @d:    IRQ data
+ * @type: IRQ type flags (IRQ_TYPE_EDGE_*, IRQ_TYPE_LEVEL_*)
+ *
+ * IRQCHIP_SET_TYPE_MASKED ensures the IRQ is masked, so this only validates
+ * the type; the shadow update is deferred to irq_unmask().
+ *
+ * Return: 0 on success, -EINVAL if type unsupported.
+ */
+static int lstp_gpio_irq_set_type(struct irq_data *d, unsigned int type)
+{
+	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+	struct lstp_gpio_priv *priv = gpiochip_get_data(gc);
+	unsigned int pin = irqd_to_hwirq(d);
+	u8 irq_type;
+	int ret;
+
+	ret = lstp_gpio_linux_irq_to_lstp(type, &irq_type);
+	if (ret)
+		return ret;
+
+	if (irqd_irq_masked(d))
+		return 0;
+
+	priv->shadow_irq_type[pin] = irq_type;
+	return 0;
+}
+
+/**
+ * lstp_gpio_irq_bus_lock() - Acquire IRQ configuration lock.
+ * @d: IRQ data
+ *
+ * Serializes irq_chip callbacks in a sleepable context (bus_lock pattern).
+ */
+static void lstp_gpio_irq_bus_lock(struct irq_data *d)
+{
+	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+	struct lstp_gpio_priv *priv = gpiochip_get_data(gc);
+
+	mutex_lock(&priv->irq_lock);
+}
+
+/**
+ * lstp_gpio_irq_bus_sync_unlock() - Commit pending IRQ config and release lock.
+ * @d: IRQ data for the pin that was modified
+ *
+ * Sends SET_IRQ_CONFIG if shadow differs from hardware for this pin.
+ * On failure, reverts shadow to previous known state. Releases priv->irq_lock.
+ */
+static void lstp_gpio_irq_bus_sync_unlock(struct irq_data *d)
+{
+	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+	struct lstp_gpio_priv *priv = gpiochip_get_data(gc);
+	u16 pin = irqd_to_hwirq(d);
+
+	if (priv->shadow_irq_type[pin] != priv->hw_irq_type[pin]) {
+		if (lstp_gpio_set_irq_config(priv, pin, priv->shadow_irq_type[pin]))
+			priv->shadow_irq_type[pin] = priv->hw_irq_type[pin];
+		else
+			priv->hw_irq_type[pin] = priv->shadow_irq_type[pin];
+	}
+
+	mutex_unlock(&priv->irq_lock);
+}
+
+/**
+ * lstp_gpio_irq_print_chip() - Print GPIO chip label in /proc/interrupts.
+ * @d: IRQ data
+ * @p: Seq file to write to
+ */
+static void lstp_gpio_irq_print_chip(struct irq_data *d, struct seq_file *p)
+{
+	struct gpio_chip *gc = irq_data_get_irq_chip_data(d);
+
+	seq_puts(p, gc->label ? gc->label : d->chip->name);
+}
+
+static const struct irq_chip lstp_gpio_irq_chip = {
+	.name = "lstp-gpio",
+	.irq_mask = lstp_gpio_irq_mask,
+	.irq_unmask = lstp_gpio_irq_unmask,
+	.irq_set_type = lstp_gpio_irq_set_type,
+	.irq_bus_lock = lstp_gpio_irq_bus_lock,
+	.irq_bus_sync_unlock = lstp_gpio_irq_bus_sync_unlock,
+	.irq_print_chip = lstp_gpio_irq_print_chip,
+	.flags = IRQCHIP_SET_TYPE_MASKED | IRQCHIP_MASK_ON_SUSPEND | IRQCHIP_IMMUTABLE,
+	GPIOCHIP_IRQ_RESOURCE_HELPERS,
+};
+
+/**
+ * lstp_gpio_irq_event_work() - Deferred GPIO interrupt batch handler.
+ * @work: Work structure containing a snapshot of one unsolicited RX payload
+ *
+ * Delivers matching events in payload order via handle_nested_irq();
+ * synchronize_irq() after each keeps threaded handlers from reordering.
+ * The ordered workqueue serializes batches in USB receive order.
+ */
+static void lstp_gpio_irq_event_work(struct work_struct *work)
+{
+	struct lstp_gpio_irq_event_work *batch =
+		container_of(work, struct lstp_gpio_irq_event_work, work);
+	struct lstp_gpio_priv *priv = batch->priv;
+	struct lstp_channel *ch = priv->ch;
+	struct gpio_chip *gc = &priv->gc;
+	const struct lstp_gpio_irq_event_req *event;
+	const struct lstp_gpio_irq_event_req *end;
+	u16 pin;
+	u8 value;
+	int irq;
+
+	/* Probe enforces bulk_rx_size >= LSTP_USB_EP_MIN_SIZE; anchor base here. */
+	BUILD_BUG_ON(sizeof(struct lstp_header) + sizeof(*event) > LSTP_USB_EP_MIN_SIZE);
+
+	if (batch->payload_len < sizeof(*event)) {
+		dev_err(ch->dev, "%s: ch_%d: IRQ event packet too small (got %u, need >=%zu)\n",
+			__func__, ch->ch_id, batch->payload_len, sizeof(*event));
+		goto out;
+	}
+
+	if (batch->payload_len % sizeof(*event)) {
+		dev_err(ch->dev,
+			"%s: ch_%d: Malformed IRQ event payload (len %u, record size %zu)\n",
+			__func__, ch->ch_id, batch->payload_len, sizeof(*event));
+		goto out;
+	}
+
+	end = (void *)(batch->payload + batch->payload_len);
+	for (event = (void *)batch->payload; event < end; event++) {
+		pin = le16_to_cpu(event->pin);
+		if (pin >= priv->npins || priv->leds[pin]) {
+			dev_warn_ratelimited(ch->dev, "%s: ch_%d: IRQ on non-GPIO pin %u\n",
+					     __func__, ch->ch_id, pin);
+			continue;
+		}
+
+		value = event->value;
+		dev_dbg(ch->dev, "%s: ch=%d: IRQ event: pin=%u, value=%u\n", __func__, ch->ch_id,
+			pin, value);
+
+		if (!lstp_gpio_irq_event_matches(priv->hw_irq_type[pin], value)) {
+			dev_dbg(gc->parent, "%s: Skipping pin %u value %u (irq_type %u)\n",
+				__func__, pin, value, priv->hw_irq_type[pin]);
+			continue;
+		}
+
+		if (!gc->irq.domain) {
+			dev_warn_ratelimited(gc->parent, "%s: IRQ domain not ready for pin %u\n",
+					     __func__, pin);
+			continue;
+		}
+
+		irq = irq_find_mapping(gc->irq.domain, pin);
+		if (irq) {
+			handle_nested_irq(irq);
+			synchronize_irq(irq);
+			dev_dbg(gc->parent, "%s: Nested IRQ %d handled for pin %u\n", __func__, irq,
+				pin);
+		} else {
+			dev_warn_ratelimited(gc->parent, "%s: No IRQ mapping found for pin %u\n",
+					     __func__, pin);
+		}
+	}
+
+out:
+	kfree(batch);
+}
+
+/**
+ * lstp_gpio_irq_event() - Process GPIO interrupt event from unsolicited RX packet.
+ * @ch:  LSTP channel that received the request.
+ * @pkt: Received LSTP packet (header + payload).
+ *
+ * Copies the payload out of @pkt and returns immediately so USB RX can
+ * dequeue the next packet. All GPIO-specific validation and ordered delivery run
+ * in the ordered workqueue handler. Must not block (atomic context).
+ */
+static void lstp_gpio_irq_event(struct lstp_channel *ch, struct lstp_packet *pkt)
+{
+	struct lstp_gpio_priv *priv = ch->priv;
+	struct lstp_gpio_irq_event_work *batch;
+	u16 payload_len;
+
+	if (!priv) {
+		dev_err(ch->dev, "%s: ch_%d: No GPIO private data found in channel\n", __func__,
+			ch->ch_id);
+		return;
+	}
+
+	payload_len = le16_to_cpu(pkt->hdr.length);
+	if (!payload_len)
+		return;
+
+	if (payload_len > ch->max_rx_payload) {
+		dev_warn_ratelimited(ch->dev,
+				     "%s: ch_%d: Dropping IRQ payload too large (%u > %zu bytes)\n",
+				     __func__, ch->ch_id, payload_len, ch->max_rx_payload);
+		return;
+	}
+
+	batch = kzalloc(struct_size(batch, payload, payload_len), GFP_ATOMIC);
+	if (!batch)
+		return;
+
+	batch->priv = priv;
+	batch->payload_len = payload_len;
+	memcpy(batch->payload, pkt->payload, payload_len);
+
+	INIT_WORK(&batch->work, lstp_gpio_irq_event_work);
+	if (!queue_work(priv->wq, &batch->work)) {
+		dev_warn(ch->dev, "%s: ch_%d: Failed to queue IRQ event work (%u bytes)\n",
+			 __func__, ch->ch_id, payload_len);
+		kfree(batch);
+	}
+}
+
+/*******************************************************************************
+ * LED class functions
+ ******************************************************************************/
+
+/**
+ * lstp_led_blink_set() - blink_set callback. (blocking)
+ * @cdev:      LED class device
+ * @delay_on:  in/out; on-time in ms (0 -> hold OFF; 0/0 -> 500 ms default)
+ * @delay_off: in/out; off-time in ms (0 -> hold ON; 0/0 -> 500 ms default)
+ *
+ * On-brightness uses @cdev->brightness if non-zero, else @cdev->max_brightness.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_led_blink_set(struct led_classdev *cdev, unsigned long *delay_on,
+			      unsigned long *delay_off)
+{
+	struct lstp_gpio_led *led = container_of(cdev, struct lstp_gpio_led, cdev);
+	u8 on_value = cdev->brightness ? (u8)cdev->brightness : (u8)cdev->max_brightness;
+	struct led_pattern steps[2];
+	u8 len;
+
+	if (*delay_on == 0 && *delay_off == 0) {
+		*delay_on = LSTP_LED_DEFAULT_BLINK_MS;
+		*delay_off = LSTP_LED_DEFAULT_BLINK_MS;
+	}
+
+	if (*delay_on == 0) {
+		steps[0].delta_t = LSTP_LED_DEFAULT_HOLD_TIME_MS;
+		steps[0].brightness = LED_OFF;
+		len = 1;
+	} else if (*delay_off == 0) {
+		steps[0].delta_t = LSTP_LED_DEFAULT_HOLD_TIME_MS;
+		steps[0].brightness = on_value;
+		len = 1;
+	} else {
+		steps[0].delta_t = *delay_on;
+		steps[0].brightness = on_value;
+		steps[1].delta_t = *delay_off;
+		steps[1].brightness = LED_OFF;
+		len = 2;
+	}
+	return lstp_led_set_pattern(led, LSTP_LED_REPEAT_FOREVER, steps, len);
+}
+
+/**
+ * lstp_led_pattern_set() - pattern_set callback. (blocking)
+ * @cdev:    LED class device
+ * @pattern: Array of @len steps (delta_t in ms, brightness)
+ * @len:     Number of steps (must fit wire's u8 num_steps)
+ * @repeat:  LSTP_LED_LINUX_REPEAT_FOREVER or N >= 1; anything else is invalid
+ *
+ * Return: 0 on success, -EMSGSIZE if @len exceeds u8, -EINVAL on invalid
+ * @repeat, negative errno on other failure.
+ */
+static int lstp_led_pattern_set(struct led_classdev *cdev, struct led_pattern *pattern, u32 len,
+				int repeat)
+{
+	struct lstp_gpio_led *led = container_of(cdev, struct lstp_gpio_led, cdev);
+	u32 mapped_repeat;
+
+	if (len > U8_MAX)
+		return -EMSGSIZE;
+	if (repeat == 0 || repeat < LSTP_LED_LINUX_REPEAT_FOREVER)
+		return -EINVAL;
+	mapped_repeat = (repeat == LSTP_LED_LINUX_REPEAT_FOREVER) ? LSTP_LED_REPEAT_FOREVER :
+								    (u32)repeat;
+	return lstp_led_set_pattern(led, mapped_repeat, pattern, (u8)len);
+}
+
+/**
+ * lstp_led_pattern_clear() - pattern_clear callback. (blocking)
+ * @cdev: LED class device
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_led_pattern_clear(struct led_classdev *cdev)
+{
+	struct lstp_gpio_led *led = container_of(cdev, struct lstp_gpio_led, cdev);
+
+	return lstp_led_set_pattern(led, LSTP_LED_REPEAT_FOREVER, NULL, 0);
+}
+
+/**
+ * lstp_led_brightness_set_blocking() - brightness_set_blocking callback. (blocking)
+ * @cdev:       LED class device
+ * @brightness: Already clamped by LED core to @cdev->max_brightness
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_led_brightness_set_blocking(struct led_classdev *cdev,
+					    enum led_brightness brightness)
+{
+	struct lstp_gpio_led *led = container_of(cdev, struct lstp_gpio_led, cdev);
+	struct led_pattern step = { .delta_t = LSTP_LED_DEFAULT_HOLD_TIME_MS,
+				    .brightness = brightness };
+
+	return lstp_led_set_pattern(led, LSTP_LED_REPEAT_FOREVER, &step, 1);
+}
+
+/*******************************************************************************
+ * GPIO channel initialization
+ ******************************************************************************/
+
+/**
+ * lstp_gpio_pin_is_led() - Return whether @led_support marks a pin as LED.
+ * @led_support: led_support byte from pin config
+ *
+ * HOLD and INTERPOLATE differ only in device-side rendering; the host treats both
+ * as LED pins, excluded from the gpiochip.
+ */
+static bool lstp_gpio_pin_is_led(u8 led_support)
+{
+	return led_support == LSTP_GPIO_LED_MODE_HOLD ||
+	       led_support == LSTP_GPIO_LED_MODE_INTERPOLATE;
+}
+
+/**
+ * lstp_gpio_clear_led_valid_mask() - Clear LED pins from a valid mask.
+ * @priv:       GPIO channel private data
+ * @valid_mask: Pre-filled bitmap of length @ngpios
+ * @ngpios:     Number of lines on the chip (priv->npins)
+ */
+static void lstp_gpio_clear_led_valid_mask(struct lstp_gpio_priv *priv, unsigned long *valid_mask,
+					   unsigned int ngpios)
+{
+	unsigned int i;
+
+	for (i = 0; i < ngpios; i++) {
+		if (priv->leds[i])
+			clear_bit(i, valid_mask);
+	}
+}
+
+/**
+ * lstp_gpio_init_valid_mask() - gpio_chip callback to mark LED pins invalid.
+ * @gc:         GPIO chip
+ * @valid_mask: Pre-filled bitmap of length @ngpios
+ * @ngpios:     Number of lines on the chip (priv->npins)
+ *
+ * Return: 0.
+ */
+static int lstp_gpio_init_valid_mask(struct gpio_chip *gc, unsigned long *valid_mask,
+				     unsigned int ngpios)
+{
+	lstp_gpio_clear_led_valid_mask(gpiochip_get_data(gc), valid_mask, ngpios);
+	return 0;
+}
+
+/**
+ * lstp_gpio_irq_init_valid_mask() - gpio_irq_chip callback to mark LED pins invalid.
+ * @gc:         GPIO chip
+ * @valid_mask: Pre-filled bitmap of length @ngpios
+ * @ngpios:     Number of lines on the chip (priv->npins)
+ */
+static void lstp_gpio_irq_init_valid_mask(struct gpio_chip *gc, unsigned long *valid_mask,
+					  unsigned int ngpios)
+{
+	lstp_gpio_clear_led_valid_mask(gpiochip_get_data(gc), valid_mask, ngpios);
+}
+
+/**
+ * lstp_gpio_destroy_wq() - Devres callback to destroy the GPIO IRQ workqueue.
+ * @wq: Workqueue to destroy
+ */
+static void lstp_gpio_destroy_wq(void *wq)
+{
+	destroy_workqueue(wq);
+}
+
+/**
+ * lstp_gpio_create_gpiochip() - Initialize gpio_chip.
+ * @priv: GPIO channel private data (ch, npins, and pin_names must be set)
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_gpio_create_gpiochip(struct lstp_gpio_priv *priv)
+{
+	struct lstp_channel *ch = priv->ch;
+	struct device *dev = ch->dev;
+	struct gpio_chip *gc = &priv->gc;
+
+	gc->label = ch->display_name;
+	gc->owner = THIS_MODULE;
+	gc->names = priv->pin_names;
+	gc->base = -1;
+	gc->ngpio = priv->npins;
+	gc->get = lstp_gpio_get_value;
+	gc->set = lstp_gpio_set_value;
+	gc->can_sleep = true;
+	gc->get_multiple = lstp_gpio_get_multiple;
+	gc->set_multiple = lstp_gpio_set_multiple;
+	gc->get_direction = lstp_gpio_get_direction;
+	gc->direction_input = lstp_gpio_direction_input;
+	gc->direction_output = lstp_gpio_direction_output;
+	gc->init_valid_mask = lstp_gpio_init_valid_mask;
+	gc->parent = dev;
+
+	if (ch->fwnode)
+		gc->fwnode = ch->fwnode;
+
+	return 0;
+}
+
+/**
+ * lstp_gpio_create_irq_chip() - Allocate IRQ state and initialize gpio_irq_chip.
+ * @priv: GPIO channel private data
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_gpio_create_irq_chip(struct lstp_gpio_priv *priv)
+{
+	struct lstp_channel *ch = priv->ch;
+	struct device *dev = ch->dev;
+	struct gpio_chip *gc = &priv->gc;
+	struct gpio_irq_chip *girq = &gc->irq;
+	int ret;
+
+	if (!priv->ngpio)
+		return 0;
+
+	priv->shadow_irq_type =
+		devm_kcalloc(dev, priv->npins, sizeof(*priv->shadow_irq_type), GFP_KERNEL);
+	if (!priv->shadow_irq_type)
+		return -ENOMEM;
+
+	priv->hw_irq_type = devm_kcalloc(dev, priv->npins, sizeof(*priv->hw_irq_type), GFP_KERNEL);
+	if (!priv->hw_irq_type)
+		return -ENOMEM;
+
+	gpio_irq_chip_set_chip(girq, &lstp_gpio_irq_chip);
+	girq->init_valid_mask = lstp_gpio_irq_init_valid_mask;
+	girq->parent_handler = NULL;
+	girq->num_parents = 0;
+	girq->parents = NULL;
+	girq->default_type = IRQ_TYPE_NONE;
+	girq->handler = handle_simple_irq;
+	girq->threaded = true;
+
+	mutex_init(&priv->irq_lock);
+
+	priv->wq = alloc_ordered_workqueue("lstp_gpio_wq", 0);
+	if (!priv->wq) {
+		dev_err(dev, "%s: ch_%d: Failed to create ordered IRQ workqueue\n", __func__,
+			ch->ch_id);
+		return -ENOMEM;
+	}
+
+	ret = devm_add_action_or_reset(dev, lstp_gpio_destroy_wq, priv->wq);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+/**
+ * lstp_gpio_create_led() - Create an LED cdev for a pin at probe.
+ * @priv:        GPIO private data
+ * @pin:         Pin index
+ * @name:        Sysfs name (caller-owned for channel lifetime; do not free)
+ * @direction:   Direction byte from the pin's config
+ * @led_support: LED support byte from the pin's config
+ *
+ * Allocate an LED cdev for output + HOLD/INTERPOLATE pins. Register in lstp_gpio_register_led().
+ *
+ * Return: 0 on success; -EINVAL if LED config is rejected (caller falls back to GPIO);
+ * -ENOMEM on allocation failure.
+ */
+static int lstp_gpio_create_led(struct lstp_gpio_priv *priv, u16 pin, const char *name,
+				u8 direction, u8 led_support)
+{
+	struct lstp_channel *ch = priv->ch;
+	struct device *parent = ch->dev;
+	struct lstp_gpio_led *led;
+
+	if (!lstp_gpio_pin_is_led(led_support))
+		return -EINVAL;
+
+	if (direction != LSTP_GPIO_OUTPUT) {
+		dev_warn(parent,
+			 "%s: ch_%d: led_support=0x%02x for pin %u but direction is input, treating as GPIO\n",
+			 __func__, ch->ch_id, led_support, pin);
+		return -EINVAL;
+	}
+	if (priv->leds[pin]) {
+		dev_dbg(parent, "%s: ch_%d: LED '%s', pin %u already created, skipping\n", __func__,
+			ch->ch_id, priv->leds[pin]->cdev.name, pin);
+		return 0;
+	}
+
+	led = devm_kzalloc(parent, sizeof(*led), GFP_KERNEL);
+	if (!led)
+		return -ENOMEM;
+
+	led->priv = priv;
+	led->pin = pin;
+	led->cdev.name = name;
+	led->cdev.max_brightness = U8_MAX;
+	led->cdev.brightness_set_blocking = lstp_led_brightness_set_blocking;
+	led->cdev.blink_set = lstp_led_blink_set;
+	led->cdev.pattern_set = lstp_led_pattern_set;
+	led->cdev.pattern_clear = lstp_led_pattern_clear;
+
+	priv->leds[pin] = led;
+	dev_dbg(parent, "%s: ch_%d: Created LED '%s'\n", __func__, ch->ch_id, name);
+	return 0;
+}
+
+/**
+ * lstp_gpio_register_led() - Register @pin's LED with the LED class core.
+ * @priv: GPIO private data
+ * @pin:  Pin index
+ *
+ * Best-effort: skips if no cdev or already registered. Registration is
+ * devres-managed; on failure logs and LED stays unregistered.
+ *
+ * Return: 0 on success or nothing to register; negative errno on failure.
+ */
+static int lstp_gpio_register_led(struct lstp_gpio_priv *priv, unsigned int pin)
+{
+	struct device *parent = priv->ch->dev;
+	int ret;
+
+	if (pin >= priv->npins || !priv->leds[pin] || priv->leds[pin]->cdev.dev)
+		return 0;
+
+	ret = devm_led_classdev_register(parent, &priv->leds[pin]->cdev);
+	if (ret)
+		dev_warn(parent, "%s: ch_%d: Could not register LED '%s', pin %u (%pe)\n", __func__,
+			 priv->ch->ch_id, priv->leds[pin]->cdev.name, pin, ERR_PTR(ret));
+	return ret;
+}
+
+/**
+ * lstp_gpio_pin_setup_on_entry() - Classify a config entry as GPIO or LED.
+ * @ch:    LSTP channel
+ * @pin:   Pin index
+ * @entry: Config entry (struct lstp_gpio_pin)
+ * @ctx:   GPIO channel private data (struct lstp_gpio_priv)
+ *
+ * Return: 0 on success.
+ */
+static int lstp_gpio_pin_setup_on_entry(struct lstp_channel *ch, unsigned int pin,
+					const void *entry, void *ctx)
+{
+	struct lstp_gpio_priv *priv = ctx;
+	const struct lstp_gpio_pin *pin_cfg = entry;
+	char *name;
+	u8 led_support = pin_cfg->config.led_support;
+	int ret;
+
+	name = devm_kzalloc(ch->dev, GPIO_MAX_NAME_SIZE, GFP_KERNEL);
+	if (!name)
+		return -ENOMEM;
+	snprintf(name, GPIO_MAX_NAME_SIZE, "%.*s", (int)LSTP_GPIO_PIN_NAME_LEN, pin_cfg->pin_name);
+	priv->pin_names[pin] = name;
+
+	if (lstp_gpio_pin_is_led(led_support)) {
+		ret = lstp_gpio_create_led(priv, pin, name, pin_cfg->config.direction, led_support);
+		if (ret == -ENOMEM)
+			return ret;
+		if (!ret) {
+			priv->nleds++;
+			return 0;
+		}
+		/* LED config rejected (create_led logged why); fall back to GPIO. */
+	} else if (led_support != LSTP_GPIO_NOT_LED) {
+		dev_warn(ch->dev,
+			 "%s: ch_%d: Unknown led_support=0x%02x for pin %u, treating as GPIO\n",
+			 __func__, ch->ch_id, led_support, pin);
+	}
+
+	priv->ngpio++;
+	return 0;
+}
+
+/**
+ * lstp_gpio_init() - Initialize GPIO channel.
+ * @ch:   LSTP channel configured for GPIO
+ * @info: Channel config blob (struct lstp_gpio_config)
+ *
+ * Sets up the gpio_chip and irq_chip and classifies each configured pin as a
+ * GPIO or an LED. Does not register the chip; call lstp_gpio_start() once the
+ * RX URB is active.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_gpio_init(struct lstp_channel *ch, const struct lstp_channel_init_info *info)
+{
+	int ret;
+	struct lstp_gpio_priv *priv;
+	const struct lstp_gpio_config *config = info->config;
+
+	if (info->config_len < sizeof(*config)) {
+		dev_err(ch->dev, "%s: ch_%d: GPIO config too short: %zu < %zu\n", __func__,
+			ch->ch_id, info->config_len, sizeof(*config));
+		return -EINVAL;
+	}
+	if (config->npins == 0) {
+		dev_err(ch->dev, "%s: ch_%d: Invalid npins of 0\n", __func__, ch->ch_id);
+		return -EINVAL;
+	}
+
+	priv = devm_kzalloc(ch->dev, sizeof(*priv), GFP_KERNEL);
+	if (!priv)
+		return -ENOMEM;
+
+	priv->pin_names =
+		devm_kcalloc(ch->dev, config->npins, sizeof(*priv->pin_names), GFP_KERNEL);
+	if (!priv->pin_names)
+		return -ENOMEM;
+
+	priv->leds = devm_kcalloc(ch->dev, config->npins, sizeof(*priv->leds), GFP_KERNEL);
+	if (!priv->leds)
+		return -ENOMEM;
+
+	priv->ch = ch;
+	priv->npins = config->npins;
+	ch->priv = priv;
+
+	/* Truncate display_name to fit GPIO_MAX_NAME_SIZE (32 bytes including '\0') */
+	if (strlen(ch->display_name) >= GPIO_MAX_NAME_SIZE) {
+		dev_warn(ch->dev, "%s: ch_%d: display_name truncated to '%.*s' (max %d chars)\n",
+			 __func__, ch->ch_id, GPIO_MAX_NAME_SIZE - 1, ch->display_name,
+			 GPIO_MAX_NAME_SIZE - 1);
+		ch->display_name[GPIO_MAX_NAME_SIZE - 1] = '\0';
+	}
+
+	ret = lstp_gpio_create_gpiochip(priv);
+	if (ret)
+		return ret;
+
+	/* Setup all pins from device config */
+	ret = lstp_read_config_table(ch, sizeof(struct lstp_gpio_config),
+				     sizeof(struct lstp_gpio_pin), priv->npins,
+				     lstp_gpio_pin_setup_on_entry, priv);
+	if (ret) {
+		dev_err(ch->dev, "%s: ch_%d: Could not setup pins (%pe)\n", __func__, ch->ch_id,
+			ERR_PTR(ret));
+		return ret;
+	}
+	if (priv->ngpio == 0 && priv->nleds == 0) {
+		dev_err(ch->dev, "%s: ch_%d: No GPIO or LED pins discovered\n", __func__,
+			ch->ch_id);
+		return -EINVAL;
+	}
+
+	ret = lstp_gpio_create_irq_chip(priv);
+	if (ret)
+		return ret;
+
+	dev_dbg(ch->dev, "%s: ch_%d: Initialized as %s\n", __func__, ch->ch_id, priv->gc.label);
+	return 0;
+}
+
+/**
+ * lstp_gpio_start() - Register GPIO chip and LED cdevs with kernel.
+ * @ch: LSTP channel (from lstp_gpio_init)
+ *
+ * Register gpiochip and probe-time LED cdevs. LED classdevs are devres-managed
+ * and unregister on interface release.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_gpio_start(struct lstp_channel *ch)
+{
+	int ret;
+	struct lstp_gpio_priv *priv = ch->priv;
+	struct gpio_chip *gc;
+	unsigned int pin;
+
+	if (!priv) {
+		dev_err(ch->dev, "%s: ch_%d: GPIO chip not initialized\n", __func__, ch->ch_id);
+		return -EINVAL;
+	}
+
+	gc = &priv->gc;
+
+	if (priv->ngpio) {
+		ret = lstp_gpio_sync_hw_irq_state(priv);
+		if (ret)
+			return ret;
+
+		ret = gpiochip_add_data(gc, priv);
+		if (ret) {
+			dev_err(ch->dev, "%s: ch_%d: Could not register GPIO chip (%pe)\n",
+				__func__, ch->ch_id, ERR_PTR(ret));
+			return ret;
+		}
+
+		deprecated_lstp_channel_publish_child_dev(ch, gpio_device_to_device(gc->gpiodev));
+	}
+
+	for (pin = 0; pin < priv->npins; pin++)
+		lstp_gpio_register_led(priv, pin);
+
+	/*
+	 * The channel's "device" symlink needs a target. A GPIO channel points
+	 * it at the gpiochip (above); a pure-LED channel has no gpiochip, so
+	 * link the first registered LED instead. The single-peer link cannot
+	 * name every LED, but some target is required: the framework warns when
+	 * a channel exposes no device.
+	 */
+	for (pin = 0; !priv->ngpio && pin < priv->npins; pin++) {
+		if (priv->leds[pin] && priv->leds[pin]->cdev.dev) {
+			deprecated_lstp_channel_publish_child_dev(ch, priv->leds[pin]->cdev.dev);
+			break;
+		}
+	}
+
+	dev_info(ch->dev, "%s: ch_%d: Started as %s with %u GPIOs and %u LEDs\n", __func__,
+		 ch->ch_id, gc->label, priv->ngpio, priv->nleds);
+	return 0;
+}
+
+/**
+ * lstp_gpio_stop() - Tear down the GPIO channel.
+ * @ch: LSTP channel previously started by lstp_gpio_start()
+ *
+ * Drains pending IRQ-event work, then unregisters the gpio_chip.
+ */
+static void lstp_gpio_stop(struct lstp_channel *ch)
+{
+	struct lstp_gpio_priv *priv = ch->priv;
+
+	if (!priv)
+		return;
+
+	/* Drain RX-queued IRQ-event work while gc->irq.domain is still valid. */
+	if (priv->wq)
+		flush_workqueue(priv->wq);
+
+	if (priv->ngpio)
+		gpiochip_remove(&priv->gc);
+}
+
+/* clang-format off */
+LSTP_SUBSYS(gpio, LSTP_CHANNEL_TYPE_GPIO, lstp_gpio_init, lstp_gpio_start,
+	    .fwnode_compatible = "nvidia,lstp-gpio",
+	    .irq_callback = lstp_gpio_irq_event,
+	    .channel_stop = lstp_gpio_stop,
+);
+/* clang-format on */

--- a/drivers/usb/misc/lstp/lstp-i2c.c
+++ b/drivers/usb/misc/lstp/lstp-i2c.c
@@ -1,0 +1,812 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * I2C driver for LSTP USB interface.
+ *
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+#include <linux/i2c.h>
+#include <linux/err.h>
+#include <linux/overflow.h>
+#include <linux/version.h>
+
+#include "lstp-main.h"
+
+enum lstp_i2c_cmd {
+	LSTP_I2C_CMD_BUS_RECOVERY = 0x00,
+	LSTP_I2C_CMD_READ = 0x01,
+	LSTP_I2C_CMD_WRITE = 0x02,
+	LSTP_I2C_CMD_READ_RECVLEN_DEPRECATED = 0x03, /* Do not use */
+	LSTP_I2C_CMD_WRITE_READ = 0x04,
+	LSTP_I2C_CMD_SMBUS_BLOCK_READ = 0x05
+} __packed;
+
+enum lstp_i2c_cmd_flags { LSTP_I2C_CMD_FLAG_NO_STOP = 0x40 };
+
+enum lstp_i2c_smbus_block_read_flags {
+	LSTP_I2C_SMBUS_BLOCK_READ_FLAG_PEC = BIT(0),
+} __packed;
+
+struct lstp_i2c_read_req {
+	u8 addr;
+	__le16 rd_len;
+} __packed;
+
+struct lstp_i2c_write_req {
+	u8 addr;
+	u8 wr_data[];
+} __packed;
+
+struct lstp_i2c_rd_recvlen_deprecated_req {
+	u8 addr;
+} __packed;
+
+struct lstp_i2c_wr_rd_req {
+	u8 addr;
+	__le16 rd_len;
+	u8 wr_data[]; /* Write length inferred from length in header */
+} __packed;
+
+struct lstp_i2c_smbus_block_read_req {
+	u8 addr;
+	__le16 flags; /* lstp_i2c_smbus_block_read_flags */
+	u8 wr_data[]; /* Write length inferred from length in header */
+} __packed;
+
+/*
+ * Largest write phase the block-read opcode carries: an SMBus command byte and a block count
+ * ahead of a maximum-size block.
+ */
+#define LSTP_I2C_SMBUS_BLOCK_READ_WR_MAX (2 + I2C_SMBUS_BLOCK_MAX)
+
+enum lstp_i2c_speed {
+	LSTP_I2C_SPEED_100KHZ = 0x00,
+	LSTP_I2C_SPEED_400KHZ = 0x01,
+	LSTP_I2C_SPEED_1000KHZ = 0x02,
+	LSTP_I2C_SPEED_3400KHZ = 0x03,
+};
+
+struct lstp_i2c_config {
+	u8 speed;
+	__le16 output_drive_strength; /* in mA */
+	__le16 slew_rate; /* in 100 ps (0.1 ns) increments */
+	__le16 input_debounce_time; /* in us */
+	__le16 glitch_filter_width; /* in ns */
+	u8 bus_low_timeout; /* in ms */
+	u8 bus_arbitration_retries;
+} __packed;
+
+#define LSTP_I2C_LEGACY_CONFIG_LEN offsetofend(struct lstp_i2c_config, speed)
+
+struct lstp_i2c_priv {
+	struct i2c_adapter *adap;
+	bool use_smbus_block_read; /* False once MCU has rejected LSTP_I2C_CMD_SMBUS_BLOCK_READ */
+};
+
+static bool lstp_i2c_can_retry(int lstp_status)
+{
+	return lstp_status == LSTP_BUSY || lstp_status == LSTP_ARB_LOST;
+}
+
+static bool lstp_i2c_suppress_error_logs(int lstp_status)
+{
+	return lstp_status == LSTP_NACK || lstp_i2c_can_retry(lstp_status);
+}
+
+/**
+ * lstp_i2c_bus_recovery() - Perform I2C bus recovery procedure.
+ * @adap: I2C adapter to recover
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_i2c_bus_recovery(struct i2c_adapter *adap)
+{
+	struct lstp_channel *ch = adap->algo_data;
+	int lstp_status = LSTP_NO_RESPONSE_STATUS;
+	int ret;
+
+	ret = lstp_request(ch, LSTP_I2C_CMD_BUS_RECOVERY, NULL, 0, NULL, 0, NULL, &lstp_status);
+	if (ret && !lstp_i2c_suppress_error_logs(lstp_status))
+		dev_err(&adap->dev, "%s: ch_%d: Bus recovery failed (%pe)\n", __func__, ch->ch_id,
+			ERR_PTR(ret));
+	if (ret && lstp_i2c_can_retry(lstp_status))
+		return -EAGAIN;
+	return ret;
+}
+
+/**
+ * lstp_i2c_validate_msg() - Validate an I2C message before transmission.
+ * @msg: I2C message to validate
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_i2c_validate_msg(struct i2c_msg *msg)
+{
+	if (!msg->buf && msg->len > 0)
+		return -EINVAL;
+
+	if (msg->flags & I2C_M_TEN)
+		return -EAFNOSUPPORT; /* 10-bit address not supported */
+
+	if (msg->addr > 0x7F)
+		return -EINVAL; /* Only 7-bit address supported */
+
+	if ((msg->flags & I2C_M_RECV_LEN) && (!(msg->flags & I2C_M_RD) || msg->len < 1))
+		return -EINVAL;
+
+	return 0;
+}
+
+/**
+ * lstp_i2c_read() - Perform an I2C read transaction.
+ * @adap:    I2C adapter to use
+ * @msg:     I2C message describing the read
+ * @no_stop: If true, omit STOP for repeated START
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_i2c_read(struct i2c_adapter *adap, struct i2c_msg *msg, bool no_stop)
+{
+	u8 cmd = LSTP_I2C_CMD_READ;
+	struct lstp_channel *ch = adap->algo_data;
+	struct lstp_i2c_read_req req = {
+		.addr = msg->addr,
+		.rd_len = cpu_to_le16(msg->len),
+	};
+	int lstp_status = LSTP_NO_RESPONSE_STATUS;
+	int ret;
+
+	ret = lstp_i2c_validate_msg(msg);
+	if (ret) {
+		dev_err(&adap->dev, "%s: ch_%d: Invalid message to addr=0x%02x (%pe)\n", __func__,
+			ch->ch_id, msg->addr, ERR_PTR(ret));
+		return ret;
+	}
+
+	if (msg->len > ch->max_rx_payload) {
+		dev_err(&adap->dev,
+			"%s: ch_%d: Read request message to addr=0x%02x too long (%u bytes, max %zu)\n",
+			__func__, ch->ch_id, msg->addr, msg->len, ch->max_rx_payload);
+		return -EINVAL;
+	}
+
+	dev_dbg(&adap->dev, "%s: ch_%d: addr=0x%02x, len=%d\n", __func__, ch->ch_id, msg->addr,
+		msg->len);
+
+	if (no_stop)
+		cmd |= LSTP_I2C_CMD_FLAG_NO_STOP;
+
+	ret = lstp_request(ch, cmd, &req, sizeof(req), msg->buf, msg->len, NULL, &lstp_status);
+	if (ret && !lstp_i2c_suppress_error_logs(lstp_status))
+		dev_err_ratelimited(&adap->dev, "%s: ch_%d: READ to addr=0x%02x failed (%pe)\n",
+				    __func__, ch->ch_id, msg->addr, ERR_PTR(ret));
+	if (ret && lstp_i2c_can_retry(lstp_status))
+		return -EAGAIN;
+	return ret;
+}
+
+/**
+ * lstp_i2c_write() - Perform an I2C write transaction.
+ * @adap:    I2C adapter to use
+ * @msg:     I2C message describing the write
+ * @no_stop: If true, omit STOP for repeated START
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_i2c_write(struct i2c_adapter *adap, struct i2c_msg *msg, bool no_stop)
+{
+	u8 cmd = LSTP_I2C_CMD_WRITE;
+	struct lstp_channel *ch = adap->algo_data;
+	struct lstp_i2c_write_req req_head = { .addr = msg->addr };
+	struct kvec vecs[2] = {
+		{ .iov_base = &req_head, .iov_len = sizeof(req_head) },
+		{ .iov_base = msg->buf, .iov_len = msg->len },
+	};
+	int lstp_status = LSTP_NO_RESPONSE_STATUS;
+	int ret;
+
+	ret = lstp_i2c_validate_msg(msg);
+	if (ret) {
+		dev_err(&adap->dev, "%s: ch_%d: Invalid message to addr=0x%02x (%pe)\n", __func__,
+			ch->ch_id, msg->addr, ERR_PTR(ret));
+		return ret;
+	}
+
+	if (sizeof(req_head) + msg->len > ch->max_tx_payload) {
+		dev_err(&adap->dev,
+			"%s: ch_%d: Write message to addr=0x%02x too long (%u bytes, max %zu)\n",
+			__func__, ch->ch_id, msg->addr, msg->len,
+			ch->max_tx_payload - sizeof(req_head));
+		return -EINVAL;
+	}
+
+	if (msg->len > 0)
+		dev_dbg(&adap->dev, "%s: ch_%d: addr=0x%02x, len=%d, data=0x%*ph\n", __func__,
+			ch->ch_id, msg->addr, msg->len, msg->len, msg->buf);
+	else
+		dev_dbg(&adap->dev, "%s: ch_%d: addr=0x%02x, len=%d\n", __func__, ch->ch_id,
+			msg->addr, msg->len);
+
+	if (no_stop)
+		cmd |= LSTP_I2C_CMD_FLAG_NO_STOP;
+
+	ret = lstp_requestv(ch, cmd, vecs, ARRAY_SIZE(vecs), NULL, 0, NULL, &lstp_status);
+	if (ret && !lstp_i2c_suppress_error_logs(lstp_status))
+		dev_err_ratelimited(&adap->dev, "%s: ch_%d: WRITE to addr=0x%02x failed (%pe)\n",
+				    __func__, ch->ch_id, msg->addr, ERR_PTR(ret));
+	if (ret && lstp_i2c_can_retry(lstp_status))
+		return -EAGAIN;
+	return ret;
+}
+
+/**
+ * lstp_i2c_read_recvlen_deprecated() - Deprecated SMBus block read (slave indicates length). Does
+ * not support PEC.
+ * @adap:    I2C adapter to use
+ * @msg:     I2C message; msg->len updated to actual bytes received
+ * @no_stop: If true, omit STOP for repeated START
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_i2c_read_recvlen_deprecated(struct i2c_adapter *adap, struct i2c_msg *msg,
+					    bool no_stop)
+{
+	u8 cmd = LSTP_I2C_CMD_READ_RECVLEN_DEPRECATED;
+	struct lstp_channel *ch = adap->algo_data;
+	struct lstp_i2c_rd_recvlen_deprecated_req req = { .addr = msg->addr };
+	size_t pkt_len = 0;
+	/* I2C_M_RECV_LEN: msg->len is framing (count [+ PEC]); caller guarantees +BLOCK_MAX room.
+	 */
+	size_t rx_buf_len = (size_t)msg->len + I2C_SMBUS_BLOCK_MAX;
+	u16 rx_len;
+	u8 block_len;
+	int lstp_status = LSTP_NO_RESPONSE_STATUS;
+	int ret;
+
+	ret = lstp_i2c_validate_msg(msg);
+	if (ret) {
+		dev_err(&adap->dev, "%s: ch_%d: Invalid message to addr=0x%02x (%pe)\n", __func__,
+			ch->ch_id, msg->addr, ERR_PTR(ret));
+		return ret;
+	}
+
+	if (rx_buf_len > ch->max_rx_payload) {
+		dev_err(&adap->dev,
+			"%s: ch_%d: Read recvlen message to addr=0x%02x too long (%zu bytes, max %zu)\n",
+			__func__, ch->ch_id, msg->addr, rx_buf_len, ch->max_rx_payload);
+		return -EINVAL;
+	}
+
+	if (no_stop)
+		cmd |= LSTP_I2C_CMD_FLAG_NO_STOP;
+
+	ret = lstp_request(ch, cmd, &req, sizeof(req), msg->buf, rx_buf_len, &pkt_len,
+			   &lstp_status);
+	if (ret) {
+		if (!lstp_i2c_suppress_error_logs(lstp_status))
+			dev_err_ratelimited(&adap->dev,
+					    "%s: ch_%d: READ_RECVLEN to addr=0x%02x failed (%pe)\n",
+					    __func__, ch->ch_id, msg->addr, ERR_PTR(ret));
+		if (lstp_i2c_can_retry(lstp_status))
+			return -EAGAIN;
+		return ret;
+	}
+
+	if (pkt_len == 0) {
+		dev_err(&adap->dev, "%s: ch_%d: Empty response packet\n", __func__, ch->ch_id);
+		return -EIO;
+	}
+
+	block_len = msg->buf[0];
+	if (block_len > I2C_SMBUS_BLOCK_MAX) {
+		dev_err(&adap->dev, "%s: ch_%d: Invalid block length %u\n", __func__, ch->ch_id,
+			block_len);
+		return -EPROTO;
+	}
+
+	rx_len = block_len + 1;
+	if (pkt_len < rx_len) {
+		dev_err(&adap->dev, "%s: ch_%d: Invalid response length (%zu)\n", __func__,
+			ch->ch_id, pkt_len);
+		return -EIO;
+	}
+
+	msg->len = rx_len;
+	return 0;
+}
+
+/**
+ * lstp_i2c_write_read() - Atomic write-then-read with repeated START.
+ * @adap:   I2C adapter to use
+ * @wr_msg: I2C message describing the write phase (addr, buf, len)
+ * @rd_msg: I2C message describing the read phase (addr, buf, len)
+ * @no_stop: If true, omit STOP so another message can follow
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_i2c_write_read(struct i2c_adapter *adap, struct i2c_msg *wr_msg,
+			       struct i2c_msg *rd_msg, bool no_stop)
+{
+	u8 cmd = LSTP_I2C_CMD_WRITE_READ;
+	struct lstp_channel *ch = adap->algo_data;
+	struct lstp_i2c_wr_rd_req req_head = {
+		.addr = wr_msg->addr,
+		.rd_len = cpu_to_le16(rd_msg->len),
+	};
+	struct kvec vecs[2] = {
+		{ .iov_base = &req_head, .iov_len = sizeof(req_head) },
+		{ .iov_base = wr_msg->buf, .iov_len = wr_msg->len },
+	};
+	int lstp_status = LSTP_NO_RESPONSE_STATUS;
+	int ret;
+
+	ret = lstp_i2c_validate_msg(wr_msg);
+	if (ret) {
+		dev_err(&adap->dev, "%s: ch_%d: Invalid write message to addr=0x%02x (%pe)\n",
+			__func__, ch->ch_id, wr_msg->addr, ERR_PTR(ret));
+		return ret;
+	}
+
+	if (sizeof(req_head) + wr_msg->len > ch->max_tx_payload) {
+		dev_err(&adap->dev,
+			"%s: ch_%d: Write message to addr=0x%02x too long (%u bytes, max %zu)\n",
+			__func__, ch->ch_id, wr_msg->addr, wr_msg->len,
+			ch->max_tx_payload - sizeof(req_head));
+		return -EINVAL;
+	}
+
+	ret = lstp_i2c_validate_msg(rd_msg);
+	if (ret) {
+		dev_err(&adap->dev, "%s: ch_%d: Invalid read message to addr=0x%02x (%pe)\n",
+			__func__, ch->ch_id, rd_msg->addr, ERR_PTR(ret));
+		return ret;
+	}
+
+	if (rd_msg->len > ch->max_rx_payload) {
+		dev_err(&adap->dev,
+			"%s: ch_%d: Read message to addr=0x%02x too long (%u bytes, max %zu)\n",
+			__func__, ch->ch_id, rd_msg->addr, rd_msg->len, ch->max_rx_payload);
+		return -EINVAL;
+	}
+
+	if (wr_msg->addr != rd_msg->addr) {
+		dev_err(&adap->dev, "%s: ch_%d: Write/read addr mismatch (wr=0x%02x, rd=0x%02x)\n",
+			__func__, ch->ch_id, wr_msg->addr, rd_msg->addr);
+		return -EINVAL;
+	}
+
+	if (no_stop)
+		cmd |= LSTP_I2C_CMD_FLAG_NO_STOP;
+
+	ret = lstp_requestv(ch, cmd, vecs, ARRAY_SIZE(vecs), rd_msg->buf, rd_msg->len, NULL,
+			    &lstp_status);
+	if (ret && !lstp_i2c_suppress_error_logs(lstp_status))
+		dev_err_ratelimited(&adap->dev,
+				    "%s: ch_%d: WRITE_READ to addr=0x%02x failed (%pe)\n", __func__,
+				    ch->ch_id, wr_msg->addr, ERR_PTR(ret));
+	if (ret && lstp_i2c_can_retry(lstp_status))
+		return -EAGAIN;
+	return ret;
+}
+
+/**
+ * lstp_i2c_smbus_block_read() - SMBus block read with optional write phase (slave indicates
+ * length).
+ * @adap:    I2C adapter to use
+ * @wr_msg:  Optional write phase (addr, buf, len). If non-NULL, must target the same slave as
+ * rd_msg.
+ * @rd_msg:  I2C message describing the read phase; rd_msg->len updated to actual bytes received
+ * @no_stop: If true, omit STOP for repeated START
+ * @lstp_status_out: Optional out-param for the raw LSTP response status; see lstp_request()
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_i2c_smbus_block_read(struct i2c_adapter *adap, struct i2c_msg *wr_msg,
+				     struct i2c_msg *rd_msg, bool no_stop, int *lstp_status_out)
+{
+	u8 cmd = LSTP_I2C_CMD_SMBUS_BLOCK_READ;
+	struct lstp_channel *ch = adap->algo_data;
+	DEFINE_RAW_FLEX(struct lstp_i2c_smbus_block_read_req, req, wr_data,
+			LSTP_I2C_SMBUS_BLOCK_READ_WR_MAX);
+	size_t pkt_len = 0;
+	u16 rx_len;
+	u16 wr_len = wr_msg ? wr_msg->len : 0;
+	u8 *wr_buf = wr_msg ? wr_msg->buf : NULL;
+	u8 block_len;
+	bool pec = rd_msg->flags & I2C_CLIENT_PEC;
+	/* I2C_M_RECV_LEN: rd_msg->len is framing (count [+ PEC]); caller guarantees +BLOCK_MAX
+	 * room.
+	 */
+	size_t rx_buf_len = (size_t)rd_msg->len + I2C_SMBUS_BLOCK_MAX;
+	int lstp_status = LSTP_NO_RESPONSE_STATUS;
+	int ret;
+
+	if (lstp_status_out)
+		*lstp_status_out = LSTP_NO_RESPONSE_STATUS;
+
+	ret = lstp_i2c_validate_msg(rd_msg);
+	if (ret) {
+		dev_err(&adap->dev, "%s: ch_%d: Invalid read message to addr=0x%02x (%pe)\n",
+			__func__, ch->ch_id, rd_msg->addr, ERR_PTR(ret));
+		return ret;
+	}
+
+	/* A PEC read frames a trailing byte on top of the count byte, so it needs room for both. */
+	if (pec && rd_msg->len < 2) {
+		dev_err(&adap->dev,
+			"%s: ch_%d: PEC read from addr=0x%02x leaves no room for the PEC byte\n",
+			__func__, ch->ch_id, rd_msg->addr);
+		return -EINVAL;
+	}
+
+	if (wr_msg) {
+		ret = lstp_i2c_validate_msg(wr_msg);
+		if (ret) {
+			dev_err(&adap->dev,
+				"%s: ch_%d: Invalid write message to addr=0x%02x (%pe)\n", __func__,
+				ch->ch_id, wr_msg->addr, ERR_PTR(ret));
+			return ret;
+		}
+
+		if (wr_msg->addr != rd_msg->addr) {
+			dev_err(&adap->dev,
+				"%s: ch_%d: Write/read addr mismatch (wr=0x%02x, rd=0x%02x)\n",
+				__func__, ch->ch_id, wr_msg->addr, rd_msg->addr);
+			return -EINVAL;
+		}
+	}
+
+	if (wr_len > LSTP_I2C_SMBUS_BLOCK_READ_WR_MAX) {
+		dev_err(&adap->dev,
+			"%s: ch_%d: SMBus write phase to addr=0x%02x too long (%u bytes, max %u)\n",
+			__func__, ch->ch_id, rd_msg->addr, wr_len,
+			LSTP_I2C_SMBUS_BLOCK_READ_WR_MAX);
+		return -EINVAL;
+	}
+
+	if (rx_buf_len > ch->max_rx_payload) {
+		dev_err(&adap->dev,
+			"%s: ch_%d: Read message to addr=0x%02x too long (%zu bytes, max %zu)\n",
+			__func__, ch->ch_id, rd_msg->addr, rx_buf_len, ch->max_rx_payload);
+		return -EINVAL;
+	}
+
+	if (struct_size(req, wr_data, wr_len) > ch->max_tx_payload) {
+		dev_err(&adap->dev,
+			"%s: ch_%d: SMBus write phase to addr=0x%02x too long (%zu bytes, max %zu)\n",
+			__func__, ch->ch_id, rd_msg->addr, struct_size(req, wr_data, wr_len),
+			ch->max_tx_payload);
+		return -EMSGSIZE;
+	}
+
+	*req = (struct lstp_i2c_smbus_block_read_req){
+		.addr = rd_msg->addr,
+		.flags = cpu_to_le16(pec ? LSTP_I2C_SMBUS_BLOCK_READ_FLAG_PEC : 0),
+	};
+	if (wr_len)
+		memcpy(req->wr_data, wr_buf, wr_len);
+
+	if (no_stop)
+		cmd |= LSTP_I2C_CMD_FLAG_NO_STOP;
+
+	ret = lstp_request(ch, cmd, req, struct_size(req, wr_data, wr_len), rd_msg->buf, rx_buf_len,
+			   &pkt_len, &lstp_status);
+	if (lstp_status_out)
+		*lstp_status_out = lstp_status;
+	if (ret) {
+		if (lstp_status != LSTP_NOT_SUPP && !lstp_i2c_suppress_error_logs(lstp_status))
+			dev_err_ratelimited(&adap->dev,
+					    "%s: ch_%d: SMBUS_BLOCK_READ to addr=0x%02x failed (%pe)\n",
+					    __func__, ch->ch_id, rd_msg->addr, ERR_PTR(ret));
+		if (lstp_i2c_can_retry(lstp_status))
+			return -EAGAIN;
+		return ret;
+	}
+
+	if (pkt_len == 0) {
+		dev_err(&adap->dev, "%s: ch_%d: Empty response packet\n", __func__, ch->ch_id);
+		return -EIO;
+	}
+
+	block_len = rd_msg->buf[0];
+	if (block_len > I2C_SMBUS_BLOCK_MAX) {
+		dev_err(&adap->dev, "%s: ch_%d: Invalid block length %u\n", __func__, ch->ch_id,
+			block_len);
+		return -EPROTO;
+	}
+
+	rx_len = block_len + (pec ? 2 : 1);
+	if (pkt_len < rx_len) {
+		dev_err(&adap->dev, "%s: ch_%d: Invalid response length (%zu)\n", __func__,
+			ch->ch_id, pkt_len);
+		return -EIO;
+	}
+
+	rd_msg->len = rx_len;
+	return 0;
+}
+
+/**
+ * lstp_i2c_smbus_block_read_wrapper() - SMBus block read with legacy fallback.
+ * @adap:    I2C adapter to use
+ * @wr_msg:  Optional write phase. If non-NULL, must target the same slave as @rd_msg
+ * @rd_msg:  Read phase message; rd_msg->len is updated to actual bytes received
+ * @no_stop: If true, omit STOP for repeated START on the read phase
+ *
+ * Tries the atomic SMBUS_BLOCK_READ opcode first. If the device
+ * rejects it (or has done so previously this session), falls back to a
+ * lstp_i2c_write() + lstp_i2c_read_recvlen_deprecated() transaction.
+ * PEC clients are rejected on the fallback path because the deprecated path cannot transport the
+ * trailing PEC byte.
+ *
+ * TODO: remove the fallback path (and lstp_i2c_read_recvlen_deprecated()) once
+ * all deployed devices support SMBUS_BLOCK_READ.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_i2c_smbus_block_read_wrapper(struct i2c_adapter *adap, struct i2c_msg *wr_msg,
+					     struct i2c_msg *rd_msg, bool no_stop)
+{
+	struct lstp_channel *ch = adap->algo_data;
+	struct lstp_i2c_priv *priv = ch->priv;
+	u16 wr_len = wr_msg ? wr_msg->len : 0;
+	int lstp_status = LSTP_NO_RESPONSE_STATUS;
+	int ret;
+
+	if (READ_ONCE(priv->use_smbus_block_read)) {
+		ret = lstp_i2c_smbus_block_read(adap, wr_msg, rd_msg, no_stop, &lstp_status);
+		if (lstp_status != LSTP_NOT_SUPP)
+			return ret;
+
+		/*
+		 * MCU rejected the new opcode; cache the result so subsequent
+		 * calls skip straight to the legacy chain.
+		 */
+		dev_warn_once(&adap->dev,
+			      "%s: ch_%d: Using deprecated recvlen path! -- Update LSTP Device\n",
+			      __func__, ch->ch_id);
+		WRITE_ONCE(priv->use_smbus_block_read, false);
+	}
+
+	/* Deprecated fallback path */
+	if (rd_msg->flags & I2C_CLIENT_PEC) {
+		dev_err(&adap->dev,
+			"%s: ch_%d: PEC client at addr=0x%02x not supported by deprecated recv-len opcode; update MCU firmware to support LSTP_I2C_CMD_SMBUS_BLOCK_READ\n",
+			__func__, ch->ch_id, rd_msg->addr);
+		return -EOPNOTSUPP;
+	}
+
+	if (wr_msg && wr_len > 0) {
+		ret = lstp_i2c_write(adap, wr_msg, true /* no_stop */);
+		if (ret)
+			return ret;
+	}
+	return lstp_i2c_read_recvlen_deprecated(adap, rd_msg, no_stop);
+}
+
+/*
+ * A write immediately followed by a read to the same target is one combined transaction: the write
+ * carries the command and the read collects the answer after a repeated START.
+ */
+static bool lstp_i2c_is_combined_pair(const struct i2c_msg *wr_msg, const struct i2c_msg *rd_msg)
+{
+	return !(wr_msg->flags & I2C_M_RD) && (rd_msg->flags & I2C_M_RD) &&
+	       wr_msg->addr == rd_msg->addr;
+}
+
+/**
+ * lstp_i2c_xfer() - Main I2C transfer function for the adapter.
+ * @adap: I2C adapter to use
+ * @msgs: Array of I2C messages to transfer
+ * @num:  Number of messages in the array
+ *
+ * Implements the i2c_algorithm.xfer callback. Processes an array of I2C
+ * messages, handling read, write, and combined transactions.
+ *
+ * Return: Number of messages transferred on success, negative errno on failure.
+ */
+static int lstp_i2c_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs, int num)
+{
+	int ret = 0;
+	int i;
+	struct lstp_channel *ch = adap->algo_data;
+
+	if (!msgs || num <= 0)
+		return -EINVAL;
+
+	dev_dbg(&adap->dev, "%s: ch_%d: I2C transfer with %d message(s)\n", __func__, ch->ch_id,
+		num);
+
+	for (i = 0; i < num; i++) {
+		bool no_stop;
+
+		if (i + 1 < num && lstp_i2c_is_combined_pair(&msgs[i], &msgs[i + 1])) {
+			struct i2c_msg *wr_msg = &msgs[i++];
+			struct i2c_msg *rd_msg = &msgs[i];
+
+			no_stop = i != num - 1;
+			if (rd_msg->flags & I2C_M_RECV_LEN)
+				ret = lstp_i2c_smbus_block_read_wrapper(adap, wr_msg, rd_msg,
+									no_stop);
+			else
+				ret = lstp_i2c_write_read(adap, wr_msg, rd_msg, no_stop);
+		} else {
+			no_stop = i != num - 1;
+
+			if (msgs[i].flags & I2C_M_RD) {
+				if (msgs[i].flags & I2C_M_RECV_LEN)
+					ret = lstp_i2c_smbus_block_read_wrapper(adap, NULL,
+										&msgs[i], no_stop);
+				else
+					ret = lstp_i2c_read(adap, &msgs[i], no_stop);
+			} else {
+				ret = lstp_i2c_write(adap, &msgs[i], no_stop);
+			}
+		}
+
+		if (ret)
+			return ret;
+	}
+
+	return num;
+}
+
+/**
+ * lstp_i2c_functionality() - Report I2C adapter capabilities.
+ * @adap: I2C adapter to query
+ *
+ * Return: Bitmask of supported I2C_FUNC_* flags.
+ */
+static u32 lstp_i2c_functionality(struct i2c_adapter *adap)
+{
+	/* TODO: This needs to be discoverable, also need separate commands for 10-bit address */
+	return I2C_FUNC_I2C | I2C_FUNC_SMBUS_EMUL_ALL;
+}
+
+static struct i2c_bus_recovery_info lstp_i2c_recovery_info = {
+	.recover_bus = lstp_i2c_bus_recovery,
+};
+
+static const struct i2c_algorithm lstp_i2c_algorithm = {
+	.xfer = lstp_i2c_xfer,
+	.functionality = lstp_i2c_functionality,
+};
+
+#define LSTP_I2C_DEFAULT_RETRIES 3
+
+/**
+ * lstp_i2c_configure_retry_policy() - Set adapter retry count and timeout.
+ * @adap:       I2C adapter to configure (firmware node must already be set)
+ * @cfg:        Channel config blob from firmware
+ * @config_len: Length of @cfg in bytes
+ *
+ * Sets adap->retries / adap->timeout for I2C-core -EAGAIN reissues, which
+ * cover both LSTP_BUSY and LSTP_ARB_LOST. A non-zero bus_arbitration_retries
+ * means the device performs its own bus retries, so the host adds none;
+ * otherwise use DT "retries", else LSTP_I2C_DEFAULT_RETRIES. Timeout is
+ * (retries + 1) USB response windows.
+ */
+static void lstp_i2c_configure_retry_policy(struct i2c_adapter *adap,
+					    const struct lstp_i2c_config *cfg, size_t config_len)
+{
+	u32 retries = LSTP_I2C_DEFAULT_RETRIES;
+	u32 configured_retries;
+
+	if (config_len >= offsetofend(struct lstp_i2c_config, bus_arbitration_retries) &&
+	    cfg->bus_arbitration_retries) {
+		if (!device_property_read_u32(&adap->dev, "retries", &configured_retries) &&
+		    configured_retries)
+			dev_warn(&adap->dev,
+				 "Ignoring DT retries=%u; device already retries the bus %u time(s)\n",
+				 configured_retries, cfg->bus_arbitration_retries);
+		retries = 0;
+	} else if (!device_property_read_u32(&adap->dev, "retries", &configured_retries)) {
+		if (configured_retries <= U8_MAX)
+			retries = configured_retries;
+		else
+			dev_warn(&adap->dev, "Ignoring retries value %u; maximum is %u\n",
+				 configured_retries, U8_MAX);
+	}
+
+	adap->retries = retries;
+	adap->timeout = msecs_to_jiffies((retries + 1) * LSTP_USB_RESPONSE_TIMEOUT_MS);
+}
+
+/**
+ * lstp_i2c_init() - Initialize I2C adapter for an LSTP channel.
+ * @ch:   LSTP channel configured as I2C type
+ * @info: Channel config blob (struct lstp_i2c_config; legacy speed-only OK)
+ *
+ * Allocates adapter and parses config. Adapter stored in
+ * ch->priv but not registered; call lstp_i2c_start() after RX URB setup.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_i2c_init(struct lstp_channel *ch, const struct lstp_channel_init_info *info)
+{
+	struct i2c_adapter *adap;
+	struct lstp_i2c_priv *priv;
+	const struct lstp_i2c_config *cfg = info->config;
+
+	if (info->config_len < LSTP_I2C_LEGACY_CONFIG_LEN) {
+		dev_err(ch->dev, "%s: ch_%d: I2C config too short: %zu < %zu\n", __func__,
+			ch->ch_id, info->config_len, LSTP_I2C_LEGACY_CONFIG_LEN);
+		return -EINVAL;
+	}
+
+	/* Allocate memory */
+	priv = devm_kzalloc(ch->dev, sizeof(*priv), GFP_KERNEL);
+	if (!priv)
+		return -ENOMEM;
+	adap = devm_kzalloc(ch->dev, sizeof(*adap), GFP_KERNEL);
+	if (!adap)
+		return -ENOMEM;
+
+	/* Initialize I2C adapter */
+	adap->owner = THIS_MODULE;
+	adap->class = I2C_CLASS_HWMON;
+	adap->algo = &lstp_i2c_algorithm;
+	adap->algo_data = ch;
+	adap->dev.parent = ch->dev;
+	adap->bus_recovery_info = &lstp_i2c_recovery_info;
+	device_set_node(&adap->dev, ch->fwnode);
+	lstp_i2c_configure_retry_policy(adap, cfg, info->config_len);
+	strscpy(adap->name, ch->display_name, sizeof(adap->name));
+	/* TODO: save i2c speed from config */
+
+	priv->adap = adap;
+	priv->use_smbus_block_read = true;
+	ch->priv = priv;
+
+	dev_dbg(ch->dev, "%s: ch_%d: Initialized as %s\n", __func__, ch->ch_id, adap->name);
+	return 0;
+}
+
+/**
+ * lstp_i2c_start() - Register I2C adapter with Linux I2C core.
+ * @ch: LSTP channel with initialized adapter (from lstp_i2c_init)
+ *
+ * When the adapter's firmware node is set (from lstp_i2c_init), the
+ * I2C core resolves bus numbers via aliases and auto-enumerates child
+ * devices from firmware (DT or ACPI) child nodes.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_i2c_start(struct lstp_channel *ch)
+{
+	int ret;
+	struct lstp_i2c_priv *priv = ch->priv;
+	struct i2c_adapter *adap = priv ? priv->adap : NULL;
+
+	if (!adap) {
+		dev_err(ch->dev, "%s: ch_%d: I2C adapter not initialized\n", __func__, ch->ch_id);
+		return -EINVAL;
+	}
+
+	ret = devm_i2c_add_adapter(ch->dev, adap);
+	if (ret) {
+		dev_err(ch->dev, "%s: ch_%d: Could not register I2C adapter (%pe)\n", __func__,
+			ch->ch_id, ERR_PTR(ret));
+		return ret;
+	}
+
+	deprecated_lstp_channel_publish_child_dev(ch, &adap->dev);
+
+	dev_info(ch->dev, "%s: ch_%d: Started as %s\n", __func__, ch->ch_id, adap->name);
+	return 0;
+}
+
+/* clang-format off */
+LSTP_SUBSYS(i2c, LSTP_CHANNEL_TYPE_I2C, lstp_i2c_init, lstp_i2c_start,
+	    .fwnode_compatible = "nvidia,lstp-i2c",
+);
+/* clang-format on */

--- a/drivers/usb/misc/lstp/lstp-ipmi-postcodes.h
+++ b/drivers/usb/misc/lstp/lstp-ipmi-postcodes.h
@@ -1,0 +1,383 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * IPMI postcodes support for LSTP USB interface.
+ *
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+#ifndef __LSTP_IPMI_POSTCODES_H
+#define __LSTP_IPMI_POSTCODES_H
+
+#include <linux/types.h>
+
+#ifdef CONFIG_SEPARATE_LSTP_IPMI_POSTCODES
+
+#include <linux/miscdevice.h>
+#include <linux/kfifo.h>
+#include <linux/slab.h>
+#include <linux/spinlock.h>
+#include <linux/wait.h>
+#include <linux/poll.h>
+#include <linux/uaccess.h>
+
+/*
+ * Postcode message format (OEM Group Extension):
+ * Byte 0: netfn/lun (netfn 0x2C = Group Extension)
+ * Byte 1: cmd (0x02 = OEM command)
+ * Byte 2: group (0xAE = OEM group identifier)
+ * Bytes 3-11: 9 bytes of postcode data
+ */
+#define LSTP_IPMI_POST_NETFN 0x2C
+#define LSTP_IPMI_POST_CMD 0x02
+#define LSTP_IPMI_POST_GROUP 0xAE
+#define LSTP_IPMI_POST_MIN_LEN 3 /* netfn + cmd + group */
+#define LSTP_IPMI_POST_CODE_SIZE 9 /* postcode data length */
+#define LSTP_IPMI_POST_CODE_OFFSET 3 /* offset to postcode data */
+#define LSTP_IPMI_POST_BUFFER_SIZE 1024
+
+/**
+ * struct lstp_ipmi_postcodes - Postcodes device context.
+ * @miscdev:     Userspace miscdev.
+ * @lock:        Protects @fifo and @running.
+ * @wait_queue:  Blocked readers / pollers.
+ * @fifo:        Inbound postcode bytes pending read().
+ * @running:     Exclusive-open flag.
+ * @initialized: Init succeeded; gates _start / _stop / _destroy.
+ * @stopped:     Set by lstp_ipmi_postcodes_stop() to fence file ops.
+ * @parent:      Opaque enclosing object pinned while any fd is open.
+ * @parent_get:  Bumps @parent's refcount; invoked from open().
+ * @parent_put:  Drops @parent's refcount; invoked from release().
+ */
+struct lstp_ipmi_postcodes {
+	struct miscdevice miscdev;
+	spinlock_t lock; /* Protects FIFO and running flag */
+	wait_queue_head_t wait_queue;
+	struct kfifo fifo;
+	bool running;
+	bool initialized;
+	bool stopped;
+	void *parent;
+	void (*parent_get)(void *parent);
+	void (*parent_put)(void *parent);
+};
+
+/* Helper to get postcodes context from file */
+static inline struct lstp_ipmi_postcodes *lstp_ipmi_postcodes_to_ctx(struct file *file)
+{
+	return container_of(file->private_data, struct lstp_ipmi_postcodes, miscdev);
+}
+
+static inline bool lstp_ipmi_postcodes_stopped(struct lstp_ipmi_postcodes *post)
+{
+	/* Pairs with smp_store_release() in lstp_ipmi_postcodes_stop(). */
+	return smp_load_acquire(&post->stopped);
+}
+
+static int lstp_ipmi_postcodes_open(struct inode *inode, struct file *file)
+{
+	struct lstp_ipmi_postcodes *post = lstp_ipmi_postcodes_to_ctx(file);
+	int ret = 0;
+
+	spin_lock_irq(&post->lock);
+	if (post->running)
+		ret = -EBUSY;
+	else
+		post->running = true;
+	spin_unlock_irq(&post->lock);
+
+	if (ret)
+		return ret;
+
+	if (post->parent_get)
+		post->parent_get(post->parent);
+
+	return 0;
+}
+
+static ssize_t lstp_ipmi_postcodes_read(struct file *file, char __user *buf, size_t count,
+					loff_t *ppos)
+{
+	struct lstp_ipmi_postcodes *post = lstp_ipmi_postcodes_to_ctx(file);
+	u8 tmp_buf[LSTP_IPMI_POST_CODE_SIZE];
+	unsigned long flags;
+	unsigned int copied;
+	ssize_t ret;
+
+	if (kfifo_is_empty(&post->fifo)) {
+		if (file->f_flags & O_NONBLOCK)
+			return -EAGAIN;
+		ret = wait_event_interruptible(post->wait_queue,
+					       !kfifo_is_empty(&post->fifo) ||
+						       lstp_ipmi_postcodes_stopped(post));
+		if (ret == -ERESTARTSYS)
+			return ret;
+		if (lstp_ipmi_postcodes_stopped(post))
+			return -ENODEV;
+	}
+
+	/*
+	 * Copy to kernel buffer under spinlock, then copy to user without lock.
+	 * This avoids calling copy_to_user() with spinlock held (which can sleep
+	 * on page fault).
+	 */
+	spin_lock_irqsave(&post->lock, flags);
+	copied = kfifo_out(&post->fifo, tmp_buf, min_t(size_t, count, LSTP_IPMI_POST_CODE_SIZE));
+	spin_unlock_irqrestore(&post->lock, flags);
+
+	if (copied == 0)
+		return -EAGAIN;
+
+	if (copy_to_user(buf, tmp_buf, copied))
+		return -EFAULT;
+
+	return copied;
+}
+
+static int lstp_ipmi_postcodes_release(struct inode *inode, struct file *file)
+{
+	struct lstp_ipmi_postcodes *post = lstp_ipmi_postcodes_to_ctx(file);
+
+	spin_lock_irq(&post->lock);
+	post->running = false;
+	spin_unlock_irq(&post->lock);
+
+	if (post->parent_put)
+		post->parent_put(post->parent);
+
+	return 0;
+}
+
+static __poll_t lstp_ipmi_postcodes_poll(struct file *file, poll_table *wait)
+{
+	struct lstp_ipmi_postcodes *post = lstp_ipmi_postcodes_to_ctx(file);
+
+	poll_wait(file, &post->wait_queue, wait);
+	if (lstp_ipmi_postcodes_stopped(post))
+		return EPOLLHUP;
+	if (!kfifo_is_empty(&post->fifo))
+		return POLLIN | POLLRDNORM;
+
+	return 0;
+}
+
+static const struct file_operations lstp_ipmi_postcodes_fops = {
+	.owner = THIS_MODULE,
+	.open = lstp_ipmi_postcodes_open,
+	.read = lstp_ipmi_postcodes_read,
+	.release = lstp_ipmi_postcodes_release,
+	.poll = lstp_ipmi_postcodes_poll,
+};
+
+/**
+ * lstp_ipmi_postcodes_init() - Initialize postcodes support.
+ * @post:       Postcodes context.
+ * @dev:        Parent device for the miscdev (sysfs hierarchy).
+ * @base_name:  Device name; "-postcodes" is appended.
+ * @parent:     See &struct lstp_ipmi_postcodes.
+ * @parent_get: See &struct lstp_ipmi_postcodes.
+ * @parent_put: See &struct lstp_ipmi_postcodes.
+ *
+ * Context: Process context.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static inline int lstp_ipmi_postcodes_init(struct lstp_ipmi_postcodes *post, struct device *dev,
+					   const char *base_name, void *parent,
+					   void (*parent_get)(void *parent),
+					   void (*parent_put)(void *parent))
+{
+	int ret;
+
+	memset(post, 0, sizeof(*post));
+
+	ret = kfifo_alloc(&post->fifo, LSTP_IPMI_POST_BUFFER_SIZE, GFP_KERNEL);
+	if (ret)
+		return ret;
+
+	spin_lock_init(&post->lock);
+	init_waitqueue_head(&post->wait_queue);
+
+	post->miscdev.name = kasprintf(GFP_KERNEL, "%s-postcodes", base_name);
+	if (!post->miscdev.name) {
+		kfifo_free(&post->fifo);
+		return -ENOMEM;
+	}
+
+	post->miscdev.minor = MISC_DYNAMIC_MINOR;
+	post->miscdev.fops = &lstp_ipmi_postcodes_fops;
+	post->miscdev.parent = dev;
+
+	post->parent = parent;
+	post->parent_get = parent_get;
+	post->parent_put = parent_put;
+
+	post->initialized = true;
+
+	return 0;
+}
+
+/**
+ * lstp_ipmi_postcodes_start - Register the postcodes misc device
+ * @post: Postcodes context
+ *
+ * Registers the postcodes misc device to make it available to userspace.
+ *
+ * Context: Process context.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static inline int lstp_ipmi_postcodes_start(struct lstp_ipmi_postcodes *post)
+{
+	if (!post->initialized)
+		return -EINVAL;
+
+	return misc_register(&post->miscdev);
+}
+
+/**
+ * lstp_ipmi_postcodes_stop() - Quiesce the postcodes miscdev on disconnect.
+ * @post: Postcodes context.
+ *
+ * Deregisters the miscdev, sets @stopped, and wakes blocked readers.
+ * Open fds keep @parent alive via @parent_put until they release.
+ *
+ * Context: Process context.
+ */
+static inline void lstp_ipmi_postcodes_stop(struct lstp_ipmi_postcodes *post)
+{
+	if (!post->initialized)
+		return;
+
+	misc_deregister(&post->miscdev);
+	/* Pairs with smp_load_acquire() in lstp_ipmi_postcodes_stopped(). */
+	smp_store_release(&post->stopped, true);
+	wake_up_all(&post->wait_queue);
+}
+
+/**
+ * lstp_ipmi_postcodes_destroy() - Free postcodes-owned resources.
+ * @post: Postcodes context.
+ *
+ * Caller must ensure _stop() has run and no fds remain.
+ */
+static inline void lstp_ipmi_postcodes_destroy(struct lstp_ipmi_postcodes *post)
+{
+	if (!post->initialized)
+		return;
+
+	kfifo_free(&post->fifo);
+	kfree(post->miscdev.name);
+	post->miscdev.name = NULL;
+	post->initialized = false;
+}
+
+/**
+ * lstp_ipmi_postcodes_is_postcode - Check if IPMI message is a postcode
+ * @payload: IPMI message payload
+ * @len: Payload length
+ *
+ * Checks if the IPMI message matches the OEM Group Extension postcode
+ * signature (netfn=0x2C, cmd=0x02, group=0xAE).
+ *
+ * Context: Any context (lock-free, no side effects).
+ *
+ * Return: true if message is a postcode, false otherwise.
+ */
+static inline bool lstp_ipmi_postcodes_is_postcode(const u8 *payload, u16 len)
+{
+	if (len < LSTP_IPMI_POST_MIN_LEN)
+		return false;
+
+	return ((payload[0] >> 2) == LSTP_IPMI_POST_NETFN && payload[1] == LSTP_IPMI_POST_CMD &&
+		payload[2] == LSTP_IPMI_POST_GROUP);
+}
+
+/**
+ * lstp_ipmi_postcodes_send - Queue a postcode message
+ * @post: Postcodes context
+ * @payload: IPMI message payload containing postcode data
+ * @len: Payload length
+ *
+ * Extracts postcode data from the IPMI payload and queues it to the FIFO.
+ * The postcode is POST_CODE_SIZE bytes starting at POST_CODE_OFFSET.
+ *
+ * Context: Interrupt context safe. Acquires post->lock with irqsave.
+ */
+static inline void lstp_ipmi_postcodes_send(struct lstp_ipmi_postcodes *post, const u8 *payload,
+					    u16 len)
+{
+	unsigned long flags;
+	unsigned int rc;
+
+	if (!post->initialized)
+		return;
+
+	if (len < (LSTP_IPMI_POST_CODE_OFFSET + LSTP_IPMI_POST_CODE_SIZE))
+		return;
+
+	spin_lock_irqsave(&post->lock, flags);
+
+	/* Reset FIFO if there's not enough space */
+	if ((LSTP_IPMI_POST_BUFFER_SIZE - kfifo_len(&post->fifo)) < LSTP_IPMI_POST_CODE_SIZE)
+		kfifo_reset(&post->fifo);
+
+	rc = kfifo_in(&post->fifo, &payload[LSTP_IPMI_POST_CODE_OFFSET], LSTP_IPMI_POST_CODE_SIZE);
+	if (rc != LSTP_IPMI_POST_CODE_SIZE) {
+		kfifo_reset(&post->fifo);
+		spin_unlock_irqrestore(&post->lock, flags);
+		return;
+	}
+
+	spin_unlock_irqrestore(&post->lock, flags);
+
+	wake_up_all(&post->wait_queue);
+}
+
+#else /* !CONFIG_SEPARATE_LSTP_IPMI_POSTCODES */
+
+/* Stub implementation when CONFIG_SEPARATE_LSTP_IPMI_POSTCODES is not defined */
+
+struct lstp_ipmi_postcodes {
+	char __dummy; /* Avoid empty struct warnings */
+};
+
+static inline int lstp_ipmi_postcodes_init(struct lstp_ipmi_postcodes *, struct device *,
+					   const char *, void *, void (*)(void *), void (*)(void *))
+{
+	return 0;
+}
+
+static inline int lstp_ipmi_postcodes_start(struct lstp_ipmi_postcodes *)
+{
+	return 0;
+}
+
+static inline void lstp_ipmi_postcodes_stop(struct lstp_ipmi_postcodes *)
+{
+}
+
+static inline void lstp_ipmi_postcodes_destroy(struct lstp_ipmi_postcodes *)
+{
+}
+
+static inline bool lstp_ipmi_postcodes_is_postcode(const u8 *, u16)
+{
+	return false;
+}
+
+static inline void lstp_ipmi_postcodes_send(struct lstp_ipmi_postcodes *, const u8 *, u16)
+{
+}
+
+#endif /* CONFIG_SEPARATE_LSTP_IPMI_POSTCODES */
+
+#endif /* __LSTP_IPMI_POSTCODES_H */

--- a/drivers/usb/misc/lstp/lstp-ipmi.c
+++ b/drivers/usb/misc/lstp/lstp-ipmi.c
@@ -69,13 +69,16 @@ struct ipmi_lstp_msg {
  * @tx_mutex:  Serializes lstp_ipmi_write() against lstp_ipmi_stop().
  *             Owned by @ctx (kref-pinned) rather than @ch -- see the
  *             rationale in lstp_ipmi_write().
+ * @rx_mutex:  Serializes readers and protects @pending_msg/@pending_len
+ *             while userspace copies may sleep.
  * @lock:      Serializes @running, @msg_count and the @fifo producer/
- *             consumer paths. Held only across kfifo_in / kfifo_out;
- *             copy_to_user() in lstp_ipmi_read() runs after the unlock.
+ *             consumer paths. Held only across kfifo_in / kfifo_out.
  * @req_wq:    Wait queue for blocked readers / pollers.
  * @fifo:      Inbound IPMI requests pending read(), one variable-size
  *             record per message (2-byte length prefix per record).
  *             Drops oldest records on overflow until the new one fits.
+ * @pending_msg: Record removed from @fifo but not yet copied successfully.
+ * @pending_len: Length of @pending_msg, or zero if no record is retained.
  * @msg_count: Per-message tag echoed back on write() to drop responses
  *             to stale requests.
  * @postcodes: Embedded postcodes sub-device.
@@ -88,9 +91,12 @@ struct lstp_ipmi_ctx {
 	bool running;
 	bool stopped;
 	struct mutex tx_mutex; /* serializes write() vs lstp_ipmi_stop() */
+	struct mutex rx_mutex; /* protects the retained userspace read */
 	spinlock_t lock; /* protects @running, @msg_count, @fifo */
 	wait_queue_head_t req_wq;
 	struct kfifo_rec_ptr_2 fifo;
+	struct ipmi_lstp_msg pending_msg;
+	unsigned int pending_len;
 	u8 msg_count;
 	struct lstp_ipmi_postcodes postcodes;
 };
@@ -123,7 +129,8 @@ static inline bool lstp_ipmi_stopped(struct lstp_ipmi_ctx *ctx)
  */
 static inline bool lstp_ipmi_readable(struct lstp_ipmi_ctx *ctx)
 {
-	return !kfifo_is_empty(&ctx->fifo) || lstp_ipmi_stopped(ctx);
+	return READ_ONCE(ctx->pending_len) || !kfifo_is_empty(&ctx->fifo) ||
+	       lstp_ipmi_stopped(ctx);
 }
 
 /**
@@ -141,6 +148,7 @@ static void lstp_ipmi_ctx_release(struct kref *kref)
 	if (ctx->ida_id >= 0)
 		ida_free(&lstp_ipmi_ida, ctx->ida_id);
 	kfree(ctx->miscdev.name);
+	mutex_destroy(&ctx->rx_mutex);
 	mutex_destroy(&ctx->tx_mutex);
 	kfree(ctx);
 }
@@ -255,42 +263,61 @@ static int lstp_ipmi_open(struct inode *inode, struct file *file)
  *
  * Context: Process context. May sleep.
  *
- * Return: Bytes read, or -EAGAIN / -ERESTARTSYS / -ENODEV.
+ * Return: Bytes read, or -EAGAIN / -ERESTARTSYS / -ENODEV / -EMSGSIZE /
+ *         -EFAULT.
  */
 static ssize_t lstp_ipmi_read(struct file *file, char __user *buf, size_t count, loff_t *ppos)
 {
 	struct lstp_ipmi_ctx *ctx = to_ctx(file);
-	struct ipmi_lstp_msg msg;
 	unsigned long flags;
-	unsigned int len = 0;
+	unsigned int len;
 	int ret;
 
 	/*
-	 * Drain into a stack-local @msg under @ctx->lock, then copy_to_user
-	 * outside the lock since it may sleep. Loop to handle two threads
-	 * sharing an fd both winning the wait_event() but only one the
-	 * kfifo_out().
+	 * Keep one record outside the drop-oldest FIFO until userspace has
+	 * accepted it. The mutex also serializes threads sharing the fd.
 	 */
-	while (!len) {
+	ret = mutex_lock_interruptible(&ctx->rx_mutex);
+	if (ret)
+		return ret;
+
+	while (!READ_ONCE(ctx->pending_len)) {
 		if (kfifo_is_empty(&ctx->fifo)) {
-			if (lstp_ipmi_stopped(ctx))
-				return -ENODEV;
-			if (file->f_flags & O_NONBLOCK)
-				return -EAGAIN;
+			if (lstp_ipmi_stopped(ctx)) {
+				ret = -ENODEV;
+				goto out_unlock;
+			}
+			if (file->f_flags & O_NONBLOCK) {
+				ret = -EAGAIN;
+				goto out_unlock;
+			}
 			ret = wait_event_interruptible(ctx->req_wq, lstp_ipmi_readable(ctx));
 			if (ret)
-				return ret;
+				goto out_unlock;
 		}
 
 		spin_lock_irqsave(&ctx->lock, flags);
-		len = kfifo_out(&ctx->fifo, &msg, sizeof(msg));
+		len = kfifo_out(&ctx->fifo, &ctx->pending_msg, sizeof(ctx->pending_msg));
 		spin_unlock_irqrestore(&ctx->lock, flags);
+		WRITE_ONCE(ctx->pending_len, len);
 	}
 
-	len = min_t(unsigned int, count, len);
-	if (copy_to_user(buf, &msg, len))
-		return -EFAULT;
-	return len;
+	len = READ_ONCE(ctx->pending_len);
+	if (count < len) {
+		ret = -EMSGSIZE;
+		goto out_unlock;
+	}
+	if (copy_to_user(buf, &ctx->pending_msg, len)) {
+		ret = -EFAULT;
+		goto out_unlock;
+	}
+
+	WRITE_ONCE(ctx->pending_len, 0);
+	ret = len;
+
+out_unlock:
+	mutex_unlock(&ctx->rx_mutex);
+	return ret;
 }
 
 /**
@@ -402,7 +429,7 @@ static __poll_t lstp_ipmi_poll(struct file *file, poll_table *wait)
 	poll_wait(file, &ctx->req_wq, wait);
 	if (lstp_ipmi_stopped(ctx))
 		return EPOLLHUP;
-	if (!kfifo_is_empty(&ctx->fifo))
+	if (READ_ONCE(ctx->pending_len) || !kfifo_is_empty(&ctx->fifo))
 		return POLLIN | POLLRDNORM;
 
 	return 0;
@@ -573,6 +600,7 @@ static int lstp_ipmi_init(struct lstp_channel *ch, const struct lstp_channel_ini
 	ctx->ch = ch;
 	spin_lock_init(&ctx->lock);
 	mutex_init(&ctx->tx_mutex);
+	mutex_init(&ctx->rx_mutex);
 	init_waitqueue_head(&ctx->req_wq);
 
 	ret = devm_add_action_or_reset(ch->dev, lstp_ipmi_ctx_put_cb, ctx);

--- a/drivers/usb/misc/lstp/lstp-ipmi.c
+++ b/drivers/usb/misc/lstp/lstp-ipmi.c
@@ -1,0 +1,684 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * IPMI driver for LSTP USB interface.
+ *
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+#include <linux/poll.h>
+#include <linux/err.h>
+#include <linux/miscdevice.h>
+#include <linux/kfifo.h>
+#include <linux/idr.h>
+#include <linux/kref.h>
+#include <linux/slab.h>
+
+#include "lstp-main.h"
+#include "lstp-ipmi-postcodes.h"
+
+/*
+ * Byte capacity of the pending-request fifo. One PAGE_SIZE-equivalent
+ * allocation: cheap from the buddy allocator, and at typical OpenBMC IPMI
+ * rates (~100 req/s, ~25 B avg payload) it absorbs ~1 s of userspace
+ * stall before drop-oldest kicks in -- around the host's IPMI retry
+ * timeout, so deeper buffering would just queue stale work.
+ */
+#define BUFFER_SIZE 4096
+
+static DEFINE_IDA(lstp_ipmi_ida);
+
+/* IPMI message constants and structures */
+
+#define IPMI_LSTP_PAYLOAD_MAX 254
+#define IPMI_MIN_MSG_LEN 2 /* netfn/lun + cmd */
+
+struct ipmi_lstp_msg_header {
+	unsigned int len;
+	u8 msg_num;
+} __packed;
+
+struct ipmi_lstp_msg {
+	struct ipmi_lstp_msg_header header;
+	__u8 payload[IPMI_LSTP_PAYLOAD_MAX];
+};
+
+/**
+ * struct lstp_ipmi_ctx - Per-channel IPMI userspace state.
+ * @kref:      Refcount. Open fds and the channel's devres action each hold
+ *             one, so @ctx outlives disconnect while any fd is open.
+ * @ch:        Owning channel. Freed by devres after disconnect, before
+ *             @ctx; only safe to dereference under @tx_mutex while
+ *             @stopped is clear.
+ * @miscdev:   /dev/ipmi-lstpN node. Lifecycle managed via devres (see
+ *             lstp_ipmi_stop_and_deregister()), independent of @kref.
+ * @ida_id:    Auto-generated name suffix, or -1 if a firmware "label"
+ *             supplied the name.
+ * @running:   Exclusive-open flag. Protected by @lock.
+ * @stopped:   Disconnect-quiesce flag. Set under both @tx_mutex and @lock.
+ *             Distinct from the framework's disconnect flag (read via
+ *             lstp_channel_disconnected()).
+ * @tx_mutex:  Serializes lstp_ipmi_write() against lstp_ipmi_stop().
+ *             Owned by @ctx (kref-pinned) rather than @ch -- see the
+ *             rationale in lstp_ipmi_write().
+ * @lock:      Serializes @running, @msg_count and the @fifo producer/
+ *             consumer paths. Held only across kfifo_in / kfifo_out;
+ *             copy_to_user() in lstp_ipmi_read() runs after the unlock.
+ * @req_wq:    Wait queue for blocked readers / pollers.
+ * @fifo:      Inbound IPMI requests pending read(), one variable-size
+ *             record per message (2-byte length prefix per record).
+ *             Drops oldest records on overflow until the new one fits.
+ * @msg_count: Per-message tag echoed back on write() to drop responses
+ *             to stale requests.
+ * @postcodes: Embedded postcodes sub-device.
+ */
+struct lstp_ipmi_ctx {
+	struct kref kref;
+	struct lstp_channel *ch;
+	struct miscdevice miscdev;
+	int ida_id;
+	bool running;
+	bool stopped;
+	struct mutex tx_mutex; /* serializes write() vs lstp_ipmi_stop() */
+	spinlock_t lock; /* protects @running, @msg_count, @fifo */
+	wait_queue_head_t req_wq;
+	struct kfifo_rec_ptr_2 fifo;
+	u8 msg_count;
+	struct lstp_ipmi_postcodes postcodes;
+};
+
+enum lstp_ipmi_cmd {
+	LSTP_IPMI_CMD_MESSAGE = 0x00,
+};
+
+/*******************************************************************************
+ * Lifetime management
+ ******************************************************************************/
+
+/**
+ * lstp_ipmi_stopped() - Test whether the IPMI channel has been quiesced.
+ * @ctx: IPMI context
+ *
+ * Return: true after lstp_ipmi_quiesce() has set @stopped.
+ */
+static inline bool lstp_ipmi_stopped(struct lstp_ipmi_ctx *ctx)
+{
+	/* Pairs with smp_store_release() in lstp_ipmi_quiesce(). */
+	return smp_load_acquire(&ctx->stopped);
+}
+
+/**
+ * lstp_ipmi_readable() - wait_event condition for lstp_ipmi_read().
+ * @ctx: IPMI context
+ *
+ * Return: true when the FIFO has data or the channel is stopped.
+ */
+static inline bool lstp_ipmi_readable(struct lstp_ipmi_ctx *ctx)
+{
+	return !kfifo_is_empty(&ctx->fifo) || lstp_ipmi_stopped(ctx);
+}
+
+/**
+ * lstp_ipmi_ctx_release() - kref release callback for @ctx.
+ * @kref: kref embedded in &struct lstp_ipmi_ctx
+ *
+ * Frees @ctx-owned resources once the last open fd and devres ref drop.
+ */
+static void lstp_ipmi_ctx_release(struct kref *kref)
+{
+	struct lstp_ipmi_ctx *ctx = container_of(kref, struct lstp_ipmi_ctx, kref);
+
+	lstp_ipmi_postcodes_destroy(&ctx->postcodes);
+	kfifo_free(&ctx->fifo);
+	if (ctx->ida_id >= 0)
+		ida_free(&lstp_ipmi_ida, ctx->ida_id);
+	kfree(ctx->miscdev.name);
+	mutex_destroy(&ctx->tx_mutex);
+	kfree(ctx);
+}
+
+/**
+ * lstp_ipmi_ctx_get() - Acquire a reference on @ctx.
+ * @ctx: IPMI context
+ */
+static void lstp_ipmi_ctx_get(struct lstp_ipmi_ctx *ctx)
+{
+	kref_get(&ctx->kref);
+}
+
+/**
+ * lstp_ipmi_ctx_put() - Release a reference on @ctx.
+ * @ctx: IPMI context
+ *
+ * May invoke lstp_ipmi_ctx_release() when the refcount reaches zero.
+ */
+static void lstp_ipmi_ctx_put(struct lstp_ipmi_ctx *ctx)
+{
+	kref_put(&ctx->kref, lstp_ipmi_ctx_release);
+}
+
+/**
+ * lstp_ipmi_ctx_get_cb() - void * trampoline for lstp_ipmi_ctx_get().
+ * @data: &struct lstp_ipmi_ctx
+ */
+static void lstp_ipmi_ctx_get_cb(void *data)
+{
+	lstp_ipmi_ctx_get(data);
+}
+
+/**
+ * lstp_ipmi_ctx_put_cb() - void * trampoline for lstp_ipmi_ctx_put().
+ * @data: &struct lstp_ipmi_ctx
+ *
+ * Devres action that drops the channel's initial kref from lstp_ipmi_init().
+ */
+static void lstp_ipmi_ctx_put_cb(void *data)
+{
+	lstp_ipmi_ctx_put(data);
+}
+
+/*******************************************************************************
+ * Helper functions
+ ******************************************************************************/
+
+/**
+ * to_ctx() - Get IPMI context from file pointer.
+ * @file: File pointer from file operations
+ *
+ * Retrieves the lstp_ipmi_ctx structure from the file's private_data
+ * using container_of on the embedded miscdevice.
+ *
+ * Context: Any context.
+ *
+ * Return: Pointer to the lstp_ipmi_ctx structure
+ */
+static inline struct lstp_ipmi_ctx *to_ctx(struct file *file)
+{
+	return container_of(file->private_data, struct lstp_ipmi_ctx, miscdev);
+}
+
+/*******************************************************************************
+ * Character device file operations
+ ******************************************************************************/
+
+/**
+ * lstp_ipmi_open() - Open the IPMI character device.
+ * @inode: Unused
+ * @file:  File for the opened device
+ *
+ * Exclusive-open. Bumps @ctx->kref so the fd can outlive disconnect, and
+ * rejects the post-stop / pre-misc_deregister window with -ENODEV.
+ *
+ * Context: Process context.
+ *
+ * Return: 0, -EBUSY if already open, -ENODEV if torn down.
+ */
+static int lstp_ipmi_open(struct inode *inode, struct file *file)
+{
+	struct lstp_ipmi_ctx *ctx = to_ctx(file);
+	int ret = 0;
+
+	spin_lock_irq(&ctx->lock);
+	if (lstp_ipmi_stopped(ctx))
+		ret = -ENODEV;
+	else if (ctx->running)
+		ret = -EBUSY;
+	else
+		ctx->running = true;
+	spin_unlock_irq(&ctx->lock);
+
+	if (ret)
+		return ret;
+
+	lstp_ipmi_ctx_get(ctx);
+	return 0;
+}
+
+/**
+ * lstp_ipmi_read() - Read IPMI request from the device.
+ * @file:  File for the device
+ * @buf:   User buffer
+ * @count: Maximum bytes to read
+ * @ppos:  Unused
+ *
+ * Drains the FIFO; blocks until data arrives or the channel is torn down
+ * unless O_NONBLOCK is set. Output format is &struct ipmi_lstp_msg_header
+ * followed by the IPMI payload.
+ *
+ * Context: Process context. May sleep.
+ *
+ * Return: Bytes read, or -EAGAIN / -ERESTARTSYS / -ENODEV.
+ */
+static ssize_t lstp_ipmi_read(struct file *file, char __user *buf, size_t count, loff_t *ppos)
+{
+	struct lstp_ipmi_ctx *ctx = to_ctx(file);
+	struct ipmi_lstp_msg msg;
+	unsigned long flags;
+	unsigned int len = 0;
+	int ret;
+
+	/*
+	 * Drain into a stack-local @msg under @ctx->lock, then copy_to_user
+	 * outside the lock since it may sleep. Loop to handle two threads
+	 * sharing an fd both winning the wait_event() but only one the
+	 * kfifo_out().
+	 */
+	while (!len) {
+		if (kfifo_is_empty(&ctx->fifo)) {
+			if (lstp_ipmi_stopped(ctx))
+				return -ENODEV;
+			if (file->f_flags & O_NONBLOCK)
+				return -EAGAIN;
+			ret = wait_event_interruptible(ctx->req_wq, lstp_ipmi_readable(ctx));
+			if (ret)
+				return ret;
+		}
+
+		spin_lock_irqsave(&ctx->lock, flags);
+		len = kfifo_out(&ctx->fifo, &msg, sizeof(msg));
+		spin_unlock_irqrestore(&ctx->lock, flags);
+	}
+
+	len = min_t(unsigned int, count, len);
+	if (copy_to_user(buf, &msg, len))
+		return -EFAULT;
+	return len;
+}
+
+/**
+ * lstp_ipmi_write() - Write IPMI response to the device.
+ * @file:  File for the device
+ * @buf:   User buffer holding &struct ipmi_lstp_msg_header + payload
+ * @count: Bytes available in @buf
+ * @ppos:  Unused
+ *
+ * Forwards a response to the remote endpoint. Writes whose @msg_num
+ * doesn't match the current request tag are silently dropped (return
+ * @count) so userspace doesn't have to track the race against new
+ * incoming requests.
+ *
+ * Context: Process context. Takes @ctx->tx_mutex. Performs blocking USB I/O.
+ *
+ * Return: @count, or -EINVAL / -EFAULT / -ENODEV.
+ */
+static ssize_t lstp_ipmi_write(struct file *file, const char __user *buf, size_t count,
+			       loff_t *ppos)
+{
+	struct lstp_ipmi_ctx *ctx = to_ctx(file);
+	struct lstp_channel *ch;
+	struct ipmi_lstp_msg msg;
+	ssize_t ret;
+
+	if (count < sizeof(struct ipmi_lstp_msg_header) || count > sizeof(struct ipmi_lstp_msg))
+		return -EINVAL;
+
+	if (copy_from_user(&msg, buf, count))
+		return -EFAULT;
+
+	/* Stale tag read is fine; pairs with WRITE_ONCE in the IRQ producer. */
+	if (msg.header.msg_num != READ_ONCE(ctx->msg_count))
+		return count;
+
+	if (!msg.header.len || msg.header.len > IPMI_LSTP_PAYLOAD_MAX ||
+	    count < sizeof(struct ipmi_lstp_msg_header) + msg.header.len)
+		return -EINVAL;
+
+	/*
+	 * Lock on @ctx, not @ch: open fds kref-pin @ctx, but @ch is freed
+	 * by devres once lstp_disconnect() returns, so the framework's
+	 * channel TX mutex would itself UAF for a writer preempted between
+	 * the @ctx->ch load and mutex_lock(). lstp_ipmi_stop() flips
+	 * @stopped under the same mutex, so once we hold it @ch is either
+	 * declared dead (bail) or pinned alive until we unlock.
+	 *
+	 * TODO: drop this private mutex+flag once the lstp_subsys API
+	 * exposes a kref-pinned tx fence with fd-lifetime semantics; the
+	 * per-subsystem duplication of the framework channel TX mutex
+	 * disappears then.
+	 */
+	mutex_lock(&ctx->tx_mutex);
+
+	if (ctx->stopped) {
+		ret = -ENODEV;
+		goto out_unlock;
+	}
+
+	ch = ctx->ch;
+
+	ret = lstp_send(ch, LSTP_IPMI_CMD_MESSAGE, msg.payload, msg.header.len);
+	if (ret)
+		dev_err(ch->dev, "%s: ch_%d: Could not forward response (%pe)\n", __func__,
+			ch->ch_id, ERR_PTR(ret));
+
+out_unlock:
+	mutex_unlock(&ctx->tx_mutex);
+
+	return (ret < 0) ? ret : count;
+}
+
+/**
+ * lstp_ipmi_release() - Release the IPMI character device.
+ * @inode: Unused
+ * @file:  File for the device
+ *
+ * Drops the @ctx->kref taken by lstp_ipmi_open(); the last fd to release
+ * after disconnect is what triggers lstp_ipmi_ctx_release().
+ *
+ * Return: 0.
+ */
+static int lstp_ipmi_release(struct inode *inode, struct file *file)
+{
+	struct lstp_ipmi_ctx *ctx = to_ctx(file);
+
+	spin_lock_irq(&ctx->lock);
+	ctx->running = false;
+	spin_unlock_irq(&ctx->lock);
+
+	lstp_ipmi_ctx_put(ctx);
+
+	return 0;
+}
+
+/**
+ * lstp_ipmi_poll() - Poll for readable data on the device.
+ * @file: File for the device
+ * @wait: Poll table
+ *
+ * Returns POLLIN | POLLRDNORM when the FIFO has data, EPOLLHUP after
+ * disconnect.
+ */
+static __poll_t lstp_ipmi_poll(struct file *file, poll_table *wait)
+{
+	struct lstp_ipmi_ctx *ctx = to_ctx(file);
+
+	poll_wait(file, &ctx->req_wq, wait);
+	if (lstp_ipmi_stopped(ctx))
+		return EPOLLHUP;
+	if (!kfifo_is_empty(&ctx->fifo))
+		return POLLIN | POLLRDNORM;
+
+	return 0;
+}
+
+static const struct file_operations lstp_ipmi_fops = {
+	.owner = THIS_MODULE,
+	.open = lstp_ipmi_open,
+	.read = lstp_ipmi_read,
+	.write = lstp_ipmi_write,
+	.release = lstp_ipmi_release,
+	.poll = lstp_ipmi_poll,
+};
+
+/*******************************************************************************
+ * Devres action callbacks
+ ******************************************************************************/
+
+/**
+ * lstp_ipmi_quiesce() - Mark the IPMI channel stopped and wake waiters.
+ * @ctx: IPMI context
+ *
+ * Sets @stopped under @tx_mutex and @ctx->lock so in-flight write() and
+ * blocked read()/poll() paths observe teardown.
+ *
+ * Context: Process context. Takes @tx_mutex.
+ */
+static void lstp_ipmi_quiesce(struct lstp_ipmi_ctx *ctx)
+{
+	/* Lock order: @tx_mutex (sleeping) outer, @ctx->lock (irq-safe) inner. */
+	mutex_lock(&ctx->tx_mutex);
+	spin_lock_irq(&ctx->lock);
+	/* Pairs with smp_load_acquire() in lstp_ipmi_stopped(). */
+	smp_store_release(&ctx->stopped, true);
+	spin_unlock_irq(&ctx->lock);
+	mutex_unlock(&ctx->tx_mutex);
+
+	wake_up_all(&ctx->req_wq);
+}
+
+/**
+ * lstp_ipmi_stop_and_deregister() - Devres action: stop opens and drop the miscdev.
+ * @data: &struct lstp_ipmi_ctx
+ *
+ * @ctx-owned allocations (kfifo, ida slot, miscdev.name, @ctx itself)
+ * are freed by lstp_ipmi_ctx_release() once the last fd drops the kref,
+ * so they outlive disconnect for any still-open fds.
+ */
+static void lstp_ipmi_stop_and_deregister(void *data)
+{
+	struct lstp_ipmi_ctx *ctx = data;
+
+	lstp_ipmi_quiesce(ctx);
+	misc_deregister(&ctx->miscdev);
+}
+
+/*******************************************************************************
+ * RX callback for unsolicited IPMI requests
+ ******************************************************************************/
+
+/**
+ * lstp_ipmi_irq_callback() - Handle incoming IPMI requests from the device.
+ * @ch:  LSTP channel that received the data.
+ * @pkt: Received LSTP packet (header + payload).
+ *
+ * Callback invoked when an unsolicited IPMI request is received from the
+ * remote endpoint. Validates the message length, filters out postcode
+ * messages (netfn=0x2c, cmd=0x02, group=0xAE), and queues valid requests
+ * to the FIFO for userspace to read.
+ *
+ * If the FIFO is full, oldest queued messages are dropped one at a time
+ * until the new message fits, so stale messages don't block fresh ones.
+ *
+ * Context: Interrupt context (called from USB RX completion). Acquires
+ *          @ctx->lock with irqsave. Must not sleep.
+ */
+static void lstp_ipmi_irq_callback(struct lstp_channel *ch, struct lstp_packet *pkt)
+{
+	struct lstp_ipmi_ctx *ctx = ch->priv;
+	u16 rx_len = le16_to_cpu(pkt->hdr.length);
+	struct ipmi_lstp_msg msg;
+	unsigned long flags;
+	unsigned int msg_size;
+	unsigned int dropped = 0;
+
+	if (rx_len < IPMI_MIN_MSG_LEN || rx_len > IPMI_LSTP_PAYLOAD_MAX) {
+		dev_warn(ch->dev, "%s: ch_%d: Invalid IPMI request length %u\n", __func__,
+			 ch->ch_id, rx_len);
+		return;
+	}
+
+	if (lstp_ipmi_postcodes_is_postcode(pkt->payload, rx_len)) {
+		lstp_ipmi_postcodes_send(&ctx->postcodes, pkt->payload, rx_len);
+		return;
+	}
+
+	if (!kfifo_initialized(&ctx->fifo))
+		return;
+
+	msg_size = sizeof(msg.header) + rx_len;
+	msg.header.len = rx_len;
+	memcpy(msg.payload, pkt->payload, rx_len);
+
+	spin_lock_irqsave(&ctx->lock, flags);
+	/* WRITE_ONCE pairs with the lockless READ_ONCE in lstp_ipmi_write(). */
+	msg.header.msg_num = ctx->msg_count + 1;
+	WRITE_ONCE(ctx->msg_count, msg.header.msg_num);
+	/* Drop oldest first: stale requests have likely timed out host-side. */
+	while (kfifo_avail(&ctx->fifo) < msg_size) {
+		kfifo_skip(&ctx->fifo);
+		dropped++;
+	}
+	kfifo_in(&ctx->fifo, &msg, msg_size);
+	spin_unlock_irqrestore(&ctx->lock, flags);
+
+	if (dropped)
+		dev_warn_ratelimited(ch->dev, "%s: ch_%d: FIFO full, dropped %u stale request(s)\n",
+				     __func__, ch->ch_id, dropped);
+
+	wake_up_all(&ctx->req_wq);
+}
+
+/*******************************************************************************
+ * IPMI channel initialization, start, and stop
+ ******************************************************************************/
+
+/**
+ * lstp_ipmi_init() - Initialize an LSTP IPMI channel.
+ * @ch:   LSTP channel to initialize as IPMI
+ * @info: unused
+ *
+ * Allocates and initializes the IPMI context structure, FIFO buffer, and
+ * prepares the miscdevice for the channel. The device name is either taken
+ * from the firmware node "label" property (DT or ACPI) or auto-generated
+ * as "ipmi-lstpN".
+ *
+ * Expected firmware node structure (optional)::
+ *
+ *   channel@M {
+ *       compatible = "nvidia,lstp-ipmi";
+ *       reg = <M>;                  // Channel ID
+ *       label = "ipmi-custom-name"; // Device name (optional)
+ *                                   // If omitted, uses "ipmi-lstpN"
+ *   };
+ *
+ * @ctx is kref-refcounted; the channel's initial ref is dropped via the
+ * lstp_ipmi_ctx_put_cb() devres action. @ctx-owned allocations (kfifo,
+ * ida slot, miscdev.name) are freed by the kref release callback, not
+ * via devres, so they outlive disconnect for still-open fds.
+ *
+ * Context: Process context. Called during probe before RX URB is active.
+ *
+ * Return: 0 on success, negative errno on failure
+ */
+static int lstp_ipmi_init(struct lstp_channel *ch, const struct lstp_channel_init_info *info)
+{
+	int ret;
+	struct lstp_ipmi_ctx *ctx;
+	const char *label;
+
+	ctx = kzalloc_obj(*ctx);
+	if (!ctx)
+		return -ENOMEM;
+
+	/* Init fields the release path may touch; failed devres call invokes it. */
+	kref_init(&ctx->kref);
+	ctx->ida_id = -1;
+	ctx->ch = ch;
+	spin_lock_init(&ctx->lock);
+	mutex_init(&ctx->tx_mutex);
+	init_waitqueue_head(&ctx->req_wq);
+
+	ret = devm_add_action_or_reset(ch->dev, lstp_ipmi_ctx_put_cb, ctx);
+	if (ret)
+		return ret;
+
+	ch->priv = ctx;
+
+	ret = kfifo_alloc(&ctx->fifo, BUFFER_SIZE, GFP_KERNEL);
+	if (ret)
+		return ret;
+
+	/* Get device name from firmware node label (DT or ACPI) or generate one */
+	if (ctx->ch->fwnode && !fwnode_property_read_string(ctx->ch->fwnode, "label", &label)) {
+		ctx->miscdev.name = kstrdup(label, GFP_KERNEL);
+	} else {
+		ctx->ida_id = ida_alloc(&lstp_ipmi_ida, GFP_KERNEL);
+		if (ctx->ida_id < 0)
+			return ctx->ida_id;
+		ctx->miscdev.name = kasprintf(GFP_KERNEL, "ipmi-lstp%d", ctx->ida_id);
+	}
+	if (!ctx->miscdev.name)
+		return -ENOMEM;
+
+	ctx->miscdev.minor = MISC_DYNAMIC_MINOR;
+	ctx->miscdev.fops = &lstp_ipmi_fops;
+	ctx->miscdev.parent = ch->dev;
+
+	/* Initialize postcodes support (name derived from miscdev.name) */
+	ret = lstp_ipmi_postcodes_init(&ctx->postcodes, ch->dev, ctx->miscdev.name, ctx,
+				       lstp_ipmi_ctx_get_cb, lstp_ipmi_ctx_put_cb);
+	if (ret)
+		return ret;
+
+	dev_dbg(ch->dev, "%s: ch_%d: Initialized as %s\n", __func__, ch->ch_id, ch->display_name);
+	return 0;
+}
+
+/**
+ * lstp_ipmi_start() - Start an LSTP IPMI channel.
+ * @ch: LSTP channel to start
+ *
+ * Registers the miscdevice to make the IPMI interface available to userspace
+ * and arms the lstp_ipmi_stop_and_deregister() devres action so the node is
+ * torn down on disconnect or on later probe failure. This should be called
+ * after the RX URB is active so the channel can properly receive unsolicited
+ * IPMI requests.
+ *
+ * Context: Process context. Called during probe after RX URB is active.
+ *
+ * Return: 0 on success, negative errno on failure
+ */
+static int lstp_ipmi_start(struct lstp_channel *ch)
+{
+	struct lstp_ipmi_ctx *ctx = (struct lstp_ipmi_ctx *)ch->priv;
+	int ret;
+
+	if (!ctx) {
+		dev_err(ch->dev, "%s: ch_%d: IPMI context not initialized\n", __func__, ch->ch_id);
+		return -EINVAL;
+	}
+
+	ret = misc_register(&ctx->miscdev);
+	if (ret) {
+		dev_err(ch->dev, "%s: ch_%d: Could not register miscdevice (%pe)\n", __func__,
+			ch->ch_id, ERR_PTR(ret));
+		return ret;
+	}
+
+	ret = devm_add_action_or_reset(ch->dev, lstp_ipmi_stop_and_deregister, ctx);
+	if (ret)
+		return ret;
+
+	/* Start postcodes device */
+	ret = lstp_ipmi_postcodes_start(&ctx->postcodes);
+	if (ret) {
+		devm_release_action(ch->dev, lstp_ipmi_stop_and_deregister, ctx);
+		return ret;
+	}
+
+	deprecated_lstp_channel_publish_child_dev(ch, ctx->miscdev.this_device);
+
+	dev_info(ch->dev, "%s: ch_%d: Started as %s\n", __func__, ch->ch_id, ch->display_name);
+	return 0;
+}
+
+/**
+ * lstp_ipmi_stop() - Quiesce the IPMI channel on disconnect.
+ * @ch: LSTP channel being stopped
+ *
+ * Flips @ctx->stopped and wakes blocked readers/pollers. The main miscdev is
+ * unregistered later by the lstp_ipmi_stop_and_deregister() devres action;
+ * opens that race the window are rejected via @stopped in lstp_ipmi_open().
+ */
+static void lstp_ipmi_stop(struct lstp_channel *ch)
+{
+	struct lstp_ipmi_ctx *ctx = ch->priv;
+
+	lstp_ipmi_postcodes_stop(&ctx->postcodes);
+	lstp_ipmi_quiesce(ctx);
+}
+
+/* clang-format off */
+LSTP_SUBSYS(ipmi, LSTP_CHANNEL_TYPE_IPMI, lstp_ipmi_init, lstp_ipmi_start,
+	    .fwnode_compatible = "nvidia,lstp-ipmi",
+	    .irq_callback = lstp_ipmi_irq_callback,
+	    .channel_stop = lstp_ipmi_stop,
+);
+/* clang-format on */

--- a/drivers/usb/misc/lstp/lstp-main.c
+++ b/drivers/usb/misc/lstp/lstp-main.c
@@ -1,0 +1,2462 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * LSTP USB interface driver.
+ *
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+#include <linux/cleanup.h>
+#include <linux/module.h>
+#include <linux/err.h>
+#include <linux/overflow.h>
+
+#include "lstp-main.h"
+
+enum lstp_ch0_cmd {
+	LSTP_CH0_CMD_READ_CONFIG = 0x08,
+	LSTP_CH0_CMD_WRITE_CONFIG = 0x09,
+	LSTP_CH0_CMD_LOCK = 0x0A,
+};
+
+struct lstp_ch0_config {
+	u8 lstp_version;
+	u8 num_channels; /* does not include ch0 */
+} __packed;
+
+/**
+ * struct lstp_channel_priv - Framework-private extension of struct lstp_channel.
+ * @pub:                  Public, subsystem-visible part. Must be the first
+ *                        member.
+ * @ch_type:              LSTP channel type.
+ * @subsys:               Owning subsystem descriptor.
+ * @usb:                  Back-pointer to the LSTP USB device.
+ * @tx_mutex:             Serializes outbound requests (one in flight per
+ *                        channel).
+ * @cfg_lock:             Serializes ch0 descriptor read-modify-write.
+ * @resp_buffer_lock:     Bit lock guarding @resp_buf.
+ * @irq_buffer_lock:      Bit lock guarding @irq_buf.
+ * @irq_resp_buffer_lock: Bit lock guarding the IRQ response slot.
+ * @rx_ready:             Set when a solicited response has been deposited
+ *                        in @resp_buf.
+ * @disconnected:         True once the USB device has been disconnected.
+ * @started:              Gates RX dispatch and channel_stop(); set by
+ *                        lstp_start_channels() after a successful
+ *                        channel_start(). See lstp_start_channels()
+ *                        and lstp_usb_rx_callback() for the
+ *                        release/acquire pairing.
+ * @tx_buf:               Bulk-out scratch buffer for requests.
+ * @tx_resp_buf:          Bulk-out scratch buffer for IRQ responses.
+ * @resp_buf:             Buffer for solicited responses, or NULL.
+ * @irq_buf:              Buffer for unsolicited requests, or NULL.
+ * @bulk_tx_urb:          URB for outbound requests.
+ * @bulk_tx_resp_urb:     URB for IRQ responses.
+ * @rx_wq:                Wait queue for solicited-response readers.
+ * @kobj:                 /sys/.../lstp/channel/%d directory.
+ * @child_dev:            Subsystem-side device backing the sysfs link.
+ */
+struct lstp_channel_priv {
+	struct lstp_channel pub;
+
+	u8 ch_type;
+	const struct lstp_subsys *subsys;
+	struct lstp_usb *usb;
+	struct mutex tx_mutex; /* serializes outbound requests */
+	struct mutex cfg_lock; /* serializes ch0 descriptor read-modify-write */
+	unsigned long resp_buffer_lock;
+	unsigned long irq_buffer_lock;
+	unsigned long irq_resp_buffer_lock;
+	bool rx_ready;
+	bool disconnected;
+	bool started;
+	u8 *tx_buf;
+	u8 *tx_resp_buf;
+	u8 *resp_buf;
+	u8 *irq_buf;
+	struct urb *bulk_tx_urb;
+	struct urb *bulk_tx_resp_urb;
+	wait_queue_head_t rx_wq;
+	struct kobject kobj;
+	struct device *child_dev;
+};
+
+#define to_lstp_priv(ch) container_of((ch), struct lstp_channel_priv, pub)
+
+/*
+ * lstp_create_channel() returns &priv->pub and the framework stores
+ * that pointer in dev->channels[]; to_lstp_priv() must recover the
+ * exact same address, so @pub has to sit at offset 0.
+ */
+static_assert(offsetof(struct lstp_channel_priv, pub) == 0,
+	      "struct lstp_channel must be the first member of struct lstp_channel_priv");
+
+/*******************************************************************************
+ * Forward declarations
+ ******************************************************************************/
+
+static void lstp_usb_rx_callback(struct urb *urb);
+static void lstp_rx_retry_work(struct work_struct *work);
+static void lstp_teardown(struct lstp_usb *dev);
+static void lstp_kobj_release(struct kobject *kobj);
+static void lstp_channel_kobj_release(struct kobject *kobj);
+static ssize_t lstp_name_show(struct kobject *kobj, struct kobj_attribute *attr, char *buf);
+static ssize_t lstp_channel_enable_show(struct kobject *kobj, struct kobj_attribute *attr,
+					char *buf);
+static ssize_t lstp_channel_enable_store(struct kobject *kobj, struct kobj_attribute *attr,
+					 const char *buf, size_t count);
+static ssize_t lstp_channel_name_show(struct kobject *kobj, struct kobj_attribute *attr, char *buf);
+
+/*
+ * Framework-internal per-channel TX mutex guard. The mutex serializes
+ * outbound requests so each lstp_request*() / lstp_send() helper
+ * runs as a single atomic LSTP exchange. The guard is not exported:
+ * subsystems compose multi-exchange behaviour at their own layer
+ * (e.g. via tty drain or their own subsystem-local mutex) rather than
+ * bracketing several framework helpers under the channel lock.
+ */
+DEFINE_GUARD(lstp_channel, struct lstp_channel *, mutex_lock(&to_lstp_priv(_T)->tx_mutex),
+	     mutex_unlock(&to_lstp_priv(_T)->tx_mutex))
+
+static struct kobj_attribute lstp_name_attr = __ATTR(name, 0444, lstp_name_show, NULL);
+
+static struct attribute *lstp_attrs[] = {
+	&lstp_name_attr.attr,
+	NULL,
+};
+ATTRIBUTE_GROUPS(lstp);
+
+static const struct kobj_type lstp_ktype = {
+	.release = lstp_kobj_release,
+	.sysfs_ops = &kobj_sysfs_ops,
+	.default_groups = lstp_groups,
+};
+
+static struct kobj_attribute lstp_enable_attr =
+	__ATTR(enable, 0644, lstp_channel_enable_show, lstp_channel_enable_store);
+
+static struct kobj_attribute lstp_channel_name_attr =
+	__ATTR(name, 0444, lstp_channel_name_show, NULL);
+
+static struct attribute *lstp_channel_attrs[] = {
+	&lstp_enable_attr.attr,
+	&lstp_channel_name_attr.attr,
+	NULL,
+};
+ATTRIBUTE_GROUPS(lstp_channel);
+
+static const struct kobj_type lstp_channel_ktype = {
+	.release = lstp_channel_kobj_release,
+	.sysfs_ops = &kobj_sysfs_ops,
+	.default_groups = lstp_channel_groups,
+};
+
+/* clang-format off */
+static const int lstp_errno_map[] = {
+	[LSTP_SUCCESS] = 0,
+	[LSTP_ERROR] = -EIO,
+	[LSTP_TIMEOUT] = -ETIMEDOUT,
+	[LSTP_BUSY] = -EBUSY,
+	[LSTP_NACK] = -ENXIO,
+	[LSTP_ARB_LOST] = -EAGAIN,
+	[LSTP_NOT_SUPP] = -EOPNOTSUPP,
+	[LSTP_TOO_LARGE] = -EFBIG,
+}; /* clang-format on */
+
+/**
+ * lstp_status_to_errno() - Convert LSTP protocol status to Linux errno.
+ * @status: LSTP status code from device response
+ *
+ * Return: Negative errno, or 0 on LSTP_SUCCESS.
+ */
+static int lstp_status_to_errno(u8 status)
+{
+	if (status < ARRAY_SIZE(lstp_errno_map))
+		return lstp_errno_map[status];
+
+	return -EIO;
+}
+
+/*******************************************************************************
+ * Management channel (Channel 0)
+ ******************************************************************************/
+
+/**
+ * lstp_validate_rx_pkt() - Generic validation for received LSTP packets.
+ * @dev:           LSTP USB device structure
+ * @rx_pkt:        Received packet to validate
+ * @actual_length: Actual number of bytes received from USB
+ *
+ * Checks header size, channel ID range, and payload length.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_validate_rx_pkt(struct lstp_usb *dev, struct lstp_packet *rx_pkt,
+				size_t actual_length)
+{
+	struct lstp_header *rx_hdr = &rx_pkt->hdr;
+	size_t claimed_payload_len;
+	size_t max_payload_len;
+	u8 ch_id;
+
+	/* Validate header size */
+	if (actual_length < sizeof(struct lstp_header)) {
+		dev_err(&dev->intf->dev, "%s: Packet without header (got %zu, need >=%lu)\n",
+			__func__, actual_length, sizeof(struct lstp_header));
+		return -EIO;
+	}
+
+	/* Validate channel ID */
+	ch_id = rx_hdr->ch_id;
+	if (ch_id > dev->max_ch_id) {
+		dev_err(&dev->intf->dev, "%s: Invalid channel ID (got %u, max %u)\n", __func__,
+			ch_id, dev->max_ch_id);
+		return -EIO;
+	}
+
+	claimed_payload_len = le16_to_cpu(rx_hdr->length);
+	max_payload_len = dev->bulk_rx_size - sizeof(struct lstp_header);
+
+	/* Overflow protection: validate payload length against buffer capacity */
+	/* TODO: remove/change these checks when we implement the multi-packet support */
+	if (claimed_payload_len > max_payload_len) {
+		dev_err(&dev->intf->dev, "%s: ch_%u: Payload too large (claims %zu, max %zu)\n",
+			__func__, ch_id, claimed_payload_len, max_payload_len);
+		return -EIO;
+	}
+
+	/* Underflow protection: validate received data matches claimed payload */
+	if (sizeof(struct lstp_header) + claimed_payload_len > actual_length) {
+		dev_err(&dev->intf->dev, "%s: ch_%u: Payload too short (claims %zu, got %zu)\n",
+			__func__, ch_id, claimed_payload_len,
+			actual_length - sizeof(struct lstp_header));
+		return -EIO;
+	}
+
+	return 0;
+}
+
+/**
+ * lstp_validate_resp() - Validate LSTP response packets.
+ * @dev:             Device structure for error reporting
+ * @rx_pkt:          Received packet to validate
+ * @min_payload_len:  Minimum payload length, or LSTP_ANY_RX_LEN to accept any length
+ * @lstp_status: Optional out-param. Set to the raw LSTP response status only
+ *                    when the returned errno is derived from that status; left
+ *                    untouched otherwise (payload/length validation failures).
+ *
+ * Assumes the packet has already been validated with lstp_validate_rx_pkt().
+ *
+ * Accepts payloads at least @min_payload_len bytes long; longer payloads are
+ * permitted to allow forward compatibility with newer firmware that may
+ * append additional fields.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_validate_resp(struct lstp_usb *dev, struct lstp_packet *rx_pkt,
+			      size_t min_payload_len, int *lstp_status)
+{
+	int ret;
+	struct lstp_header *rx_hdr = &rx_pkt->hdr;
+	size_t payload_len;
+	u8 ch_id = rx_hdr->ch_id;
+
+	/* Validate LSTP status */
+	ret = lstp_status_to_errno(GET_BIT_0_6(rx_hdr->status));
+	if (ret) {
+		if (lstp_status)
+			*lstp_status = GET_BIT_0_6(rx_hdr->status);
+		dev_dbg(&dev->intf->dev, "%s: ch_%u: LSTP error status %d (errno=%d)\n", __func__,
+			ch_id, GET_BIT_0_6(rx_hdr->status), ret);
+		return ret;
+	}
+
+	/* Validate payload length meets minimum */
+	payload_len = le16_to_cpu(rx_hdr->length);
+	if (payload_len < min_payload_len) {
+		dev_err(&dev->intf->dev,
+			"%s: ch_%u: Payload too short (need at least %zu, got %zu)\n", __func__,
+			ch_id, min_payload_len, payload_len);
+		return -EIO;
+	}
+
+	/*
+	 * Surface oversized payloads under dynamic debug so wire-format mismatches
+	 * are visible during investigation without spamming the kernel log on the
+	 * normal forward-compat path. Suppressed when no minimum was requested.
+	 */
+	if (min_payload_len && payload_len > min_payload_len)
+		dev_dbg(&dev->intf->dev,
+			"%s: ch_%u: Payload longer than minimum (got %zu, min %zu) -- forward-compat extension?\n",
+			__func__, ch_id, payload_len, min_payload_len);
+
+	return 0;
+}
+
+/**
+ * lstp_ch0_read_config() - Read a config slice via ch0 READ_CONFIG.
+ * @ch:       Target LSTP channel to read config from
+ * @offset:   Byte offset starting at ch_config[0]
+ * @length:   Bytes to read from ch_config[], or LSTP_READ_CONFIG_MAX to read
+ *            up to the per-packet ch_config[] limit starting at @offset.
+ * @resp_out: On success, *@resp_out points to a kmalloc'd buffer holding the
+ *            on-wire READ_CONFIG response (head + config bytes). Caller takes
+ *            ownership and must kfree()
+ * @len_out:  On success, total response bytes in *@resp_out. At least
+ *            sizeof(struct lstp_ch0_read_resp); when @length is an explicit
+ *            byte count (not LSTP_READ_CONFIG_MAX), at least @length bytes of
+ *            ch_config[] are included.
+ * @lstp_status: Optional out-param for the raw status from the final LSTP
+ *               request; see lstp_request()
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+int lstp_ch0_read_config(struct lstp_channel *ch, u16 offset, u16 length,
+			 struct lstp_ch0_read_resp **resp_out, size_t *len_out, int *lstp_status)
+{
+	struct lstp_channel *ch0;
+	struct lstp_channel_priv *priv;
+	size_t max_payload_len, actual, need;
+	u16 max_config_len, config_len;
+	struct lstp_ch0_read_req req;
+	struct lstp_ch0_read_resp *resp __free(kfree) = NULL;
+	int request_status = LSTP_NO_RESPONSE_STATUS;
+	int ret;
+
+	if (lstp_status)
+		*lstp_status = LSTP_NO_RESPONSE_STATUS;
+	if (!ch)
+		return -ENODEV;
+	priv = to_lstp_priv(ch);
+	if (!priv->usb || !priv->usb->channels[0])
+		return -ENODEV;
+	if (!resp_out || !len_out)
+		return -EINVAL;
+
+	ch0 = priv->usb->channels[0];
+	max_payload_len = ch0->max_rx_payload;
+	max_config_len = max_payload_len - offsetof(struct lstp_ch0_read_resp, ch_config);
+
+	config_len = length;
+	if (length == LSTP_READ_CONFIG_MAX)
+		config_len = max_config_len;
+	else if (length > max_config_len)
+		return -EINVAL;
+
+	resp = kzalloc(max_payload_len, GFP_KERNEL);
+	if (!resp)
+		return -ENOMEM;
+
+	req = (struct lstp_ch0_read_req){
+		.ch_id = ch->ch_id,
+		.offset = cpu_to_le16(offset),
+		.length = cpu_to_le16(config_len),
+	};
+
+	ret = lstp_request(ch0, LSTP_CH0_CMD_READ_CONFIG, &req, sizeof(req), resp, max_payload_len,
+			   &actual, &request_status);
+	if (request_status == LSTP_ERROR && offset == 0 && length == LSTP_READ_CONFIG_MAX) {
+		/*
+		 * TODO: Legacy support - remove this at some point
+		 * Fallback for old firmware that rejects an explicit
+		 * max_config_len read; retry with length=0, which it
+		 * treats as "read all that fits in one packet".
+		 */
+		dev_warn_ratelimited(ch->dev,
+				     "%s: ch_%d: Falling back to deprecated READ_CONFIG_MAX\n",
+				     __func__, ch->ch_id);
+		req.length = cpu_to_le16(DEPRECATED_LSTP_READ_CONFIG_MAX);
+		ret = lstp_request(ch0, LSTP_CH0_CMD_READ_CONFIG, &req, sizeof(req), resp,
+				   max_payload_len, &actual, &request_status);
+	}
+	if (lstp_status)
+		*lstp_status = request_status;
+	if (ret) {
+		dev_dbg(ch->dev, "%s: ch_%d: READ_CONFIG failed (%pe)\n", __func__, ch->ch_id,
+			ERR_PTR(ret));
+		return ret;
+	}
+
+	need = sizeof(*resp);
+	if (length != LSTP_READ_CONFIG_MAX)
+		need += length;
+	if (actual < need) {
+		dev_dbg(ch->dev, "%s: ch_%d: READ_CONFIG short reply: %zu < %zu\n", __func__,
+			ch->ch_id, actual, need);
+		return -EIO;
+	}
+
+	*resp_out = no_free_ptr(resp);
+	*len_out = actual;
+	return 0;
+}
+
+/**
+ * lstp_read_config_table() - Walk a channel's variable-length config entry array.
+ * @ch:                Target LSTP channel to read config from
+ * @config_head_size:  Bytes before the entry array starts (sizeof the fixed config head)
+ * @config_entry_size: Size of one wire config entry
+ * @total_entries:     Number of entries to walk
+ * @entry_fn:          Per-entry callback; @entry points into the READ_CONFIG
+ *                     response and is valid only for the duration of the call
+ * @entry_ctx:         Opaque context passed to @entry_fn
+ *
+ * Each chunk is fetched via ch0 READ_CONFIG at the computed offset into ch_config[].
+ *
+ * Return: 0 on success, or the first negative errno from a read or from @entry_fn.
+ */
+int lstp_read_config_table(struct lstp_channel *ch, size_t config_head_size,
+			   size_t config_entry_size, unsigned int total_entries,
+			   lstp_config_entry_fn entry_fn, void *entry_ctx)
+{
+	unsigned int max_entries, n_chunks, chunk, start_entry, n_entries, entry;
+	size_t avail, max_entry_bytes, offset, length;
+	int ret;
+
+	if (!total_entries)
+		return 0;
+
+	avail = ch->max_rx_payload - sizeof(struct lstp_ch0_read_resp);
+	if (!entry_fn || !config_entry_size || config_head_size > avail)
+		return -EINVAL;
+
+	/* Conservative cap: one response must hold the read head plus its entries. */
+	max_entry_bytes = avail - config_head_size;
+	max_entries = max_entry_bytes / config_entry_size; /* max entries per chunk */
+	if (!max_entries)
+		return -ENOSPC;
+
+	n_chunks = DIV_ROUND_UP(total_entries, max_entries);
+	for (chunk = 0; chunk < n_chunks; chunk++) {
+		struct lstp_ch0_read_resp *resp __free(kfree) = NULL;
+		size_t resp_len;
+
+		start_entry = chunk * max_entries;
+		n_entries = min(total_entries - start_entry, max_entries);
+		offset = config_head_size + (size_t)start_entry * config_entry_size;
+		if (check_mul_overflow(n_entries, config_entry_size, &length))
+			return -EINVAL;
+
+		ret = lstp_ch0_read_config(ch, offset, length, &resp, &resp_len, NULL);
+		if (ret) {
+			dev_err(ch->dev,
+				"%s: ch_%d: config chunk %u (entries %u-%u) failed (%pe)\n",
+				__func__, ch->ch_id, chunk, start_entry,
+				start_entry + n_entries - 1, ERR_PTR(ret));
+			return ret;
+		}
+
+		for (entry = 0; entry < n_entries; entry++) {
+			ret = entry_fn(ch, start_entry + entry,
+				       resp->ch_config + entry * config_entry_size, entry_ctx);
+			if (ret)
+				return ret;
+		}
+	}
+	return 0;
+}
+
+/**
+ * lstp_ch0_read_desc() - Read a channel's current descriptor head from the device.
+ * @ch:   Target LSTP channel whose descriptor to read
+ * @desc: Out: descriptor head (ch_type/ch_flags/ch_name) from the READ_CONFIG reply
+ *
+ * Issues a ch0 READ_CONFIG for @ch and keeps only the descriptor head. Callers
+ * that read-modify-write the descriptor hold priv->cfg_lock across this and the
+ * subsequent write so the device stays the source of truth and the exchange is
+ * atomic against other descriptor writers.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_ch0_read_desc(struct lstp_channel *ch, struct lstp_ch_desc *desc)
+{
+	struct lstp_channel_priv *priv;
+	struct lstp_channel *ch0;
+	struct lstp_ch0_read_req req;
+	int ret;
+
+	if (!ch)
+		return -ENODEV;
+	priv = to_lstp_priv(ch);
+	if (!priv->usb || !priv->usb->channels[0])
+		return -ENODEV;
+	ch0 = priv->usb->channels[0];
+
+	req = (struct lstp_ch0_read_req){
+		.ch_id = ch->ch_id,
+		.offset = cpu_to_le16(0),
+		.length = cpu_to_le16(0),
+	};
+
+	/* Fixed read: firmware may append a config trailer; keep only the desc head. */
+	ret = lstp_request(ch0, LSTP_CH0_CMD_READ_CONFIG, &req, sizeof(req), desc, sizeof(*desc),
+			   NULL, NULL);
+	if (ret)
+		dev_err(ch->dev, "%s: ch_%d: READ_CONFIG failed (%pe)\n", __func__, ch->ch_id,
+			ERR_PTR(ret));
+	return ret;
+}
+
+/**
+ * __lstp_ch0_write_config() - Raw WRITE_CONFIG sender with an explicit descriptor.
+ * @ch:         Target LSTP channel to write config to
+ * @offset:     Byte offset starting at ch_config[0]
+ * @desc:       Channel descriptor head to send with the write
+ * @config:     ch_config[] bytes to write; NULL iff @config_len == 0
+ * @config_len: Bytes from @config to write
+ *
+ * Low-level helper that sends @desc verbatim. Every WRITE_CONFIG re-sends the
+ * descriptor head, so callers that change the descriptor must serialize their
+ * read-modify-write on priv->cfg_lock and re-read @desc from the device under
+ * that lock. This raw helper stays file-local.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int __lstp_ch0_write_config(struct lstp_channel *ch, u16 offset,
+				   const struct lstp_ch_desc *desc, const void *config,
+				   u16 config_len)
+{
+	struct lstp_channel_priv *priv;
+	struct lstp_channel *ch0;
+	struct lstp_ch0_write_req *req __free(kfree) = NULL;
+	size_t req_len;
+	int ret;
+
+	if (!ch || !desc)
+		return -ENODEV;
+	priv = to_lstp_priv(ch);
+	if (!priv->usb || !priv->usb->channels[0])
+		return -ENODEV;
+	if (config_len && !config)
+		return -EINVAL;
+
+	ch0 = priv->usb->channels[0];
+	if (check_add_overflow(offsetof(struct lstp_ch0_write_req, ch_config), config_len,
+			       &req_len))
+		return -EINVAL;
+
+	req = kmalloc(req_len, GFP_KERNEL);
+	if (!req)
+		return -ENOMEM;
+
+	req->ch_id = ch->ch_id;
+	req->offset = cpu_to_le16(offset);
+	req->desc = *desc;
+	if (config_len)
+		memcpy(req->ch_config, config, config_len);
+
+	ret = lstp_request(ch0, LSTP_CH0_CMD_WRITE_CONFIG, req, req_len, NULL, 0, NULL, NULL);
+	if (ret)
+		dev_warn_ratelimited(ch->dev,
+				     "%s: ch_%d: WRITE_CONFIG failed (%pe). Config locked?\n",
+				     __func__, ch->ch_id, ERR_PTR(ret));
+
+	return ret;
+}
+
+/**
+ * lstp_ch0_set_enable() - Set/clear a channel's enable flag.
+ * @ch:      Target LSTP channel to modify
+ * @enable:  true to set LSTP_CH_FLAG_ENABLE, false to clear it
+ *
+ * Re-reads the descriptor from the device, flips LSTP_CH_FLAG_ENABLE, and
+ * writes the descriptor head back via WRITE_CONFIG, all under priv->cfg_lock.
+ * Re-reading under the lock keeps the device authoritative for ch_type/ch_name
+ * and any other ch_flags bits, while serializing against concurrent descriptor
+ * writers so an enable toggle is never lost.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_ch0_set_enable(struct lstp_channel *ch, bool enable)
+{
+	struct lstp_ch_desc desc;
+	int ret;
+
+	if (!ch)
+		return -ENODEV;
+
+	guard(mutex)(&to_lstp_priv(ch)->cfg_lock);
+
+	ret = lstp_ch0_read_desc(ch, &desc);
+	if (ret)
+		return ret;
+
+	/* Override only ch_flags; ch_type/ch_name come from the device. */
+	if (enable)
+		desc.ch_flags |= LSTP_CH_FLAG_ENABLE;
+	else
+		desc.ch_flags &= ~LSTP_CH_FLAG_ENABLE;
+
+	return __lstp_ch0_write_config(ch, 0, &desc, NULL, 0);
+}
+
+/*******************************************************************************
+ * Devres action callbacks
+ ******************************************************************************/
+
+/**
+ * lstp_put_usb_dev() - Devres callback to release USB device reference.
+ * @data: Pointer to USB device
+ */
+static void lstp_put_usb_dev(void *data)
+{
+	usb_put_dev((struct usb_device *)data);
+}
+
+/**
+ * lstp_release_urb_slot() - Devres callback to kill, free, and NULL a URB slot.
+ * @data: Pointer to the URB-pointer field (``struct urb **``) to release
+ *
+ * Reads the URB from ``*slot``, kills and frees it, and writes %NULL back
+ * to ``*slot``. Designed to be registered with
+ * devm_add_action_or_reset(); on registration failure the action fires
+ * inline and leaves the slot %NULL, so callers may use the natural
+ *
+ *     slot = usb_alloc_urb(...);
+ *     ret = devm_add_action_or_reset(dev, lstp_release_urb_slot, &slot);
+ *     if (ret) return ret;
+ *
+ * pattern without risking a dangling pointer in ``slot`` on the error
+ * path. The slot must live in a struct whose lifetime is at least as long
+ * as the devres node (typically a devm-allocated struct on the same
+ * device), since @data is dereferenced both on inline-fire and on
+ * device-unwind.
+ */
+static void lstp_release_urb_slot(void *data)
+{
+	struct urb **slot = data;
+
+	usb_kill_urb(*slot);
+	usb_free_urb(*slot);
+	*slot = NULL;
+}
+
+/**
+ * lstp_kobj_del_put() - Remove kobject from sysfs and release reference.
+ * @data: Pointer to kobject to clean up
+ */
+static void lstp_kobj_del_put(void *data)
+{
+	struct kobject *kobj = data;
+
+	kobject_del(kobj);
+	kobject_put(kobj);
+}
+
+/**
+ * lstp_kobj_release() - Release callback for the lstp kobject.
+ * @kobj: Kobject being released
+ */
+static void lstp_kobj_release(struct kobject *kobj)
+{
+	/* Intentionally empty: memory is devm-managed in struct lstp_usb */
+}
+
+/**
+ * lstp_channel_kobj_release() - Release callback for channel kobjects.
+ * @kobj: Kobject being released
+ */
+static void lstp_channel_kobj_release(struct kobject *kobj)
+{
+	/* Intentionally empty: channel memory is devm-managed */
+}
+
+/**
+ * lstp_put_fwnode() - Devres callback to release firmware node reference.
+ * @data: Pointer to fwnode_handle
+ */
+static void lstp_put_fwnode(void *data)
+{
+	fwnode_handle_put((struct fwnode_handle *)data);
+}
+
+/*******************************************************************************
+ * Sysfs attributes for channels
+ ******************************************************************************/
+
+/**
+ * lstp_sysfs_get_channel() - Get channel from sysfs kobject.
+ * @kobj: Kobject passed to sysfs callback
+ *
+ * Return: Channel pointer, or ERR_PTR on failure.
+ */
+static struct lstp_channel *lstp_sysfs_get_channel(struct kobject *kobj)
+{
+	struct lstp_channel_priv *priv;
+
+	priv = container_of(kobj, struct lstp_channel_priv, kobj);
+
+	if (!priv->usb)
+		return ERR_PTR(-ENODEV);
+
+	return &priv->pub;
+}
+
+/**
+ * lstp_name_show() - Read handler for ``lstp/name``.
+ * @kobj: Kobject for the ``lstp`` sysfs directory (embedded in lstp_usb)
+ * @attr: Sysfs kobject attribute
+ * @buf:  Output buffer for sysfs read
+ *
+ * Emits the LSTP interface name from the channel-0 discovery response.
+ *
+ * Return: Number of bytes written to buf, or negative errno on failure.
+ */
+static ssize_t lstp_name_show(struct kobject *kobj, struct kobj_attribute *attr, char *buf)
+{
+	struct lstp_usb *lstp = container_of(kobj, struct lstp_usb, lstp_kobj);
+
+	return sysfs_emit(buf, "%s\n", lstp->lstp_intf_name);
+}
+
+/**
+ * lstp_channel_enable_show() - Show channel enable status via sysfs.
+ * @kobj: Kobject for the channel (embedded in lstp_channel_priv)
+ * @attr: Sysfs kobject attribute
+ * @buf:  Output buffer for sysfs read
+ *
+ * Queries the management channel (ch0) for this channel's configuration
+ * and extracts the enable bit (bit 0 of ch_flags in READ_CONFIG response).
+ *
+ * Return: Number of bytes written to buf, or negative errno on failure.
+ */
+static ssize_t lstp_channel_enable_show(struct kobject *kobj, struct kobj_attribute *attr,
+					char *buf)
+{
+	struct lstp_channel *ch;
+	struct lstp_ch_desc desc;
+	u8 enable_bit;
+	int ret;
+
+	ch = lstp_sysfs_get_channel(kobj);
+	if (IS_ERR(ch))
+		return PTR_ERR(ch);
+
+	ret = lstp_ch0_read_desc(ch, &desc);
+	if (ret)
+		return ret;
+
+	enable_bit = (desc.ch_flags & LSTP_CH_FLAG_ENABLE) ? 1 : 0;
+
+	return sysfs_emit(buf, "%u\n", enable_bit);
+}
+
+/**
+ * lstp_channel_enable_store() - Set channel enable status via sysfs.
+ * @kobj:  Kobject for the channel (embedded in lstp_channel_priv)
+ * @attr:  Sysfs kobject attribute
+ * @buf:   Input buffer containing "0" or "1"
+ * @count: Number of bytes in buf
+ *
+ * Return: Bytes consumed, or negative errno.
+ */
+static ssize_t lstp_channel_enable_store(struct kobject *kobj, struct kobj_attribute *attr,
+					 const char *buf, size_t count)
+{
+	struct lstp_channel *ch;
+	unsigned int enable;
+	int ret;
+
+	ch = lstp_sysfs_get_channel(kobj);
+	if (IS_ERR(ch))
+		return PTR_ERR(ch);
+
+	ret = kstrtouint(buf, 0, &enable);
+	if (ret)
+		return ret;
+
+	if (enable > 1)
+		return -EINVAL;
+
+	ret = lstp_ch0_set_enable(ch, enable != 0);
+	if (ret)
+		return ret;
+
+	return count;
+}
+
+/**
+ * lstp_channel_name_show() - Show channel display name via sysfs "name" attr.
+ * @kobj: Kobject for the channel (embedded in lstp_channel_priv)
+ * @attr: Sysfs kobject attribute
+ * @buf:  Output buffer for sysfs read
+ *
+ * Emits the channel's display_name.
+ *
+ * Return: Number of bytes written to buf, or negative errno on failure.
+ */
+static ssize_t lstp_channel_name_show(struct kobject *kobj, struct kobj_attribute *attr, char *buf)
+{
+	struct lstp_channel *ch;
+
+	ch = lstp_sysfs_get_channel(kobj);
+	if (IS_ERR(ch))
+		return PTR_ERR(ch);
+
+	return sysfs_emit(buf, "%s\n", ch->display_name);
+}
+
+/**
+ * lstp_create_sysfs_hierarchy() - Create lstp sysfs ("name" + "channel/").
+ * @dev: LSTP USB device structure
+ *
+ * Under the USB interface device sysfs directory, create:
+ *     lstp/
+ *     ├── name			(LSTP interface name, read-only)
+ *     └── channel/		(per-channel sysfs parent directory)
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_create_sysfs_hierarchy(struct lstp_usb *dev)
+{
+	struct device *parent_dev = &dev->intf->dev;
+	int ret;
+
+	/* Create lstp directory (name attribute provided by lstp_ktype) */
+	ret = kobject_init_and_add(&dev->lstp_kobj, &lstp_ktype, &parent_dev->kobj, "lstp");
+	if (ret) {
+		kobject_put(&dev->lstp_kobj);
+		return ret;
+	}
+
+	ret = devm_add_action_or_reset(parent_dev, lstp_kobj_del_put, &dev->lstp_kobj);
+	if (ret)
+		return ret;
+
+	/* Create channel directory under lstp */
+	dev->channel_kobj = kobject_create_and_add("channel", &dev->lstp_kobj);
+	if (!dev->channel_kobj)
+		return -ENOMEM;
+
+	return devm_add_action_or_reset(parent_dev, lstp_kobj_del_put, dev->channel_kobj);
+}
+
+/**
+ * lstp_remove_device_link() - Devres callback to remove device symlink.
+ * @data: Pointer to channel kobject
+ */
+static void lstp_remove_device_link(void *data)
+{
+	struct kobject *kobj = data;
+
+	sysfs_remove_link(kobj, "device");
+}
+
+/**
+ * lstp_channel_link_device() - Create symlink from channel to its child device.
+ * @ch: LSTP channel (must have a child device set via
+ *      deprecated_lstp_channel_publish_child_dev())
+ *
+ * Creates a symlink named "device" under the channel's sysfs directory
+ * that points to the child device. This allows easy identification of
+ * which subsystem device corresponds to each channel.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_channel_link_device(struct lstp_channel *ch)
+{
+	struct lstp_channel_priv *priv = to_lstp_priv(ch);
+	struct device *parent_dev = ch->dev;
+	int ret;
+
+	if (WARN(!priv->child_dev, "lstp: ch_%d (%s): child_dev not set\n", ch->ch_id,
+		 priv->subsys ? priv->subsys->name : "?"))
+		return 0;
+
+	ret = sysfs_create_link(&priv->kobj, &priv->child_dev->kobj, "device");
+	if (ret) {
+		dev_err(parent_dev, "%s: ch_%d: Failed to create device symlink (%pe)\n", __func__,
+			ch->ch_id, ERR_PTR(ret));
+		return ret;
+	}
+
+	return devm_add_action_or_reset(parent_dev, lstp_remove_device_link, &priv->kobj);
+}
+
+/**
+ * lstp_create_channel_sysfs() - Create sysfs directory and attrs for channel.
+ * @ch: LSTP channel
+ *
+ * Creates a directory "lstp/channel/N" (where N is the channel ID) with
+ * "enable" and "name" attributes. "enable" is read-write and queries/updates
+ * the device via the management channel. "name" is read-only and shows the
+ * channel's display_name.
+ *
+ * Also creates a "device" symlink to the child device when one was
+ * registered via deprecated_lstp_channel_publish_child_dev().
+ *
+ * The kobject cleanup is registered via devm_add_action_or_reset() so it
+ * will be automatically handled when the USB interface is released.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_create_channel_sysfs(struct lstp_channel *ch)
+{
+	struct lstp_channel_priv *priv = to_lstp_priv(ch);
+	struct device *dev = ch->dev;
+	int ret;
+
+	ret = kobject_init_and_add(&priv->kobj, &lstp_channel_ktype, priv->usb->channel_kobj, "%d",
+				   ch->ch_id);
+	if (ret) {
+		dev_err(dev, "%s: Failed to create sysfs for ch_%d (%pe)\n", __func__, ch->ch_id,
+			ERR_PTR(ret));
+		kobject_put(&priv->kobj);
+		return ret;
+	}
+
+	ret = devm_add_action_or_reset(dev, lstp_kobj_del_put, &priv->kobj);
+	if (ret)
+		return ret;
+
+	return lstp_channel_link_device(ch);
+}
+
+/*******************************************************************************
+ * Device Tree functions
+ ******************************************************************************/
+
+/**
+ * lstp_find_channel_fwnode() - Find channel firmware node (DT or ACPI).
+ * @usb_dev_fwnode: USB device firmware node
+ * @intf_num:       Interface number
+ * @channel_id:     Channel ID
+ * @compatible:     Compatible string
+ *
+ * Finds a channel firmware node that matches the given parameters.
+ * Works transparently with Device Tree, ACPI (_DSD properties), and
+ * software nodes.
+ *
+ * Expected firmware hierarchy::
+ *
+ *   usb-device@X {                    // USB device node (usb_dev_fwnode)
+ *       compatible = "usbVVVV,PPPP";  // USB VID:PID (e.g., "usb0955,cf11")
+ *
+ *       interface@N {                 // USB interface node
+ *           reg = <N>;                // bInterfaceNumber (intf_num)
+ *
+ *           channel@M {               // LSTP channel node (returned)
+ *               reg = <M>;            // Channel ID (channel_id)
+ *               compatible = "...";   // Must match 'compatible' parameter
+ *               // Channel-specific properties and child devices...
+ *           };
+ *       };
+ *   };
+ *
+ * Return: fwnode_handle with incremented refcount on success, NULL on failure.
+ */
+static struct fwnode_handle *lstp_find_channel_fwnode(struct fwnode_handle *usb_dev_fwnode,
+						      u8 intf_num, u8 channel_id,
+						      const char *compatible)
+{
+	struct fwnode_handle *intf_node, *ch_node;
+	u32 reg;
+
+	if (!usb_dev_fwnode)
+		return NULL;
+
+	fwnode_for_each_child_node(usb_dev_fwnode, intf_node) {
+		if (fwnode_property_read_u32(intf_node, "reg", &reg) || reg != intf_num)
+			continue;
+
+		fwnode_for_each_child_node(intf_node, ch_node) {
+			if (fwnode_property_read_u32(ch_node, "reg", &reg) || reg != channel_id)
+				continue;
+			if (fwnode_property_match_string(ch_node, "compatible", compatible) < 0)
+				continue;
+			fwnode_handle_put(intf_node);
+			return ch_node;
+		}
+		fwnode_handle_put(intf_node);
+		break;
+	}
+
+	return NULL;
+}
+
+/**
+ * lstp_init_channel_fwnode() - Initialize channel's firmware node (DT or ACPI).
+ * @ch:         LSTP channel to initialize
+ * @compatible: Compatible string to match in firmware description
+ *
+ * Finds and assigns the appropriate firmware node for this channel.
+ * Works with Device Tree, ACPI, and software nodes.
+ * Registers a devm action to automatically release the node reference.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_init_channel_fwnode(struct lstp_channel *ch, const char *compatible)
+{
+	struct lstp_channel_priv *priv = to_lstp_priv(ch);
+
+	if (!compatible)
+		return 0;
+
+	ch->fwnode =
+		lstp_find_channel_fwnode(dev_fwnode(&priv->usb->udev->dev),
+					 priv->usb->intf->cur_altsetting->desc.bInterfaceNumber,
+					 ch->ch_id, compatible);
+	if (!ch->fwnode)
+		return 0;
+
+	return devm_add_action_or_reset(ch->dev, lstp_put_fwnode, ch->fwnode);
+}
+
+/**
+ * lstp_alloc_channel_bufs() - Allocate framework-owned per-channel buffers.
+ * @ch: LSTP channel whose subsystem may opt into framework-allocated buffers.
+ *
+ * Reads the LSTP_SUBSYS() descriptor on priv->subsys and devm-allocates the
+ * matching framework-owned scratch buffers and URBs against @ch->dev so they
+ * are torn down on disconnect. Called from lstp_init_subsys_channel() before
+ * channel_init() so every slot is in place before any callback fires.
+ *
+ * Always allocates @priv->resp_buf, the solicited-response landing buffer
+ * required by lstp_request*(); it is framework-private so subsystems cannot
+ * own this allocation. Only subsystem channels reach this helper, so ch0
+ * (which never lands a solicited response) never gets one.
+ *
+ * A non-NULL @irq_callback is the single signal that the subsystem handles
+ * unsolicited packets, so it gates the whole IRQ-side slot:
+ *   @priv->irq_buf           -- the RX completion hands the unsolicited
+ *                               packet to the callback without reusing the
+ *                               shared rx_buf for the next URB;
+ *   @priv->tx_resp_buf +     -- lstp_send_irq_resp() can ACK the unsolicited
+ *   @priv->bulk_tx_resp_urb     request from atomic context.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_alloc_channel_bufs(struct lstp_channel *ch)
+{
+	struct lstp_channel_priv *priv = to_lstp_priv(ch);
+	int ret;
+
+	priv->resp_buf = devm_kzalloc(ch->dev, priv->usb->bulk_rx_size, GFP_KERNEL);
+	if (!priv->resp_buf)
+		return -ENOMEM;
+
+	if (priv->subsys->irq_callback) {
+		priv->irq_buf = devm_kzalloc(ch->dev, priv->usb->bulk_rx_size, GFP_KERNEL);
+		if (!priv->irq_buf)
+			return -ENOMEM;
+
+		priv->tx_resp_buf = devm_kzalloc(ch->dev, sizeof(struct lstp_header), GFP_KERNEL);
+		if (!priv->tx_resp_buf)
+			return -ENOMEM;
+
+		priv->bulk_tx_resp_urb = usb_alloc_urb(0, GFP_KERNEL);
+		if (!priv->bulk_tx_resp_urb)
+			return -ENOMEM;
+		ret = devm_add_action_or_reset(ch->dev, lstp_release_urb_slot,
+					       &priv->bulk_tx_resp_urb);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * lstp_create_channel() - Allocate and initialize an LSTP channel.
+ * @dev:   Parent LSTP USB device.
+ * @ch_id: Channel ID to assign to the new channel.
+ *
+ * Return: Pointer to the new channel on success, NULL on allocation failure.
+ */
+static struct lstp_channel *lstp_create_channel(struct lstp_usb *dev, u8 ch_id)
+{
+	struct lstp_channel_priv *priv;
+	struct lstp_channel *ch;
+
+	priv = devm_kzalloc(&dev->intf->dev, sizeof(*priv), GFP_KERNEL);
+	if (!priv)
+		return NULL;
+	ch = &priv->pub;
+
+	priv->tx_buf = devm_kzalloc(&dev->intf->dev, dev->bulk_tx_size, GFP_KERNEL);
+	if (!priv->tx_buf)
+		return NULL;
+
+	priv->bulk_tx_urb = usb_alloc_urb(0, GFP_KERNEL);
+	if (!priv->bulk_tx_urb)
+		return NULL;
+	if (devm_add_action_or_reset(&dev->intf->dev, lstp_release_urb_slot, &priv->bulk_tx_urb))
+		return NULL;
+
+	ch->ch_id = ch_id;
+	priv->usb = dev;
+	ch->dev = &dev->intf->dev;
+	ch->max_tx_payload = dev->bulk_tx_size - sizeof(struct lstp_header);
+	ch->max_rx_payload = dev->bulk_rx_size - sizeof(struct lstp_header);
+	mutex_init(&priv->tx_mutex);
+	mutex_init(&priv->cfg_lock);
+	init_waitqueue_head(&priv->rx_wq);
+	dev->channels[ch_id] = ch;
+	return ch;
+}
+
+/**
+ * lstp_ch0_init() - Create and initialize channel 0 (management).
+ * @dev: LSTP USB device
+ *
+ * Creates ch0, reads its config via READ_CONFIG, and parses the LSTP
+ * version, channel count and interface label into @dev.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_ch0_init(struct lstp_usb *dev)
+{
+	struct lstp_ch0_read_resp *resp __free(kfree) = NULL;
+	const struct lstp_ch0_config *config;
+	struct lstp_channel *ch0;
+	struct lstp_channel_priv *priv0;
+	size_t actual;
+	int ret;
+
+	/* Create CH_0 and get READ request */
+	ch0 = lstp_create_channel(dev, 0);
+	if (!ch0) {
+		dev_err(&dev->intf->dev, "%s: Could not allocate channel 0\n", __func__);
+		return -ENOMEM;
+	}
+	priv0 = to_lstp_priv(ch0);
+	priv0->ch_type = LSTP_CHANNEL_TYPE_MGMT;
+	priv0->resp_buf = devm_kzalloc(&dev->intf->dev, dev->bulk_rx_size, GFP_KERNEL);
+	if (!priv0->resp_buf)
+		return -ENOMEM;
+
+	ret = lstp_ch0_read_config(ch0, 0, LSTP_READ_CONFIG_MAX, &resp, &actual, NULL);
+	if (ret)
+		return ret;
+
+	/* Validate expected CH0 config size */
+	if (actual < sizeof(*resp) + sizeof(struct lstp_ch0_config)) {
+		dev_err(&dev->intf->dev, "%s: ch_0: READ_CONFIG short reply: %zu < %zu\n", __func__,
+			actual, sizeof(*resp) + sizeof(struct lstp_ch0_config));
+		return -EIO;
+	}
+	config = (const struct lstp_ch0_config *)resp->ch_config;
+
+	/* Parse READ response for CH0 */
+	if (resp->desc.ch_type != LSTP_CHANNEL_TYPE_MGMT) {
+		dev_err(&dev->intf->dev, "%s: ch_0: Received wrong channel 0 type (got %d)\n",
+			__func__, resp->desc.ch_type);
+		return -EINVAL;
+	}
+
+	/* Validate interface name */
+	if (resp->desc.ch_name[0] == '\0') {
+		dev_warn(&dev->intf->dev,
+			 "%s: ch_0: Empty LSTP interface name, consider fixing it! Using default 'LSTP'\n",
+			 __func__);
+		strscpy(dev->lstp_intf_name, "LSTP", sizeof(dev->lstp_intf_name));
+	} else {
+		snprintf(dev->lstp_intf_name, sizeof(dev->lstp_intf_name), "%.*s", LSTP_CH_NAME_LEN,
+			 resp->desc.ch_name);
+	}
+	strscpy(ch0->display_name, dev->lstp_intf_name, sizeof(ch0->display_name));
+
+	/* Validate LSTP version */
+	if (config->lstp_version != LSTP_VERSION) {
+		dev_err(&dev->intf->dev, "%s: ch_0: Invalid LSTP version\n", __func__);
+		return -EINVAL;
+	}
+	dev->lstp_version = config->lstp_version;
+
+	/* Validate channel count */
+	if (config->num_channels == 0 || config->num_channels >= LSTP_MAX_CHANNELS) {
+		dev_err(&dev->intf->dev, "%s: ch_0: Invalid channel count %d (min 1, max %d)\n",
+			__func__, config->num_channels, LSTP_MAX_CHANNELS - 1);
+		return -EINVAL;
+	}
+	dev->max_ch_id = config->num_channels;
+
+	dev_info(&dev->intf->dev, "%s: LSTP v%d: device %s discovered with %d channels\n", __func__,
+		 dev->lstp_version, dev->lstp_intf_name, dev->max_ch_id);
+	return 0;
+}
+
+/* clang-format off */
+static const char * const lstp_ch_type_tags[] = {
+	[LSTP_CHANNEL_TYPE_SPI] = "SPI",
+	[LSTP_CHANNEL_TYPE_GPIO] = "GPIO",
+	[LSTP_CHANNEL_TYPE_I2C] = "I2C",
+	[LSTP_CHANNEL_TYPE_UART] = "UART",
+	[LSTP_CHANNEL_TYPE_IPMI] = "IPMI",
+	[LSTP_CHANNEL_TYPE_MMIO] = "MMIO",
+}; /* clang-format on */
+
+/**
+ * lstp_set_display_name() - Set ch->display_name from firmware or synthesize a default.
+ * @ch:          Channel (ch_id and ch_type must already be set)
+ * @ch_name:     Raw firmware ch_name (may not be NUL-terminated)
+ * @ch_name_len: Size of @ch_name buffer (typically LSTP_CH_NAME_LEN)
+ *
+ * Format: "<intf_name>_<ch_name>" or "<intf_name>_<TYPE>_CH<id>" (with a warning).
+ */
+static void lstp_set_display_name(struct lstp_channel *ch, const char *ch_name, size_t ch_name_len)
+{
+	struct lstp_channel_priv *priv = to_lstp_priv(ch);
+	size_t name_len = strnlen(ch_name, ch_name_len);
+	const char *tag;
+
+	if (name_len) {
+		snprintf(ch->display_name, sizeof(ch->display_name), "%s_%.*s",
+			 priv->usb->lstp_intf_name, (int)name_len, ch_name);
+		return;
+	}
+
+	tag = (priv->ch_type < ARRAY_SIZE(lstp_ch_type_tags)) ? lstp_ch_type_tags[priv->ch_type] :
+								NULL;
+	if (!tag)
+		tag = "UNKNOWN";
+
+	snprintf(ch->display_name, sizeof(ch->display_name), "%s_%s_CH%u",
+		 priv->usb->lstp_intf_name, tag, ch->ch_id);
+	dev_warn(ch->dev, "%s: ch_%d: Empty channel name, consider fixing it! Using default '%s'\n",
+		 __func__, ch->ch_id, ch->display_name);
+}
+
+/**
+ * lstp_init_subsys_channel() - Bring up a single subsystem channel (1..N).
+ * @dev:   LSTP USB device
+ * @ch_id: Channel id to initialise
+ *
+ * Reads the channel descriptor and runs the matching subsystem's
+ * channel_init(). Unsupported channel types are a no-op success.
+ *
+ * Return: 0 on success (including unsupported-type), negative errno on failure.
+ */
+static int lstp_init_subsys_channel(struct lstp_usb *dev, u8 ch_id)
+{
+	struct lstp_ch0_read_resp *resp __free(kfree) = NULL;
+	struct lstp_channel_init_info info;
+	struct lstp_channel_priv *priv;
+	struct lstp_channel *ch;
+	size_t resp_len;
+	int ret;
+
+	ch = lstp_create_channel(dev, ch_id);
+	if (!ch)
+		return -ENOMEM;
+	priv = to_lstp_priv(ch);
+
+	ret = lstp_ch0_read_config(ch, 0, LSTP_READ_CONFIG_MAX, &resp, &resp_len, NULL);
+	if (ret)
+		return ret;
+
+	priv->ch_type = resp->desc.ch_type;
+	lstp_set_display_name(ch, resp->desc.ch_name, LSTP_CH_NAME_LEN);
+
+	priv->subsys = lstp_subsys_by_channel_type(priv->ch_type);
+	if (!priv->subsys) {
+		dev_warn(&dev->intf->dev, "%s: ch_%d: Unsupported channel type %d\n", __func__,
+			 ch->ch_id, priv->ch_type);
+		return 0;
+	}
+
+	ret = lstp_init_channel_fwnode(ch, priv->subsys->fwnode_compatible);
+	if (ret)
+		goto err_clear_subsys;
+
+	ret = lstp_alloc_channel_bufs(ch);
+	if (ret)
+		goto err_clear_subsys;
+
+	info = (struct lstp_channel_init_info){
+		.config = resp->ch_config,
+		.config_len = resp_len - sizeof(*resp),
+	};
+	ret = priv->subsys->channel_init(ch, &info);
+	if (ret)
+		goto err_clear_subsys;
+
+	return 0;
+
+err_clear_subsys:
+	priv->subsys = NULL;
+	return ret;
+}
+
+/**
+ * lstp_init_channels() - Discover and initialize all LSTP channels.
+ * @dev: LSTP USB device structure
+ *
+ * Calls lstp_ch0_init() then creates and initializes channels 1...max_ch_id.
+ * Does NOT register with Linux subsystems; call lstp_start_channels() after.
+ *
+ * Return: 0 on success, negative errno if ch0 fails. Per-channel failures are
+ * logged and skipped; whether any subsystem channel actually comes online is
+ * determined by lstp_start_channels().
+ */
+static int lstp_init_channels(struct lstp_usb *dev)
+{
+	int ret;
+	int ch_id;
+
+	ret = lstp_ch0_init(dev);
+	if (ret)
+		return ret;
+
+	for (ch_id = 1; ch_id <= dev->max_ch_id; ch_id++) {
+		ret = lstp_init_subsys_channel(dev, ch_id);
+		if (ret) {
+			dev_err(&dev->intf->dev,
+				"%s: ch_%d: Channel initialization failed. (%pe)\n", __func__,
+				ch_id, ERR_PTR(ret));
+			continue;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * lstp_start_channels() - Register all channels with Linux subsystems.
+ * @dev: LSTP USB device structure
+ *
+ * Call after lstp_init_channels() and RX URB submission.
+ *
+ * Return: 0 if at least one subsystem channel starts; -ENODEV if none do
+ * (every startable channel failed, or none were startable).
+ */
+static int lstp_start_channels(struct lstp_usb *dev)
+{
+	int started_count = 0;
+	int ret;
+	int i;
+	struct lstp_channel *ch;
+
+	for (i = 1; i < LSTP_MAX_CHANNELS; i++) {
+		struct lstp_channel_priv *priv;
+
+		ch = dev->channels[i];
+		if (!ch)
+			continue;
+		priv = to_lstp_priv(ch);
+		if (!priv->subsys)
+			continue;
+
+		ret = priv->subsys->channel_start(ch);
+		if (ret) {
+			dev_err(&dev->intf->dev, "%s: ch_%d: Channel failed to start. (%pe)\n",
+				__func__, i, ERR_PTR(ret));
+			priv->subsys = NULL;
+			continue;
+		}
+
+		started_count++;
+
+		smp_store_release(&priv->started, true); /* publish; RX dispatch load-acquires */
+
+		ret = lstp_create_channel_sysfs(ch);
+		if (ret) {
+			/*
+			 * Per-channel sysfs is diagnostic/control surface only. If it fails,
+			 * keep the already-started subsystem online so the channel remains usable.
+			 */
+			dev_err(&dev->intf->dev,
+				"%s: ch_%d: Channel sysfs creation failed. (%pe)\n", __func__, i,
+				ERR_PTR(ret));
+			continue;
+		}
+	}
+
+	if (!started_count) {
+		dev_err(&dev->intf->dev, "%s: No channels started\n", __func__);
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+/**
+ * lstp_probe() - USB driver probe function.
+ * @intf: USB interface being probed
+ * @id:   USB device ID that matched
+ *
+ * Two-phase init: lstp_init_channels() discovers/allocates, then after
+ * RX URB setup, lstp_start_channels() registers with Linux subsystems.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_probe(struct usb_interface *intf, const struct usb_device_id *id)
+{
+	struct usb_device *udev = usb_get_dev(interface_to_usbdev(intf));
+	struct usb_endpoint_descriptor *ep_in, *ep_out;
+	struct lstp_usb *dev;
+	int ret;
+
+	dev = devm_kzalloc(&intf->dev, sizeof(*dev), GFP_KERNEL);
+	if (!dev) {
+		usb_put_dev(udev);
+		return -ENOMEM;
+	}
+
+	ret = devm_add_action_or_reset(&intf->dev, lstp_put_usb_dev, udev);
+	if (ret)
+		return ret;
+
+	ret = usb_find_common_endpoints(intf->cur_altsetting, &ep_in, &ep_out, NULL, NULL);
+	if (ret) {
+		dev_err(&intf->dev, "%s: Could not find bulk endpoints\n", __func__);
+		return ret;
+	}
+
+	dev->udev = udev;
+	dev->intf = intf;
+	dev->max_ch_id = 255; /* Maximum possible before device discovery */
+	dev->bulk_in_ep = ep_in->bEndpointAddress;
+	dev->bulk_out_ep = ep_out->bEndpointAddress;
+	dev->bulk_tx_size = min_t(size_t, usb_endpoint_maxp(ep_out), LSTP_USB_EP_MAX_SIZE);
+	dev->bulk_rx_size = min_t(size_t, usb_endpoint_maxp(ep_in), LSTP_USB_EP_MAX_SIZE);
+
+	/* Validate minimum size */
+	if (dev->bulk_tx_size < LSTP_USB_EP_MIN_SIZE || dev->bulk_rx_size < LSTP_USB_EP_MIN_SIZE) {
+		dev_err(&intf->dev, "%s: Invalid endpoint sizes (tx=%zu, rx=%zu, min=%u)\n",
+			__func__, dev->bulk_tx_size, dev->bulk_rx_size, LSTP_USB_EP_MIN_SIZE);
+		return -EINVAL;
+	}
+
+	dev->rx_buf = devm_kzalloc(&intf->dev, dev->bulk_rx_size, GFP_KERNEL);
+	if (!dev->rx_buf)
+		return -ENOMEM;
+
+	dev->bulk_rx_urb = usb_alloc_urb(0, GFP_KERNEL);
+	if (!dev->bulk_rx_urb)
+		return -ENOMEM;
+	ret = devm_add_action_or_reset(&intf->dev, lstp_release_urb_slot, &dev->bulk_rx_urb);
+	if (ret)
+		return ret;
+
+	usb_set_intfdata(intf, dev);
+
+	INIT_DELAYED_WORK(&dev->bulk_rx_retry.work, lstp_rx_retry_work);
+
+	usb_fill_bulk_urb(dev->bulk_rx_urb, dev->udev, usb_rcvbulkpipe(dev->udev, dev->bulk_in_ep),
+			  dev->rx_buf, dev->bulk_rx_size, lstp_usb_rx_callback, dev);
+	ret = usb_submit_urb(dev->bulk_rx_urb, GFP_KERNEL);
+	if (ret) {
+		dev_err(&intf->dev, "%s: Could not submit bulk RX URB (%pe)\n", __func__,
+			ERR_PTR(ret));
+		return ret;
+	}
+
+	ret = lstp_init_channels(dev);
+	if (ret)
+		goto err_teardown;
+
+	ret = lstp_create_sysfs_hierarchy(dev);
+	if (ret) {
+		dev_err(&intf->dev, "%s: Failed to create sysfs hierarchy (%pe)\n", __func__,
+			ERR_PTR(ret));
+		goto err_teardown;
+	}
+
+	ret = lstp_start_channels(dev);
+	if (ret)
+		goto err_teardown;
+
+	dev_info(&intf->dev, "%s: LSTP device initialized successfully\n", __func__);
+	return 0;
+
+err_teardown:
+	dev_err(&intf->dev, "%s: Probe failed (%pe)\n", __func__, ERR_PTR(ret));
+	lstp_teardown(dev);
+	return ret;
+}
+
+/*******************************************************************************
+ * Channel Signaling Helpers
+ ******************************************************************************/
+
+/**
+ * lstp_signal_disconnect() - Signal all channels that the device is disconnected.
+ * @dev: LSTP USB device structure
+ */
+static void lstp_signal_disconnect(struct lstp_usb *dev)
+{
+	for (int i = 0; i < LSTP_MAX_CHANNELS; i++) {
+		struct lstp_channel_priv *priv;
+
+		if (!dev->channels[i])
+			continue;
+		priv = to_lstp_priv(dev->channels[i]);
+		/*
+		 * Pairs with smp_load_acquire() in lstp_channel_disconnected().
+		 * Ensures the flag is visible to the waiter before wake_up_all().
+		 */
+		smp_store_release(&priv->disconnected, true);
+		wake_up_all(&priv->rx_wq);
+	}
+}
+
+/**
+ * lstp_ch_signal_response() - Signal that a response has been received on a channel.
+ * @ch: LSTP channel that received the response
+ */
+static void lstp_ch_signal_response(struct lstp_channel *ch)
+{
+	struct lstp_channel_priv *priv = to_lstp_priv(ch);
+
+	/*
+	 * Pairs with smp_load_acquire() in lstp_ch_got_response().
+	 * Release semantics ensure the memcpy into resp_buf is visible
+	 * to readers before rx_ready becomes true.
+	 */
+	smp_store_release(&priv->rx_ready, true); /* release; pairs w/ got_response() */
+	wake_up_all(&priv->rx_wq);
+}
+
+/**
+ * lstp_ch_got_response() - Check if a solicited response has been received.
+ * @ch: LSTP channel to check
+ *
+ * Return: true if a response is available in resp_buf.
+ */
+static inline bool lstp_ch_got_response(struct lstp_channel *ch)
+{
+	return smp_load_acquire(&to_lstp_priv(ch)->rx_ready); /* pairs w/ signal_response */
+}
+
+/**
+ * lstp_ch_should_wake() - wait_event condition for lstp_request_xfer().
+ * @ch: LSTP channel to check
+ *
+ * Return: true if the waiter should wake (response received or device disconnected).
+ */
+static inline bool lstp_ch_should_wake(struct lstp_channel *ch)
+{
+	return lstp_ch_got_response(ch) || lstp_channel_disconnected(ch);
+}
+
+/*******************************************************************************
+ * Channel Lifecycle / Teardown
+ ******************************************************************************/
+
+/**
+ * lstp_stop_rx() - Quiesce the RX path.
+ * @dev: LSTP USB device structure
+ *
+ * Poison first so any racing resubmit (callback or worker) gets -EPERM,
+ * then drain the worker.
+ */
+static void lstp_stop_rx(struct lstp_usb *dev)
+{
+	usb_poison_urb(dev->bulk_rx_urb);
+	cancel_delayed_work_sync(&dev->bulk_rx_retry.work);
+}
+
+/**
+ * lstp_stop_channels() - Stop all channels in reverse start order.
+ * @dev: LSTP USB device structure
+ *
+ * Mirrors lstp_start_channels() so subsystems are torn down in the
+ * opposite order they were brought up. Skips channels that never started.
+ */
+static void lstp_stop_channels(struct lstp_usb *dev)
+{
+	for (int i = LSTP_MAX_CHANNELS - 1; i >= 1; i--) {
+		struct lstp_channel *ch = dev->channels[i];
+		struct lstp_channel_priv *priv;
+
+		if (!ch)
+			continue;
+		priv = to_lstp_priv(ch);
+
+		if (priv->started && priv->subsys && priv->subsys->channel_stop)
+			priv->subsys->channel_stop(ch);
+	}
+}
+
+/**
+ * lstp_stop_tx() - Quiesce all per-channel TX URBs.
+ * @dev: LSTP USB device structure
+ *
+ * Poison the request and IRQ-response URBs on every initialised channel
+ * so any racing usb_submit_urb() returns -EPERM. Safe on never-submitted
+ * URBs.
+ */
+static void lstp_stop_tx(struct lstp_usb *dev)
+{
+	for (int i = 0; i < LSTP_MAX_CHANNELS; i++) {
+		struct lstp_channel *ch = dev->channels[i];
+		struct lstp_channel_priv *priv;
+
+		if (!ch)
+			continue;
+		priv = to_lstp_priv(ch);
+
+		usb_poison_urb(priv->bulk_tx_urb);
+		usb_poison_urb(priv->bulk_tx_resp_urb);
+	}
+}
+
+/**
+ * lstp_drain_inflight() - Wait for in-flight per-channel I/O to complete.
+ * @dev: LSTP USB device
+ *
+ * Called after lstp_signal_disconnect() so the disconnect flag is already
+ * published. Acquires and immediately releases each channel's tx_mutex:
+ * any caller currently holding the mutex finishes its USB submission and
+ * drops the lock before this returns; any caller arriving afterwards
+ * acquires the mutex uncontested, observes the disconnect flag while
+ * holding it, and bails with -ENODEV.
+ *
+ * Pairs with the "check lstp_channel_disconnected() under tx_mutex"
+ * contract followed by every public USB I/O helper. Together they
+ * guarantee no caller is using priv->tx_buf or priv->resp_buf by the
+ * time devres unwinds them on interface unbind.
+ */
+static void lstp_drain_inflight(struct lstp_usb *dev)
+{
+	for (int i = 0; i < LSTP_MAX_CHANNELS; i++) {
+		struct lstp_channel *ch = dev->channels[i];
+		struct lstp_channel_priv *priv;
+
+		if (!ch)
+			continue;
+		priv = to_lstp_priv(ch);
+		mutex_lock(&priv->tx_mutex);
+		mutex_unlock(&priv->tx_mutex);
+	}
+}
+
+/**
+ * lstp_teardown() - Ordered driver-level teardown of the LSTP device.
+ * @dev: LSTP USB device structure
+ *
+ * Shared by lstp_disconnect() and the lstp_probe() error path (USB core
+ * does not call .disconnect() on probe failure). RX must stop before
+ * channel_stop, or the dispatcher can race teardown. After
+ * lstp_signal_disconnect() publishes the per-channel disconnect flag,
+ * lstp_drain_inflight() drains any in-flight public USB I/O caller so
+ * no caller is still touching a channel TX/RX buffer when devres
+ * unwinds it on interface unbind.
+ */
+static void lstp_teardown(struct lstp_usb *dev)
+{
+	/* RX must stop before channel_stop, or the dispatcher can race teardown. */
+	lstp_stop_rx(dev);
+
+	lstp_signal_disconnect(dev);
+	lstp_drain_inflight(dev);
+	lstp_stop_channels(dev);
+	lstp_stop_tx(dev);
+}
+
+/**
+ * lstp_disconnect() - USB driver disconnect function.
+ * @intf: USB interface being disconnected
+ *
+ * Ordered teardown; remaining cleanup runs via devres on interface unbind.
+ */
+static void lstp_disconnect(struct usb_interface *intf)
+{
+	struct lstp_usb *dev = usb_get_intfdata(intf);
+
+	dev_info(&intf->dev, "%s: LSTP device disconnected\n", __func__);
+
+	if (!dev)
+		return;
+
+	lstp_teardown(dev);
+}
+
+/*******************************************************************************
+ * USB Helper Functions
+ ******************************************************************************/
+
+/**
+ * lstp_usb_tx_callback() - USB TX URB completion callback.
+ * @urb: Completed transmit URB
+ */
+static void lstp_usb_tx_callback(struct urb *urb)
+{
+	struct lstp_channel *ch = urb->context;
+
+	if (urb->status != 0 && urb->status != -ENOENT && urb->status != -ECONNRESET &&
+	    urb->status != -ESHUTDOWN) {
+		dev_warn(ch->dev, "%s: ch_%d: TX URB error (%pe)\n", __func__, ch->ch_id,
+			 ERR_PTR(urb->status));
+	}
+}
+
+/**
+ * lstp_usb_resp_tx_callback() - Completion callback for @bulk_tx_resp_urb.
+ * @urb: Completed transmit URB
+ *
+ * Clears @priv->irq_resp_buffer_lock on every completion path (including kill
+ * paths -ENOENT / -ECONNRESET / -ESHUTDOWN) so the bit never gets stuck
+ * across disconnect/re-probe.
+ */
+static void lstp_usb_resp_tx_callback(struct urb *urb)
+{
+	struct lstp_channel *ch = urb->context;
+
+	if (urb->status != 0 && urb->status != -ENOENT && urb->status != -ECONNRESET &&
+	    urb->status != -ESHUTDOWN) {
+		dev_warn(ch->dev, "%s: ch_%d: RX response TX URB error (%pe)\n", __func__,
+			 ch->ch_id, ERR_PTR(urb->status));
+	}
+
+	clear_bit(LSTP_BUFFER_LOCK_BIT, &to_lstp_priv(ch)->irq_resp_buffer_lock);
+}
+
+/**
+ * lstp_send_irq_resp() - Post a zero-payload response for an unsolicited RX packet.
+ * @ch:     LSTP channel that received the IRQ packet
+ * @status: Status byte to return to firmware (bit 7 is forced to 1 = response)
+ *
+ * Builds a header-only response packet in the framework-private TX response
+ * buffer and submits it on the framework-private TX response URB with
+ * GFP_ATOMIC. The response slot exists for exactly the channels whose
+ * subsystem declares an @irq_callback (see lstp_alloc_channel_bufs()), which
+ * are the only channels from which this helper is reachable.
+ *
+ * Intended to be called from an ``irq_callback`` handler (atomic context,
+ * USB RX completion path), where the caller has no meaningful recovery for
+ * a submission failure - errors are logged here and the function returns
+ * void (fire-and-forget).
+ *
+ * @priv->irq_resp_buffer_lock serializes the per-channel response slot,
+ * preventing concurrent reuse while a previous response is still DMA'ing.
+ * Under a strictly 1-in-flight firmware contract the guard should never
+ * trip; any hit is logged (ratelimited) as an actionable anomaly.
+ */
+void lstp_send_irq_resp(struct lstp_channel *ch, u8 status)
+{
+	struct lstp_channel_priv *priv;
+	struct lstp_packet *tx_pkt;
+	int ret;
+
+	if (!ch)
+		return;
+	priv = to_lstp_priv(ch);
+	if (!priv->usb || !priv->usb->udev)
+		return;
+
+	/*
+	 * The response slot is allocated only for channels whose subsystem
+	 * declares an irq_callback (see lstp_alloc_channel_bufs()). Bail
+	 * explicitly rather than relying on that invariant by static review.
+	 */
+	if (!priv->tx_resp_buf || !priv->bulk_tx_resp_urb)
+		return;
+
+	if (test_and_set_bit(LSTP_BUFFER_LOCK_BIT, &priv->irq_resp_buffer_lock)) {
+		dev_warn_ratelimited(ch->dev,
+				     "%s: ch_%d: Dropping response - prior URB in flight\n",
+				     __func__, ch->ch_id);
+		return;
+	}
+
+	tx_pkt = (struct lstp_packet *)priv->tx_resp_buf;
+	tx_pkt->hdr.ch_id = ch->ch_id;
+	tx_pkt->hdr.length = cpu_to_le16(0);
+	tx_pkt->hdr.status = SET_U8_BYTE(status, 1);
+
+	usb_fill_bulk_urb(priv->bulk_tx_resp_urb, priv->usb->udev,
+			  usb_sndbulkpipe(priv->usb->udev, priv->usb->bulk_out_ep), tx_pkt,
+			  sizeof(struct lstp_header), lstp_usb_resp_tx_callback, ch);
+
+	ret = usb_submit_urb(priv->bulk_tx_resp_urb, GFP_ATOMIC);
+	if (ret) {
+		clear_bit(LSTP_BUFFER_LOCK_BIT, &priv->irq_resp_buffer_lock);
+		dev_err_ratelimited(ch->dev, "%s: ch_%d: Failed to submit TX URB (%pe)\n", __func__,
+				    ch->ch_id, ERR_PTR(ret));
+	}
+}
+
+/*
+ * Retry indefinitely with bounded exponential backoff. No attempt budget:
+ * giving up on transient pressure (-ENOMEM, etc.) would permanently kill
+ * RX even when the underlying condition would self-heal.
+ *
+ * BASE_DELAY: minimum gap before the worker reposts the RX URB. Used both
+ *             as the entry delay after a usb_submit_urb() failure and as a
+ *             throttle for URB completion errors (e.g. -EPROTO from a
+ *             babbling / mid-disconnect device) so we don't tight-loop the
+ *             HCD from the completion callback. Kept well under
+ *             LSTP_USB_RESPONSE_TIMEOUT_MS so a single transient blip does
+ *             not burn the protocol's response budget.
+ * MAX_DELAY:  ceiling for repeated submit failures' exponential backoff.
+ */
+#define LSTP_RX_RETRY_BASE_DELAY_MS 50
+#define LSTP_RX_RETRY_MAX_DELAY_MS 1000
+#define LSTP_RX_RETRY_MAX_BACKOFF_SHIFT 5
+
+/**
+ * lstp_rx_retry_backoff_ms() - Compute next RX retry delay.
+ * @failures: Consecutive submit failure count (0 == first attempt)
+ *
+ * Doubles per attempt up to LSTP_RX_RETRY_MAX_DELAY_MS.
+ *
+ * Return: Delay in milliseconds before the next retry attempt.
+ */
+static unsigned long lstp_rx_retry_backoff_ms(unsigned int failures)
+{
+	unsigned int shift = failures ? min(failures - 1, LSTP_RX_RETRY_MAX_BACKOFF_SHIFT) : 0;
+	unsigned long ms = (unsigned long)LSTP_RX_RETRY_BASE_DELAY_MS << shift;
+
+	return min_t(unsigned long, ms, LSTP_RX_RETRY_MAX_DELAY_MS);
+}
+
+/**
+ * lstp_rx_handle_err() - Defer or terminate RX after a URB error.
+ * @dev:      LSTP USB device structure
+ * @ret:      Errno from a usb_submit_urb() failure or a URB completion
+ * @delay_ms: Backoff delay if scheduling a retry
+ *
+ * Records @ret in @bulk_rx_retry.last_err so the worker can act on it
+ * (e.g. clear the endpoint halt for -EPIPE). Terminal teardown errnos
+ * signal disconnect silently; everything else schedules the worker.
+ */
+static void lstp_rx_handle_err(struct lstp_usb *dev, int ret, unsigned long delay_ms)
+{
+	struct lstp_rx_retry *rxr = &dev->bulk_rx_retry;
+
+	WRITE_ONCE(rxr->last_err, ret);
+
+	/*
+	 * -EPERM is the usb_poison_urb() fence set in lstp_stop_rx();
+	 * -ENODEV/-ESHUTDOWN mean the device or HCD is gone. All three are
+	 * the expected outcome of disconnect, not failures: signal the
+	 * disconnect path and stop reposting. lstp_disconnect() already
+	 * logs the device removal, so no message here.
+	 */
+	if (ret == -ENODEV || ret == -ESHUTDOWN || ret == -EPERM) {
+		lstp_signal_disconnect(dev);
+		return;
+	}
+
+	/*
+	 * Wire-side completion errors (-EPROTO/-EOVERFLOW/-EILSEQ) come
+	 * from a babbling or otherwise misbehaving device and can fire
+	 * back-to-back, so ratelimit them. Everything else (notably
+	 * submit-side -ENOMEM/-EAGAIN/-EINVAL from the worker) is rare and
+	 * per-event diagnostic, so log unconditionally; the worker's
+	 * exponential backoff already throttles repeats.
+	 */
+	if (ret == -EPROTO || ret == -EOVERFLOW || ret == -EILSEQ)
+		dev_warn_ratelimited(&dev->intf->dev,
+				     "%s: RX URB transient error (%pe), retry in %lums\n", __func__,
+				     ERR_PTR(ret), delay_ms);
+	else
+		dev_warn(&dev->intf->dev, "%s: RX URB transient error (%pe), retry in %lums\n",
+			 __func__, ERR_PTR(ret), delay_ms);
+
+	schedule_delayed_work(&rxr->work, msecs_to_jiffies(delay_ms));
+}
+
+/**
+ * lstp_rx_retry_work() - Process-context fallback for the RX completion
+ *                        callback's atomic-context resubmit.
+ * @work: &struct lstp_rx_retry.work embedded in &struct lstp_usb
+ *
+ * Clears endpoint halts on -EPIPE, then retries the RX URB with GFP_KERNEL.
+ * Failures are handed to lstp_rx_handle_err() with an exponential
+ * backoff.
+ */
+static void lstp_rx_retry_work(struct work_struct *work)
+{
+	struct lstp_rx_retry *rxr = container_of(to_delayed_work(work), struct lstp_rx_retry, work);
+	struct lstp_usb *dev = container_of(rxr, struct lstp_usb, bulk_rx_retry);
+	int last_err = READ_ONCE(rxr->last_err);
+	int ret;
+
+	if (last_err == -EPIPE) {
+		ret = usb_clear_halt(dev->udev, usb_rcvbulkpipe(dev->udev, dev->bulk_in_ep));
+		if (ret)
+			dev_warn(&dev->intf->dev, "%s: usb_clear_halt failed (%pe)\n", __func__,
+				 ERR_PTR(ret));
+	}
+
+	ret = usb_submit_urb(dev->bulk_rx_urb, GFP_KERNEL);
+	if (ret == 0) {
+		if (rxr->failures)
+			dev_info(&dev->intf->dev, "%s: RX URB resubmitted after %u failure(s)\n",
+				 __func__, rxr->failures);
+		rxr->failures = 0;
+		return;
+	}
+
+	rxr->failures++;
+	lstp_rx_handle_err(dev, ret, lstp_rx_retry_backoff_ms(rxr->failures));
+}
+
+/**
+ * lstp_usb_rx_callback() - USB RX URB completion callback.
+ * @urb: Completed receive URB
+ *
+ * Routes requests (bit7=0) to irq_callback, responses (bit7=1) to waiters.
+ */
+static void lstp_usb_rx_callback(struct urb *urb)
+{
+	struct lstp_usb *dev = urb->context;
+	int ret;
+
+	/* URB killed during disconnect */
+	if (urb->status == -ENOENT || urb->status == -ECONNRESET || urb->status == -ESHUTDOWN) {
+		lstp_signal_disconnect(dev);
+		return;
+	}
+
+	/*
+	 * Persistent HCD errors (e.g. -EPROTO from a babbling or mid-disconnect
+	 * device) can fire back-to-back. Defer resubmit to the worker instead
+	 * of tight-looping the HCD from atomic context.
+	 */
+	if (urb->status) {
+		lstp_rx_handle_err(dev, urb->status, LSTP_RX_RETRY_BASE_DELAY_MS);
+		return;
+	}
+
+	struct lstp_packet *rx_pkt = (struct lstp_packet *)dev->rx_buf;
+
+	if (lstp_validate_rx_pkt(dev, rx_pkt, urb->actual_length))
+		goto resubmit;
+
+	/* Get channel - ch_id already bound checked by lstp_validate_rx_pkt() */
+	u8 ch_id = rx_pkt->hdr.ch_id;
+	struct lstp_channel *ch = dev->channels[ch_id];
+	struct lstp_channel_priv *priv;
+
+	if (!ch) {
+		dev_err(&dev->intf->dev, "%s: ch_%d: Channel not registered\n", __func__, ch_id);
+		goto resubmit;
+	}
+	priv = to_lstp_priv(ch);
+
+	bool in_service = smp_load_acquire(&priv->started); /* pairs w/ start_channels */
+
+	if (in_service && GET_BIT_7(rx_pkt->hdr.status) == 0 && priv->subsys &&
+	    priv->subsys->irq_callback && priv->irq_buf) {
+		/* Unsolicited request -> irq_buf + callback */
+		if (test_and_set_bit(LSTP_BUFFER_LOCK_BIT, &priv->irq_buffer_lock)) {
+			dev_warn(ch->dev, "%s: ch_%d: Dropping request - irq buffer busy\n",
+				 __func__, ch_id);
+		} else {
+			dev_dbg(ch->dev, "%s: ch_%d: Received unsolicited request (IRQ event)\n",
+				__func__, ch_id);
+			memcpy(priv->irq_buf, dev->rx_buf, urb->actual_length);
+			priv->subsys->irq_callback(ch, (struct lstp_packet *)priv->irq_buf);
+			clear_bit(LSTP_BUFFER_LOCK_BIT, &priv->irq_buffer_lock);
+		}
+	} else if (GET_BIT_7(rx_pkt->hdr.status) == 1 && priv->resp_buf) {
+		/* Solicited response -> rx_buf + wake helper */
+		if (!test_bit(LSTP_BUFFER_LOCK_BIT, &priv->resp_buffer_lock)) {
+			dev_warn(ch->dev, "%s: ch_%d: Dropping response - no one waiting\n",
+				 __func__, ch_id);
+		} else {
+			memcpy(priv->resp_buf, dev->rx_buf, urb->actual_length);
+			lstp_ch_signal_response(ch);
+		}
+	} else {
+		dev_err_ratelimited(ch->dev, "%s: ch_%d: Dropping packet - channel misconfigured\n",
+				    __func__, ch_id);
+	}
+
+resubmit:
+	ret = usb_submit_urb(urb, GFP_ATOMIC);
+	if (ret)
+		lstp_rx_handle_err(dev, ret, LSTP_RX_RETRY_BASE_DELAY_MS);
+}
+
+/**
+ * lstp_channel_disconnected() - Check if the channel's USB device has been disconnected.
+ * @ch: LSTP channel to check.
+ *
+ * Return: true if the USB device has been disconnected.
+ */
+bool lstp_channel_disconnected(const struct lstp_channel *ch)
+{
+	/* Pairs with smp_store_release() in lstp_signal_disconnect(). */
+	return smp_load_acquire(&to_lstp_priv(ch)->disconnected);
+}
+
+/**
+ * lstp_send() - Send a one-way LSTP packet on the bulk-out endpoint.
+ * @ch:      LSTP channel to send on
+ * @cmd:     LSTP command byte. Bit 7 is forced to 0 (request direction)
+ * @payload: Payload bytes to copy into the channel's TX buffer; may be NULL
+ *           if @len == 0
+ * @len:     Payload length in bytes
+ *
+ * Fire-and-forget bulk-out send. Serializes on the per-channel TX
+ * mutex across header build and USB submission, and checks
+ * lstp_channel_disconnected() under that lock so the test and the
+ * actual usb_bulk_msg() submission live on the same side of the lock.
+ * Pairs with the lstp_drain_inflight() teardown barrier so no caller
+ * is using the channel's TX buffer when devres unwinds it on interface
+ * unbind.
+ *
+ * Context: Process context. May sleep.
+ *
+ * Return: 0 on success; -ENODEV if @ch is not initialized for I/O or
+ *         the channel is disconnected; -EINVAL if @payload is NULL with
+ *         @len > 0; -EMSGSIZE if @len exceeds the TX buffer; otherwise
+ *         the errno from usb_bulk_msg().
+ */
+int lstp_send(struct lstp_channel *ch, u8 cmd, const void *payload, size_t len)
+{
+	struct lstp_channel_priv *priv;
+	struct lstp_packet *tx_pkt;
+	size_t total;
+
+	if (!ch)
+		return -ENODEV;
+	priv = to_lstp_priv(ch);
+	if (!priv->usb || !priv->tx_buf)
+		return -ENODEV;
+
+	if (len && !payload)
+		return -EINVAL;
+
+	if (len > ch->max_tx_payload || check_add_overflow(sizeof(struct lstp_header), len, &total))
+		return -EMSGSIZE;
+
+	guard(lstp_channel)(ch);
+	if (lstp_channel_disconnected(ch))
+		return -ENODEV;
+
+	tx_pkt = (struct lstp_packet *)priv->tx_buf;
+	tx_pkt->hdr.ch_id = ch->ch_id;
+	tx_pkt->hdr.cmd = SET_U8_BYTE(cmd, 0); /* bit 7 = 0 for request */
+	tx_pkt->hdr.length = cpu_to_le16(len);
+	if (len)
+		memcpy(tx_pkt->payload, payload, len);
+
+	return usb_bulk_msg(priv->usb->udev,
+			    usb_sndbulkpipe(priv->usb->udev, priv->usb->bulk_out_ep), priv->tx_buf,
+			    total, NULL, LSTP_USB_REQUEST_TIMEOUT_MS);
+}
+
+/**
+ * deprecated_lstp_channel_publish_child_dev() - Record the subsystem-side
+ *	device the channel exposes.
+ * @ch:        LSTP channel.
+ * @child_dev: Device the subsystem registered with the kernel
+ *             (i2c_adapter->dev, spi_controller->dev, gpio_device's device,
+ *             miscdevice->this_device, ...). May be NULL to clear.
+ *
+ * Stored on @ch so the framework can publish a "device" symlink under
+ * /sys/.../lstp/channel/N pointing at the subsystem-facing device.
+ * Typically called once from the subsystem's channel_start() after the
+ * underlying device has been registered.
+ *
+ * @ch stores @child_dev as a raw pointer; the caller retains ownership
+ * and must keep it registered for the channel's lifetime.
+ *
+ * The deprecated_ prefix marks this as compat scaffolding: it exists only to
+ * back the channel/N/device symlink and is grep-removable once that symlink
+ * is retired. It also cannot represent channels that expose zero or several
+ * peer devices.
+ *
+ * Context: Any.
+ */
+void deprecated_lstp_channel_publish_child_dev(struct lstp_channel *ch, struct device *child_dev)
+{
+	if (!ch)
+		return;
+	to_lstp_priv(ch)->child_dev = child_dev;
+}
+
+/**
+ * lstp_request_xfer() - Run one LSTP request/response exchange on @ch.
+ * @ch:       LSTP channel.
+ * @cmd:      LSTP command byte. Bit 7 is forced to 0 (request direction).
+ * @req_len:  Request payload length already populated in priv->tx_buf.
+ * @resp:     Caller buffer to receive the response payload, or NULL when
+ *            @resp_cap == 0.
+ * @resp_cap: Capacity of @resp in bytes. See lstp_request() for the
+ *            strict / variable mode semantics.
+ * @resp_len: Strict / variable mode selector; see lstp_request().
+ * @lstp_status: Optional out-param for the raw LSTP response status; see
+ *            lstp_request(). Publishes LSTP_SUCCESS only once the exchange is
+ *            fully validated.
+ *
+ * File-static engine used by lstp_request() / lstp_requestv() after they
+ * have taken priv->tx_mutex via guard(lstp_channel)(). Owns
+ * priv->resp_buffer_lock end-to-end: claims it on entry with
+ * test_and_set_bit() and releases it at out_release: on every exit
+ * path. The caller does not see the lock.
+ *
+ * Preconditions (file-local helper, no defensive re-checks):
+ *
+ * * @ch fully initialized (priv->usb, priv->tx_buf, priv->resp_buf non-NULL).
+ * * @req_len <= @ch->max_tx_payload.
+ * * @resp_cap <= @ch->max_rx_payload.
+ * * Caller holds priv->tx_mutex via guard(lstp_channel)().
+ * * Caller has verified the channel is not disconnected under that lock,
+ *   so the shared TX URB is not reused after a kill-skipped timeout.
+ * * priv->tx_buf->payload already carries the request payload bytes.
+ *
+ * Return: 0 on success; -EBUSY if the inflight slot was somehow already
+ *         claimed; -ENODEV on disconnect-raced URB submit; -ETIMEDOUT
+ *         on no-response; -EMSGSIZE in variable mode when the device
+ *         reports more than @resp_cap bytes; otherwise the errno from
+ *         lstp_validate_resp() or usb_submit_urb().
+ */
+static int lstp_request_xfer(struct lstp_channel *ch, u8 cmd, u16 req_len, void *resp,
+			     size_t resp_cap, size_t *resp_len, int *lstp_status)
+{
+	struct lstp_channel_priv *priv = to_lstp_priv(ch);
+	struct lstp_packet *tx_pkt = (struct lstp_packet *)priv->tx_buf;
+	struct lstp_packet *rx_pkt = (struct lstp_packet *)priv->resp_buf;
+	/*
+	 * Strict mode pushes the floor down to the wire so under-reads fail
+	 * at lstp_validate_resp(); variable mode disables the wire floor and
+	 * enforces the ceiling below.
+	 */
+	u16 wire_min = resp_len ? LSTP_ANY_RX_LEN : (u16)resp_cap;
+	size_t to_copy = 0;
+	size_t actual;
+	int ret;
+
+	/* Try to claim rx buffer - if already in use, that's a bug */
+	if (test_and_set_bit(LSTP_BUFFER_LOCK_BIT, &priv->resp_buffer_lock)) {
+		dev_err(ch->dev, "%s: ch_%d: BUG - rx buffer already in use\n", __func__,
+			ch->ch_id);
+		return -EBUSY;
+	}
+
+	tx_pkt->hdr.ch_id = ch->ch_id;
+	tx_pkt->hdr.cmd = SET_U8_BYTE(cmd, 0); /* bit 7 = 0 for request */
+	tx_pkt->hdr.length = cpu_to_le16(req_len);
+
+	if (req_len > 0)
+		dev_dbg(ch->dev, "%s: ch_%d: TX cmd=0x%02x, tx_len=%u, rx_min=%u, payload=0x%*ph\n",
+			__func__, ch->ch_id, cmd, req_len, wire_min, req_len, tx_pkt->payload);
+	else
+		dev_dbg(ch->dev, "%s: ch_%d: TX cmd=0x%02x, tx_len=0, rx_min=%u\n", __func__,
+			ch->ch_id, cmd, wire_min);
+
+	usb_fill_bulk_urb(priv->bulk_tx_urb, priv->usb->udev,
+			  usb_sndbulkpipe(priv->usb->udev, priv->usb->bulk_out_ep), priv->tx_buf,
+			  sizeof(struct lstp_header) + req_len, lstp_usb_tx_callback, ch);
+
+	/* Pairs with smp_store_release()/smp_load_acquire() on rx_ready. */
+	WRITE_ONCE(priv->rx_ready, false);
+
+	ret = usb_submit_urb(priv->bulk_tx_urb, GFP_KERNEL);
+	if (ret) {
+		/*
+		 * If teardown raced our submit, return -ENODEV (same as the
+		 * disconnect branch below) instead of leaking -EPERM/-ESHUTDOWN
+		 * to userspace.
+		 */
+		if (ret == -EPERM || ret == -ESHUTDOWN)
+			ret = -ENODEV;
+		goto out_release;
+	}
+
+	wait_event_timeout(priv->rx_wq, lstp_ch_should_wake(ch),
+			   msecs_to_jiffies(LSTP_USB_RESPONSE_TIMEOUT_MS));
+
+	if (!lstp_ch_got_response(ch)) {
+		if (lstp_channel_disconnected(ch)) {
+			/*
+			 * usb_kill_urb() blocks until the URB is retired. A
+			 * synchronous accessor can reach here holding a lock that
+			 * teardown waits on (e.g. gpiolib's SRCU section, drained
+			 * by gpiochip_remove()); under load the wait can exceed
+			 * the hung-task timeout and wedge teardown. Leave the
+			 * queued URB for lstp_stop_tx() to reclaim.
+			 */
+			ret = -ENODEV;
+		} else {
+			/* Live timeout: reclaim the URB so tx_buf can be reused. */
+			usb_kill_urb(priv->bulk_tx_urb);
+			ret = -ETIMEDOUT;
+		}
+		dev_err_ratelimited(ch->dev, "%s: ch_%d: No response (%pe)\n", __func__, ch->ch_id,
+				    ERR_PTR(ret));
+		goto out_release;
+	}
+
+	ret = lstp_validate_resp(priv->usb, rx_pkt, wire_min, lstp_status);
+	if (ret)
+		goto out_release;
+
+	actual = le16_to_cpu(rx_pkt->hdr.length);
+	dev_dbg(ch->dev, "%s: ch_%d: RX rx_len=%zu\n", __func__, ch->ch_id, actual);
+
+	if (resp_len) {
+		if (actual > resp_cap) {
+			ret = -EMSGSIZE;
+			goto out_release;
+		}
+		to_copy = actual;
+		*resp_len = actual;
+	} else {
+		/*
+		 * Forward-compat: device may legitimately reply with more than
+		 * @resp_cap bytes when firmware extends the response; consume
+		 * only what the caller asked for.
+		 */
+		to_copy = resp_cap;
+	}
+
+	if (resp && to_copy)
+		memcpy(resp, rx_pkt->payload, to_copy);
+
+	/* Publish success only once the whole exchange is validated. */
+	if (lstp_status)
+		*lstp_status = LSTP_SUCCESS;
+
+out_release:
+	clear_bit(LSTP_BUFFER_LOCK_BIT, &priv->resp_buffer_lock);
+	return ret;
+}
+
+/**
+ * lstp_request() - Issue an LSTP request/response exchange.
+ * @ch:       LSTP channel
+ * @cmd:      LSTP command byte. Bit 7 is forced to 0 (request direction)
+ * @req:      Request payload to copy into the channel's TX buffer; may be
+ *            NULL if @req_len == 0
+ * @req_len:  Request payload length in bytes
+ * @resp:     Caller buffer that receives the response payload; may be NULL
+ *            if @resp_cap == 0, or when @resp_len is non-NULL to discard
+ *            the response payload
+ * @resp_cap: Capacity of @resp in bytes. Treated as the exact expected
+ *            response length when @resp_len is NULL; treated as an upper
+ *            bound on the device-reported length when @resp_len is
+ *            non-NULL
+ * @resp_len: Out-param for the on-wire response length, or NULL. The
+ *            pointer doubles as the fixed/variable mode selector:
+ *
+ *            * NULL (fixed): The device must reply with at least
+ *              @resp_cap bytes (-EIO on under-read). Longer replies are
+ *              silently accepted for forward compatibility with newer
+ *              firmware and only the first @resp_cap bytes are copied
+ *              into @resp
+ *
+ *            * non-NULL (variable): No lower bound on the response
+ *              length. If the device reports more than @resp_cap bytes
+ *              the call fails with -EMSGSIZE; otherwise the reported
+ *              length is written to *@resp_len and that many bytes are
+ *              copied into @resp
+ * @lstp_status: Optional out-param for the raw LSTP response status.
+ *            Set to the device status when the exchange succeeds
+ *            (LSTP_SUCCESS) or when the returned errno is derived from that
+ *            status. Set to LSTP_NO_RESPONSE_STATUS when the result is not
+ *            associated with a response status, such as transport errors or
+ *            payload/length validation failures. Unmodified if NULL.
+ *
+ * Issues one atomic LSTP request/response exchange. Channel locking and
+ * RX-buffer release are internal; the caller only owns @req and @resp.
+ *
+ * For request payloads that span multiple caller-owned buffers (a
+ * fixed header struct followed by a caller-managed body, etc.) use
+ * lstp_requestv() with a struct kvec vector to skip the
+ * bounce-buffer concatenation step.
+ *
+ * Context: Process context. May sleep.
+ *
+ * Return: 0 on success; -ENODEV if @ch is not initialized for I/O;
+ *         -EINVAL if @req is NULL with @req_len > 0, or if @resp is NULL
+ *         with @resp_cap > 0 in fixed mode; -EMSGSIZE if the framed
+ *         request or response would exceed the channel's bulk TX/RX
+ *         buffer, or (in variable mode) the device reply exceeds
+ *         @resp_cap; -EIO if (in fixed mode) the device reply is
+ *         shorter than @resp_cap; otherwise the errno from the
+ *         underlying USB I/O.
+ */
+int lstp_request(struct lstp_channel *ch, u8 cmd, const void *req, size_t req_len, void *resp,
+		 size_t resp_cap, size_t *resp_len, int *lstp_status)
+{
+	return lstp_requestv(ch, cmd,
+			     &(const struct kvec){
+				     .iov_base = (void *)req,
+				     .iov_len = req_len,
+			     },
+			     1, resp, resp_cap, resp_len, lstp_status);
+}
+
+/**
+ * lstp_requestv() - Vectored variant of lstp_request().
+ * @ch:       LSTP channel
+ * @cmd:      LSTP command byte; see lstp_request()
+ * @vecs:     Input kvec vector; concatenated into the TX payload in
+ *            order. Each entry's @iov_base may be NULL only when its
+ *            @iov_len is 0. May be NULL if @nvecs is 0
+ * @nvecs:    Number of entries in @vecs. May be 0 for an empty
+ *            request
+ * @resp:     see lstp_request()
+ * @resp_cap: see lstp_request()
+ * @resp_len: see lstp_request()
+ * @lstp_status: see lstp_request()
+ *
+ * Identical to lstp_request() except that the request payload is the
+ * concatenation of @vecs[0..@nvecs-1] rather than a single buffer.
+ * Each entry is copied directly into the channel TX buffer at its
+ * position in the concatenation; no intermediate bounce is allocated.
+ *
+ * Callers typically build the kvec array on the stack and pass it with
+ * ARRAY_SIZE(), for example::
+ *
+ *	struct kvec vecs[] = {
+ *		{ .iov_base = &hdr,    .iov_len = sizeof(hdr) },
+ *		{ .iov_base = msg->buf, .iov_len = msg->len  },
+ *	};
+ *
+ *	ret = lstp_requestv(ch, cmd, vecs, ARRAY_SIZE(vecs),
+ *			    NULL, 0, NULL, NULL);
+ *
+ * Context: Process context. May sleep.
+ *
+ * Return: see lstp_request().
+ */
+int lstp_requestv(struct lstp_channel *ch, u8 cmd, const struct kvec *vecs, size_t nvecs,
+		  void *resp, size_t resp_cap, size_t *resp_len, int *lstp_status)
+{
+	struct lstp_channel_priv *priv;
+	struct lstp_packet *tx_pkt;
+	size_t req_total = 0;
+	size_t off = 0;
+	size_t i;
+
+	/* Fail-safe default: only the xfer/validation publish a real status. */
+	if (lstp_status)
+		*lstp_status = LSTP_NO_RESPONSE_STATUS;
+
+	if (!ch)
+		return -ENODEV;
+	priv = to_lstp_priv(ch);
+	if (!priv->usb || !priv->tx_buf || !priv->resp_buf)
+		return -ENODEV;
+
+	if (nvecs && !vecs)
+		return -EINVAL;
+	if (!resp_len && resp_cap && !resp)
+		return -EINVAL;
+
+	for (i = 0; i < nvecs; i++) {
+		if (vecs[i].iov_len && !vecs[i].iov_base)
+			return -EINVAL;
+		if (check_add_overflow(req_total, vecs[i].iov_len, &req_total))
+			return -EMSGSIZE;
+	}
+
+	if (req_total > ch->max_tx_payload || resp_cap > ch->max_rx_payload)
+		return -EMSGSIZE;
+
+	guard(lstp_channel)(ch);
+	if (lstp_channel_disconnected(ch))
+		return -ENODEV;
+
+	tx_pkt = (struct lstp_packet *)priv->tx_buf;
+	for (i = 0; i < nvecs; i++) {
+		if (vecs[i].iov_len) {
+			memcpy(tx_pkt->payload + off, vecs[i].iov_base, vecs[i].iov_len);
+			off += vecs[i].iov_len;
+		}
+	}
+
+	return lstp_request_xfer(ch, cmd, (u16)req_total, resp, resp_cap, resp_len, lstp_status);
+}
+
+/*******************************************************************************
+ * Driver Registration
+ ******************************************************************************/
+
+static const struct usb_device_id lstp_id_table[] = {
+	{ USB_VENDOR_AND_INTERFACE_INFO(0x0955, 0xFF, 0x3F, LSTP_VERSION) },
+	{}
+};
+MODULE_DEVICE_TABLE(usb, lstp_id_table);
+
+static struct usb_driver lstp_usb_driver = {
+	.name = "lstp",
+	.probe = lstp_probe,
+	.disconnect = lstp_disconnect,
+	.id_table = lstp_id_table,
+};
+
+LSTP_SUBSYS_DECLARE(spi);
+LSTP_SUBSYS_DECLARE(gpio);
+LSTP_SUBSYS_DECLARE(i2c);
+LSTP_SUBSYS_DECLARE(uart);
+LSTP_SUBSYS_DECLARE(ipmi);
+LSTP_SUBSYS_DECLARE(mmio);
+
+/* clang-format off */
+static const struct lstp_subsys *const lstp_subsystems[] = {
+	LSTP_SUBSYS_REF(spi),
+	LSTP_SUBSYS_REF(gpio),
+	LSTP_SUBSYS_REF(i2c),
+	LSTP_SUBSYS_REF(uart),
+	LSTP_SUBSYS_REF(ipmi),
+	LSTP_SUBSYS_REF(mmio),
+};
+
+/* clang-format on */
+
+const struct lstp_subsys *lstp_subsys_by_channel_type(u8 channel_type)
+{
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(lstp_subsystems); i++)
+		if (lstp_subsystems[i]->channel_type == channel_type)
+			return lstp_subsystems[i];
+	return NULL;
+}
+
+static int __init lstp_module_init(void)
+{
+	size_t i;
+	int ret;
+
+	for (i = 0; i < ARRAY_SIZE(lstp_subsystems); i++) {
+		ret = lstp_subsystems[i]->init ? lstp_subsystems[i]->init() : 0;
+		if (ret) {
+			pr_err("lstp: subsys %s init failed: %pe\n", lstp_subsystems[i]->name,
+			       ERR_PTR(ret));
+			goto unwind_subsys;
+		}
+	}
+
+	ret = usb_register(&lstp_usb_driver);
+	if (ret)
+		goto unwind_subsys;
+
+	return 0;
+
+unwind_subsys:
+	while (i-- > 0)
+		if (lstp_subsystems[i]->exit)
+			lstp_subsystems[i]->exit();
+	return ret;
+}
+
+static void __exit lstp_module_exit(void)
+{
+	size_t i = ARRAY_SIZE(lstp_subsystems);
+
+	usb_deregister(&lstp_usb_driver);
+
+	while (i-- > 0)
+		if (lstp_subsystems[i]->exit)
+			lstp_subsystems[i]->exit();
+}
+
+module_init(lstp_module_init);
+module_exit(lstp_module_exit);
+
+bool lstp_auto_bind_spidev = IS_ENABLED(CONFIG_USB_LSTP_SPI_SPIDEV);
+module_param_named(auto_bind_spidev, lstp_auto_bind_spidev, bool, 0444);
+/* clang-format off */
+MODULE_PARM_DESC(auto_bind_spidev, "Auto-create spidev devices on SPI channels without firmware nodes (default: CONFIG_USB_LSTP_SPI_SPIDEV)");
+/* clang-format on */
+
+MODULE_DESCRIPTION("LSTP USB device driver");
+MODULE_LICENSE("GPL");

--- a/drivers/usb/misc/lstp/lstp-main.h
+++ b/drivers/usb/misc/lstp/lstp-main.h
@@ -1,0 +1,337 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * LSTP USB interface driver.
+ *
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+#ifndef __LSTP_MAIN_H
+#define __LSTP_MAIN_H
+
+#include <linux/build_bug.h>
+#include <linux/mutex.h>
+#include <linux/property.h>
+#include <linux/uio.h>
+#include <linux/usb.h>
+#include <linux/workqueue.h>
+
+#define LSTP_VERSION 1
+#define LSTP_USB_RESPONSE_TIMEOUT_MS 1000
+#define LSTP_USB_REQUEST_TIMEOUT_MS 1000
+#define LSTP_USB_EP_MIN_SIZE 64
+#define LSTP_USB_EP_MAX_SIZE 512
+#define LSTP_MAX_CHANNELS 256 /* Includes channel 0 */
+#define LSTP_ANY_RX_LEN 0 /* "no minimum" -- callers without a known min payload length */
+#define LSTP_READ_CONFIG_MAX U16_MAX /* sentinel: max ch_config bytes per USB RX packet */
+#define DEPRECATED_LSTP_READ_CONFIG_MAX 0 /* Noncompliant firmware workaround TODO: remove */
+#define LSTP_CH_NAME_LEN 16
+#define LSTP_INTF_NAME_LEN (LSTP_CH_NAME_LEN + 1) /* ch0_name + '\0' */
+#define LSTP_DISPLAY_NAME_LEN (LSTP_CH_NAME_LEN * 2 + 2) /* intf_name + '_' + ch_name + '\0' */
+
+#define GET_BIT_7(u8_byte) (((u8_byte) >> 7) & 0x01)
+#define GET_BIT_0_6(u8_byte) ((u8_byte) & 0x7F)
+#define SET_U8_BYTE(bit_0_6, bit_7) ((((bit_7) & 0x01) << 7) | ((bit_0_6) & 0x7F))
+
+#define LSTP_GET_PAYLOAD(pkt, type)                                  \
+	({                                                           \
+		typeof(pkt) _p = (pkt);                              \
+		size_t _len = (size_t)le16_to_cpu(_p->hdr.length);   \
+		(_len >= sizeof(type)) ? (type *)_p->payload : NULL; \
+	})
+
+/* Channel flags bit definitions */
+#define LSTP_CH_FLAG_ENABLE BIT(0)
+
+/* Buffer lock bit (resp_buffer_lock and irq_buffer_lock) */
+#define LSTP_BUFFER_LOCK_BIT 0
+
+/* Channel state bits */
+#define LSTP_CHANNEL_DISABLED_BIT 0
+
+enum lstp_channel_type {
+	LSTP_CHANNEL_TYPE_MGMT = 0x00,
+	LSTP_CHANNEL_TYPE_SPI = 0x01,
+	LSTP_CHANNEL_TYPE_GPIO = 0x02,
+	LSTP_CHANNEL_TYPE_I2C = 0x03,
+	LSTP_CHANNEL_TYPE_UART = 0x04,
+	LSTP_CHANNEL_TYPE_IPMI = 0x05,
+	LSTP_CHANNEL_TYPE_MMIO = 0x06,
+	LSTP_CHANNEL_TYPE_MAX, /* sentinel, not a wire value; keep last */
+};
+
+enum lstp_status {
+	LSTP_SUCCESS = 0x00,
+	LSTP_ERROR = 0x01,
+	LSTP_TIMEOUT = 0x02,
+	LSTP_BUSY = 0x03,
+	LSTP_NACK = 0x04,
+	LSTP_ARB_LOST = 0x05,
+	LSTP_NOT_SUPP = 0x06,
+	LSTP_TOO_LARGE = 0x07,
+};
+
+/*
+ * lstp_status out-param sentinel: the request result is not associated
+ * with an LSTP response status byte (transport/local error, or no response).
+ * Distinct from any valid status (0x00..0x7f from GET_BIT_0_6()).
+ */
+#define LSTP_NO_RESPONSE_STATUS (-1)
+
+struct lstp_ch0_read_req {
+	u8 ch_id;
+	__le16 offset;
+	__le16 length;
+} __packed;
+
+/*
+ * Channel descriptor block: the firmware-controlled identity triple
+ * (type, flags, name) carried by every ch0 config exchange. Appears
+ * as a leading prefix inside lstp_ch0_write_req and as the fixed head
+ * of lstp_ch0_read_resp; extracted so callers can stack-allocate just
+ * this fixed-size piece (the flex-array trailer cannot live in
+ * automatic storage).
+ */
+struct lstp_ch_desc {
+	u8 ch_type;
+	u8 ch_flags;
+	char ch_name[LSTP_CH_NAME_LEN];
+} __packed;
+
+struct lstp_ch0_write_req {
+	u8 ch_id;
+	__le16 offset;
+	struct lstp_ch_desc desc;
+	u8 ch_config[];
+} __packed;
+
+struct lstp_ch0_read_resp {
+	struct lstp_ch_desc desc;
+	u8 ch_config[];
+} __packed;
+
+struct lstp_header {
+	u8 ch_id;
+	union { /* [0:6] cmd/status, [7] 0=request/1=response */
+		u8 cmd;
+		u8 status;
+	};
+	__le16 length;
+} __packed;
+
+struct lstp_packet {
+	struct lstp_header hdr;
+	u8 payload[];
+} __packed;
+
+/*
+ * Process-context fallback for the RX completion callback when
+ * usb_submit_urb() fails atomically (e.g. -ENOMEM, -EPIPE).
+ */
+struct lstp_rx_retry {
+	struct delayed_work work;
+	int last_err;
+	unsigned int failures;
+};
+
+struct lstp_usb {
+	struct usb_device *udev;
+	struct usb_interface *intf;
+	u8 bulk_in_ep;
+	u8 bulk_out_ep;
+	struct urb *bulk_rx_urb;
+	struct lstp_rx_retry bulk_rx_retry;
+	u8 *rx_buf;
+	size_t bulk_tx_size;
+	size_t bulk_rx_size;
+	u8 lstp_version;
+	char lstp_intf_name[LSTP_INTF_NAME_LEN];
+	u8 max_ch_id;
+	struct lstp_channel *channels[LSTP_MAX_CHANNELS];
+	struct kobject lstp_kobj; /* /sys/.../lstp */
+	struct kobject *channel_kobj; /* /sys/.../lstp/channel */
+};
+
+/**
+ * typedef lstp_irq_callback - Callback for unsolicited packets.
+ * @ch:  Channel that received the unsolicited request.
+ * @pkt: Received LSTP packet. The framework guarantees that pkt->hdr and
+ *       le16_to_cpu(pkt->hdr.length) bytes of pkt->payload are valid, so
+ *       the callback can read them without rechecking. Valid only for the
+ *       duration of the call; the same buffer is reused for the next
+ *       unsolicited packet on this channel. The callback must not retain
+ *       the pointer and must not modify packet contents.
+ *
+ * Called in atomic context - must not sleep.
+ */
+typedef void (*lstp_irq_callback)(struct lstp_channel *ch, struct lstp_packet *pkt);
+
+struct lstp_subsys;
+
+/**
+ * struct lstp_channel - Per-channel state visible to LSTP subsystems.
+ * @ch_id:          LSTP channel id assigned by the device. ch0 is the
+ *                  management channel; subsystem channels run 1..max_ch_id.
+ * @display_name:   Human-readable channel name built by the framework from
+ *                  the interface and channel names. Suitable as a
+ *                  Linux-subsystem display string (i2c_adapter.name,
+ *                  gpio_chip.label, ...). NUL-terminated; valid for the
+ *                  channel's full lifetime.
+ * @fwnode:         Firmware node describing this channel (i2c-adapter,
+ *                  gpio-chip, spi-controller, ipmi label, ...). NULL if no
+ *                  firmware match.
+ * @dev:            Stable struct device pointer for dev_*() / devm_*();
+ *                  points at the underlying USB interface device.
+ * @max_tx_payload: Largest LSTP request payload (excluding the header)
+ *                  that fits in one bulk-out URB on this channel.
+ *                  Per-channel constant.
+ * @max_rx_payload: Largest LSTP response payload (excluding the header)
+ *                  that fits in one bulk-in URB on this channel.
+ *                  Per-channel constant.
+ * @priv:           Subsystem-owned private data, allocated by the subsystem
+ *                  in its channel_init(). Opaque to the framework
+ *                  (e.g. i2c_adapter, gpio_chip).
+ *
+ * Framework-private state lives in the container that wraps this struct;
+ * subsystems see only the fields documented above.
+ */
+struct lstp_channel {
+	u8 ch_id;
+	char display_name[LSTP_DISPLAY_NAME_LEN];
+	struct fwnode_handle *fwnode;
+	struct device *dev;
+	size_t max_tx_payload;
+	size_t max_rx_payload;
+	void *priv;
+};
+
+/**
+ * struct lstp_channel_init_info - Per-call data passed to channel_init().
+ * @config:     Subsystem-specific config blob (e.g. struct lstp_spi_config),
+ *              pointing into the framework's ch0 READ_CONFIG scratch.
+ *              The framework does not validate its contents; subsystems
+ *              MUST gate any access on @config_len before dereferencing.
+ * @config_len: On-wire blob length in bytes (may be 0).
+ *
+ * Both fields are valid only for the duration of channel_init();
+ * subsystems that need to retain data must copy.
+ */
+struct lstp_channel_init_info {
+	const void *config;
+	size_t config_len;
+};
+
+/*
+ * Subsystem registration table. Each sub-component defines its own
+ * descriptor via LSTP_SUBSYS() at file scope; lstp-main.c collects them
+ * into a static array (lstp_subsystems[]) and drives module lifecycle
+ * and per-channel dispatch from it.
+ *
+ * Required (positional macro args):
+ *   _tag / channel_type / channel_init / channel_start
+ *                         Per-channel dispatch for LSTP_CHANNEL_TYPE_*.
+ * Optional (designated initializers in ...):
+ *   .fwnode_compatible    Firmware node matching.
+ *   .irq_callback         Handler for unsolicited LSTP requests on this
+ *                         subsystem's channels, invoked from the USB RX
+ *                         completion path (atomic context).
+ *   .channel_stop         Undoes channel_start(); invoked only after
+ *                         channel_start() returned success. Use it to
+ *                         quiesce activity that depends on the LSTP device
+ *                         still being reachable
+ *                         (unregister userspace-facing nodes, drop refs the
+ *                         device side holds, etc.). Resources owned by the
+ *                         channel itself -- allocations, workqueues, IRQ
+ *                         registrations, gpiochip/tty/etc. add_data calls --
+ *                         should be devres-managed instead, so they:
+ *                           - clean up on channel_init/start failure too,
+ *                             where channel_stop never runs, and
+ *                           - benefit from devres LIFO ordering vs. other
+ *                             devres cleanups.
+ *   .init / .exit         Module-level hooks.
+ */
+struct lstp_subsys {
+	const char *name;
+
+	u8 channel_type;
+	const char *fwnode_compatible;
+
+	lstp_irq_callback irq_callback;
+
+	int (*channel_init)(struct lstp_channel *ch, const struct lstp_channel_init_info *info);
+	int (*channel_start)(struct lstp_channel *ch);
+	void (*channel_stop)(struct lstp_channel *ch);
+
+	int (*init)(void);
+	void (*exit)(void);
+};
+
+/*
+ * LSTP_SUBSYS() emits a single externally-visible descriptor named
+ * lstp_<tag>_subsys. lstp-main.c declares matching externs via
+ * LSTP_SUBSYS_DECLARE() and pulls them into lstp_subsystems[] via
+ * LSTP_SUBSYS_REF(). Adding a new channel type therefore requires one
+ * entry in that central array in addition to the per-file LSTP_SUBSYS()
+ * definition -- intentional visibility for maintainers.
+ */
+/* clang-format off */
+#define LSTP_SUBSYS(_tag, _ch_type, _init, _start, ...)                      \
+	static_assert((_ch_type) > LSTP_CHANNEL_TYPE_MGMT &&                 \
+		      (_ch_type) < LSTP_CHANNEL_TYPE_MAX,                    \
+		      #_tag ": channel_type out of range");                  \
+	const struct lstp_subsys lstp_##_tag##_subsys = {                    \
+		.name = #_tag,                                               \
+		.channel_type = (_ch_type),                                  \
+		.channel_init = (_init),                                     \
+		.channel_start = (_start),                                   \
+		__VA_ARGS__                                                  \
+	}
+/* clang-format on */
+
+/* Companions to LSTP_SUBSYS(): declare the extern / take its address by tag. */
+#define LSTP_SUBSYS_DECLARE(_tag) extern const struct lstp_subsys lstp_##_tag##_subsys
+#define LSTP_SUBSYS_REF(_tag) (&lstp_##_tag##_subsys)
+
+/* Subsystem dispatch */
+const struct lstp_subsys *lstp_subsys_by_channel_type(u8 channel_type);
+
+/* Module parameters */
+extern bool lstp_auto_bind_spidev;
+
+/* Channel state probe */
+bool lstp_channel_disconnected(const struct lstp_channel *ch);
+
+/* USB I/O helpers: bulk-out send and request/response exchanges */
+int lstp_send(struct lstp_channel *ch, u8 cmd, const void *payload, size_t len);
+
+int lstp_request(struct lstp_channel *ch, u8 cmd, const void *req, size_t req_len, void *resp,
+		 size_t resp_cap, size_t *resp_len, int *lstp_status);
+
+int lstp_requestv(struct lstp_channel *ch, u8 cmd, const struct kvec *vecs, size_t nvecs,
+		  void *resp, size_t resp_cap, size_t *resp_len, int *lstp_status);
+
+/* Unsolicited-request response (atomic context, called from irq_callback) */
+void lstp_send_irq_resp(struct lstp_channel *ch, u8 status);
+
+/* ch0 READ_CONFIG helpers (lstp_request-based) */
+int lstp_ch0_read_config(struct lstp_channel *ch, u16 offset, u16 length,
+			 struct lstp_ch0_read_resp **resp_out, size_t *len_out, int *lstp_status);
+
+typedef int (*lstp_config_entry_fn)(struct lstp_channel *ch, unsigned int entry_idx,
+				    const void *entry, void *entry_ctx);
+int lstp_read_config_table(struct lstp_channel *ch, size_t config_head_size,
+			   size_t config_entry_size, unsigned int total_entries,
+			   lstp_config_entry_fn entry_fn, void *entry_ctx);
+
+/* Subsystem-side device pin (compat scaffolding; see definition) */
+void deprecated_lstp_channel_publish_child_dev(struct lstp_channel *ch, struct device *child_dev);
+
+#endif

--- a/drivers/usb/misc/lstp/lstp-mmio.c
+++ b/drivers/usb/misc/lstp/lstp-mmio.c
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * MMIO channel for LSTP USB interface.
+ *
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+#include <linux/err.h>
+#include <linux/fs.h>
+#include <linux/idr.h>
+#include <linux/kref.h>
+#include <linux/limits.h>
+#include <linux/miscdevice.h>
+#include <linux/minmax.h>
+#include <linux/module.h>
+#include <linux/overflow.h>
+#include <linux/sched/signal.h>
+#include <linux/slab.h>
+#include <linux/uaccess.h>
+#include <linux/cleanup.h>
+
+#include "lstp-main.h"
+
+static DEFINE_IDA(lstp_mmio_ida);
+
+enum lstp_mmio_cmd {
+	LSTP_MMIO_CMD_READ = 0x00,
+	LSTP_MMIO_CMD_WRITE = 0x01,
+};
+
+struct lstp_mmio_read_req {
+	__le32 offset;
+	__le16 length;
+} __packed;
+
+struct lstp_mmio_write_req {
+	__le32 offset;
+	u8 data[];
+} __packed;
+
+struct lstp_mmio_ctx {
+	struct kref kref;
+	struct lstp_channel *ch;
+	struct miscdevice miscdev;
+	int ida_id;
+	struct mutex lock; /* Protects stopped and ch use for open fds */
+	u8 *xfer_buf;
+	bool stopped;
+};
+
+static void lstp_mmio_ctx_release(struct kref *kref)
+{
+	struct lstp_mmio_ctx *ctx = container_of(kref, struct lstp_mmio_ctx, kref);
+
+	if (ctx->ida_id >= 0)
+		ida_free(&lstp_mmio_ida, ctx->ida_id);
+	kfree(ctx->miscdev.name);
+	mutex_destroy(&ctx->lock);
+	kfree(ctx->xfer_buf);
+	kfree(ctx);
+}
+
+static void lstp_mmio_ctx_get(struct lstp_mmio_ctx *ctx)
+{
+	kref_get(&ctx->kref);
+}
+
+static void lstp_mmio_ctx_put(struct lstp_mmio_ctx *ctx)
+{
+	kref_put(&ctx->kref, lstp_mmio_ctx_release);
+}
+
+static void lstp_mmio_ctx_put_cb(void *data)
+{
+	lstp_mmio_ctx_put(data);
+}
+
+static struct lstp_mmio_ctx *lstp_mmio_file_ctx(struct file *file)
+{
+	return file->private_data;
+}
+
+static int lstp_mmio_validate_range(loff_t caller_offset, size_t count)
+{
+	if (caller_offset < 0 || caller_offset > U32_MAX)
+		return -EINVAL;
+	if ((u64)count > (u64)U32_MAX - caller_offset + 1)
+		return -EINVAL;
+
+	return 0;
+}
+
+static int lstp_mmio_open(struct inode *inode, struct file *file)
+{
+	struct miscdevice *miscdev = file->private_data;
+	struct lstp_mmio_ctx *ctx = container_of(miscdev, struct lstp_mmio_ctx, miscdev);
+
+	if (READ_ONCE(ctx->stopped))
+		return -ENODEV;
+
+	lstp_mmio_ctx_get(ctx);
+	file->private_data = ctx;
+	return 0;
+}
+
+static ssize_t lstp_mmio_read(struct file *file, char __user *buf, size_t count, loff_t *ppos)
+{
+	struct lstp_mmio_ctx *ctx = lstp_mmio_file_ctx(file);
+	struct lstp_channel *ch;
+	struct lstp_mmio_read_req req;
+	loff_t caller_offset = *ppos;
+	size_t done = 0;
+	ssize_t ret;
+
+	ret = lstp_mmio_validate_range(caller_offset, count);
+	if (ret)
+		return ret;
+
+	mutex_lock(&ctx->lock);
+	if (ctx->stopped) {
+		ret = -ENODEV;
+		goto out_unlock;
+	}
+
+	ch = ctx->ch;
+
+	/* Probe enforces bulk_rx_size >= LSTP_USB_EP_MIN_SIZE; anchor the fixed request here. */
+	BUILD_BUG_ON(sizeof(struct lstp_header) + sizeof(req) > LSTP_USB_EP_MIN_SIZE);
+
+	if (!count) {
+		req = (struct lstp_mmio_read_req){
+			.offset = cpu_to_le32((u32)caller_offset),
+			.length = cpu_to_le16(0),
+		};
+
+		ret = lstp_request(ch, LSTP_MMIO_CMD_READ, &req, sizeof(req), NULL, 0, NULL, NULL);
+		goto out_unlock;
+	}
+
+	while (done < count) {
+		size_t chunk = min3(count - done, ch->max_rx_payload, (size_t)U16_MAX);
+
+		if (signal_pending(current)) {
+			ret = done ?: -ERESTARTSYS;
+			goto out;
+		}
+
+		req = (struct lstp_mmio_read_req){
+			.offset = cpu_to_le32((u32)(caller_offset + done)),
+			.length = cpu_to_le16((u16)chunk),
+		};
+
+		ret = lstp_request(ch, LSTP_MMIO_CMD_READ, &req, sizeof(req), ctx->xfer_buf, chunk,
+				   NULL, NULL);
+		if (ret) {
+			ret = done ?: ret;
+			goto out;
+		}
+
+		if (copy_to_user(buf + done, ctx->xfer_buf, chunk)) {
+			ret = done ?: -EFAULT;
+			goto out;
+		}
+
+		done += chunk;
+	}
+
+	ret = done;
+
+out:
+	if (done)
+		*ppos = caller_offset + done;
+out_unlock:
+	mutex_unlock(&ctx->lock);
+	return ret;
+}
+
+static ssize_t lstp_mmio_write(struct file *file, const char __user *buf, size_t count,
+			       loff_t *ppos)
+{
+	struct lstp_mmio_ctx *ctx = lstp_mmio_file_ctx(file);
+	struct lstp_mmio_write_req *req;
+	struct lstp_channel *ch;
+	loff_t caller_offset = *ppos;
+	size_t done = 0;
+	ssize_t ret;
+
+	ret = lstp_mmio_validate_range(caller_offset, count);
+	if (ret)
+		return ret;
+
+	mutex_lock(&ctx->lock);
+	if (ctx->stopped) {
+		ret = -ENODEV;
+		goto out_unlock;
+	}
+
+	ch = ctx->ch;
+	req = (struct lstp_mmio_write_req *)ctx->xfer_buf;
+
+	/* Probe enforces bulk_tx_size >= LSTP_USB_EP_MIN_SIZE; anchor the fixed request here. */
+	BUILD_BUG_ON(sizeof(struct lstp_header) + sizeof(*req) > LSTP_USB_EP_MIN_SIZE);
+
+	if (!count) {
+		req->offset = cpu_to_le32((u32)caller_offset);
+
+		ret = lstp_request(ch, LSTP_MMIO_CMD_WRITE, req, sizeof(*req), NULL, 0, NULL, NULL);
+		goto out_unlock;
+	}
+
+	while (done < count) {
+		size_t chunk = min(count - done, ch->max_tx_payload - sizeof(*req));
+
+		if (signal_pending(current)) {
+			ret = done ?: -ERESTARTSYS;
+			goto out;
+		}
+
+		if (copy_from_user(req->data, buf + done, chunk)) {
+			ret = done ?: -EFAULT;
+			goto out;
+		}
+
+		req->offset = cpu_to_le32((u32)(caller_offset + done));
+
+		ret = lstp_request(ch, LSTP_MMIO_CMD_WRITE, req, struct_size(req, data, chunk),
+				   NULL, 0, NULL, NULL);
+		if (ret) {
+			ret = done ?: ret;
+			goto out;
+		}
+
+		done += chunk;
+	}
+
+	ret = done;
+
+out:
+	if (done)
+		*ppos = caller_offset + done;
+out_unlock:
+	mutex_unlock(&ctx->lock);
+	return ret;
+}
+
+static loff_t lstp_mmio_llseek(struct file *file, loff_t offset, int whence)
+{
+	return fixed_size_llseek(file, offset, whence, U32_MAX);
+}
+
+static int lstp_mmio_release(struct inode *inode, struct file *file)
+{
+	lstp_mmio_ctx_put(lstp_mmio_file_ctx(file));
+
+	return 0;
+}
+
+static const struct file_operations lstp_mmio_fops = {
+	.owner = THIS_MODULE,
+	.open = lstp_mmio_open,
+	.read = lstp_mmio_read,
+	.write = lstp_mmio_write,
+	.llseek = lstp_mmio_llseek,
+	.release = lstp_mmio_release,
+};
+
+static int lstp_mmio_init(struct lstp_channel *ch, const struct lstp_channel_init_info *info)
+{
+	struct lstp_mmio_ctx *ctx;
+	int ret;
+
+	ctx = kzalloc_obj(*ctx);
+	if (!ctx)
+		return -ENOMEM;
+
+	kref_init(&ctx->kref);
+	ctx->ch = ch;
+	ctx->ida_id = -1;
+	mutex_init(&ctx->lock);
+
+	ret = devm_add_action_or_reset(ch->dev, lstp_mmio_ctx_put_cb, ctx);
+	if (ret)
+		return ret;
+
+	ctx->xfer_buf = kmalloc(max(min_t(size_t, ch->max_rx_payload, U16_MAX), ch->max_tx_payload),
+				GFP_KERNEL);
+	if (!ctx->xfer_buf)
+		return -ENOMEM;
+
+	ctx->ida_id = ida_alloc(&lstp_mmio_ida, GFP_KERNEL);
+	if (ctx->ida_id < 0)
+		return ctx->ida_id;
+
+	ctx->miscdev.name = kasprintf(GFP_KERNEL, "lstp_mmio_%d", ctx->ida_id);
+	if (!ctx->miscdev.name)
+		return -ENOMEM;
+
+	ctx->miscdev.minor = MISC_DYNAMIC_MINOR;
+	ctx->miscdev.fops = &lstp_mmio_fops;
+	ctx->miscdev.parent = ch->dev;
+	ctx->miscdev.mode = 0600;
+	ch->priv = ctx;
+
+	dev_dbg(ch->dev, "%s: ch_%d: Initialized as %s\n", __func__, ch->ch_id, ch->display_name);
+	return 0;
+}
+
+static void lstp_mmio_deregister(void *data)
+{
+	struct lstp_mmio_ctx *ctx = data;
+
+	scoped_guard(mutex, &ctx->lock)
+		WRITE_ONCE(ctx->stopped, true);
+
+	misc_deregister(&ctx->miscdev);
+}
+
+static int lstp_mmio_start(struct lstp_channel *ch)
+{
+	struct lstp_mmio_ctx *ctx = ch->priv;
+	int ret;
+
+	if (!ctx) {
+		dev_err(ch->dev, "%s: ch_%d: MMIO context not initialized\n", __func__, ch->ch_id);
+		return -EINVAL;
+	}
+
+	ret = misc_register(&ctx->miscdev);
+	if (ret) {
+		dev_err(ch->dev, "%s: ch_%d: Could not register miscdevice (%pe)\n", __func__,
+			ch->ch_id, ERR_PTR(ret));
+		return ret;
+	}
+
+	ret = devm_add_action_or_reset(ch->dev, lstp_mmio_deregister, ctx);
+	if (ret)
+		return ret;
+
+	deprecated_lstp_channel_publish_child_dev(ch, ctx->miscdev.this_device);
+
+	dev_info(ch->dev, "%s: ch_%d: Started as %s\n", __func__, ch->ch_id, ch->display_name);
+	return 0;
+}
+
+/* clang-format off */
+LSTP_SUBSYS(mmio, LSTP_CHANNEL_TYPE_MMIO, lstp_mmio_init, lstp_mmio_start);
+/* clang-format on */

--- a/drivers/usb/misc/lstp/lstp-mmio.c
+++ b/drivers/usb/misc/lstp/lstp-mmio.c
@@ -124,6 +124,8 @@ static ssize_t lstp_mmio_read(struct file *file, char __user *buf, size_t count,
 	ret = lstp_mmio_validate_range(caller_offset, count);
 	if (ret)
 		return ret;
+	if (!count)
+		return 0;
 
 	mutex_lock(&ctx->lock);
 	if (ctx->stopped) {
@@ -135,16 +137,6 @@ static ssize_t lstp_mmio_read(struct file *file, char __user *buf, size_t count,
 
 	/* Probe enforces bulk_rx_size >= LSTP_USB_EP_MIN_SIZE; anchor the fixed request here. */
 	BUILD_BUG_ON(sizeof(struct lstp_header) + sizeof(req) > LSTP_USB_EP_MIN_SIZE);
-
-	if (!count) {
-		req = (struct lstp_mmio_read_req){
-			.offset = cpu_to_le32((u32)caller_offset),
-			.length = cpu_to_le16(0),
-		};
-
-		ret = lstp_request(ch, LSTP_MMIO_CMD_READ, &req, sizeof(req), NULL, 0, NULL, NULL);
-		goto out_unlock;
-	}
 
 	while (done < count) {
 		size_t chunk = min3(count - done, ch->max_rx_payload, (size_t)U16_MAX);
@@ -197,6 +189,8 @@ static ssize_t lstp_mmio_write(struct file *file, const char __user *buf, size_t
 	ret = lstp_mmio_validate_range(caller_offset, count);
 	if (ret)
 		return ret;
+	if (!count)
+		return 0;
 
 	mutex_lock(&ctx->lock);
 	if (ctx->stopped) {
@@ -209,13 +203,6 @@ static ssize_t lstp_mmio_write(struct file *file, const char __user *buf, size_t
 
 	/* Probe enforces bulk_tx_size >= LSTP_USB_EP_MIN_SIZE; anchor the fixed request here. */
 	BUILD_BUG_ON(sizeof(struct lstp_header) + sizeof(*req) > LSTP_USB_EP_MIN_SIZE);
-
-	if (!count) {
-		req->offset = cpu_to_le32((u32)caller_offset);
-
-		ret = lstp_request(ch, LSTP_MMIO_CMD_WRITE, req, sizeof(*req), NULL, 0, NULL, NULL);
-		goto out_unlock;
-	}
 
 	while (done < count) {
 		size_t chunk = min(count - done, ch->max_tx_payload - sizeof(*req));

--- a/drivers/usb/misc/lstp/lstp-spi.c
+++ b/drivers/usb/misc/lstp/lstp-spi.c
@@ -1,0 +1,430 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * SPI driver for LSTP USB interface.
+ *
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+#include <linux/spi/spi.h>
+#include <linux/err.h>
+
+#include "lstp-main.h"
+
+/*******************************************************************************
+ * SPI command definitions
+ ******************************************************************************/
+
+enum lstp_spi_cmd {
+	LSTP_SPI_CMD_READ = 0x01,
+	LSTP_SPI_CMD_WRITE = 0x02,
+	LSTP_SPI_CMD_WRITE_READ = 0x03,
+	LSTP_SPI_CMD_POSTED_WRITE = 0x04
+};
+
+/* clang-format off */
+enum lstp_spi_cmd_cs_toggle {
+	LSTP_SPI_CMD_CS_ASSERT = 0x20,
+	LSTP_SPI_CMD_CS_DEASSERT = 0x10
+}; /* clang-format on */
+
+/* clang-format off */
+enum lstp_spi_cmd_cs_sel {
+	LSTP_SPI_CMD_CS0 = 0x00,
+	LSTP_SPI_CMD_CS1 = 0x40
+}; /* clang-format on */
+/* clang-format off */
+static const u8 lstp_spi_cs_map[] = {
+	LSTP_SPI_CMD_CS0,
+	LSTP_SPI_CMD_CS1
+}; /* clang-format on */
+
+struct lstp_spi_read_req {
+	__le32 len;
+} __packed;
+
+struct lstp_spi_config {
+	u8 num_devices;
+	__le32 speed_hz;
+} __packed;
+
+/* Private data for SPI controller */
+struct lstp_spi_priv {
+	struct spi_controller *ctrl;
+	u32 current_speed_hz;
+};
+
+/* Defaults for backwards compatibility with firmware lacking SPI channel config */
+#define LSTP_SPI_DEFAULT_NUM_DEVICES 2
+#define LSTP_SPI_DEFAULT_SPEED_HZ 18750000 /* 18.75 MHz */
+
+/*******************************************************************************
+ * SPI controller callbacks
+ ******************************************************************************/
+
+/**
+ * lstp_spi_do_transfer() - Execute a single SPI transfer with CS flags.
+ * @ch:       LSTP channel to transfer on
+ * @xfer:     SPI transfer descriptor containing tx/rx buffers and length
+ * @cs_bits:  Chip select selection bits (LSTP_SPI_CMD_CS0..CS1)
+ * @cs_flags: Chip select toggle flags (LSTP_SPI_CMD_CS_ASSERT/DEASSERT)
+ *
+ * Core transfer routine shared by lstp_spi_transfer_one_message(). Supports
+ * three modes based on which buffers are provided:
+ * - Write-Read (full duplex): Both tx_buf and rx_buf set
+ * - Write only: Only tx_buf set
+ * - Read only: Only rx_buf set
+ *
+ * Caller serialization: provided by spi_controller->io_mutex
+ * (transfer_one_message is the only entry point).
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_spi_do_transfer(struct lstp_channel *ch, struct spi_transfer *xfer, u8 cs_bits,
+				u8 cs_flags)
+{
+	struct lstp_spi_priv *priv = ch->priv;
+	u8 cmd;
+	int ret;
+
+	if (xfer->word_delay.value)
+		dev_warn_once(ch->dev, "%s: ch_%d: word_delay not supported, ignoring\n", __func__,
+			      ch->ch_id);
+
+	xfer->error = SPI_TRANS_FAIL_NO_START;
+
+	xfer->effective_speed_hz = priv->current_speed_hz;
+
+	if (xfer->tx_buf && xfer->len > ch->max_tx_payload) {
+		dev_err(ch->dev, "%s: ch_%d: TX transfer length %u exceeds capacity %zu\n",
+			__func__, ch->ch_id, xfer->len, ch->max_tx_payload);
+		return -EINVAL;
+	}
+	if (xfer->rx_buf && xfer->len > ch->max_rx_payload) {
+		dev_err(ch->dev, "%s: ch_%d: RX transfer length %u exceeds capacity %zu\n",
+			__func__, ch->ch_id, xfer->len, ch->max_rx_payload);
+		return -EINVAL;
+	}
+
+	if (xfer->tx_buf && xfer->rx_buf) {
+		cmd = LSTP_SPI_CMD_WRITE_READ | cs_bits | cs_flags;
+		ret = lstp_request(ch, cmd, xfer->tx_buf, xfer->len, xfer->rx_buf, xfer->len, NULL,
+				   NULL);
+	} else if (xfer->tx_buf) {
+		cmd = LSTP_SPI_CMD_WRITE | cs_bits | cs_flags;
+		ret = lstp_request(ch, cmd, xfer->tx_buf, xfer->len, NULL, 0, NULL, NULL);
+	} else if (xfer->rx_buf) {
+		struct lstp_spi_read_req req = { .len = cpu_to_le32(xfer->len) };
+
+		cmd = LSTP_SPI_CMD_READ | cs_bits | cs_flags;
+		ret = lstp_request(ch, cmd, &req, sizeof(req), xfer->rx_buf, xfer->len, NULL, NULL);
+	} else {
+		return -EINVAL;
+	}
+
+	if (ret) {
+		dev_err(ch->dev, "%s: ch_%d: Transfer failed (%pe)\n", __func__, ch->ch_id,
+			ERR_PTR(ret));
+		xfer->error = SPI_TRANS_FAIL_IO;
+		return ret;
+	}
+
+	xfer->error = 0;
+	return 0;
+}
+
+/**
+ * lstp_spi_transfer_one_message() - Execute a complete SPI message.
+ * @ctrl: SPI controller performing the transfer
+ * @mesg: SPI message containing one or more transfers
+ *
+ * Processes all transfers in a message, embedding chip select assert/deassert
+ * flags directly into each transfer command. This avoids the separate USB
+ * round-trips that would be needed if the SPI core managed CS via a set_cs
+ * callback.
+ *
+ * CS management follows standard SPI semantics:
+ * - CS is asserted before the first transfer
+ * - CS is deasserted after the last transfer
+ * - xfer->cs_change inverts the default: deasserts mid-message, or leaves
+ *   CS asserted after the last transfer
+ *
+ * On completion (success or failure), calls spi_finalize_current_message()
+ * so the subsystem can issue the next queued message.
+ *
+ * Context: Process context. Performs blocking USB I/O. Caller
+ * serialization is provided by spi_controller->io_mutex.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_spi_transfer_one_message(struct spi_controller *ctrl, struct spi_message *mesg)
+{
+	struct lstp_channel *ch = spi_controller_get_devdata(ctrl);
+	struct spi_transfer *xfer;
+	u8 chip_select = spi_get_chipselect(mesg->spi, 0);
+	u8 cs_bits;
+	int ret = 0;
+	bool cs_active = false;
+
+	if (chip_select >= ctrl->num_chipselect) {
+		dev_err(ch->dev, "%s: ch_%d: Invalid chip select %u (max %u)\n", __func__,
+			ch->ch_id, chip_select, ctrl->num_chipselect - 1);
+		ret = -EINVAL;
+		goto finalize;
+	}
+	cs_bits = lstp_spi_cs_map[chip_select];
+
+	list_for_each_entry(xfer, &mesg->transfers, transfer_list) {
+		u8 cs_flags = 0;
+		bool is_last = list_is_last(&xfer->transfer_list, &mesg->transfers);
+
+		if (!cs_active) {
+			cs_flags |= LSTP_SPI_CMD_CS_ASSERT;
+			cs_active = true;
+		}
+
+		if ((is_last && !xfer->cs_change) || (!is_last && xfer->cs_change)) {
+			cs_flags |= LSTP_SPI_CMD_CS_DEASSERT;
+			cs_active = false;
+		}
+
+		ret = lstp_spi_do_transfer(ch, xfer, cs_bits, cs_flags);
+		if (ret)
+			break;
+
+		mesg->actual_length += xfer->len;
+
+		if (!is_last && xfer->cs_change)
+			spi_transfer_cs_change_delay_exec(mesg, xfer);
+
+		spi_transfer_delay_exec(xfer);
+	}
+
+finalize:
+	mesg->status = ret;
+	spi_finalize_current_message(ctrl);
+	return ret;
+}
+
+/**
+ * lstp_spi_set_cs_timing() - Validate CS timing parameters for an SPI device.
+ * @spi: SPI device whose CS timing is being configured
+ *
+ * Called by spi_setup(). The LSTP firmware manages CS assertion internally, so
+ * fine-grained cs_setup / cs_hold / cs_inactive delays cannot be honoured.
+ * Accept the configuration but warn if non-zero values were requested.
+ *
+ * Return: 0 always (timing is silently ignored).
+ */
+static int lstp_spi_set_cs_timing(struct spi_device *spi)
+{
+	struct lstp_channel *ch = spi_controller_get_devdata(spi->controller);
+
+	if (spi->cs_setup.value || spi->cs_hold.value || spi->cs_inactive.value)
+		dev_warn(ch->dev, "%s: ch_%d: CS timing delays not supported, ignoring\n", __func__,
+			 ch->ch_id);
+	return 0;
+}
+
+/**
+ * lstp_spi_max_xfer_size() - Report maximum transfer size for the SPI controller.
+ * @spi: SPI device querying the maximum size
+ *
+ * Returns the maximum number of bytes that can be transferred in a single
+ * SPI transaction. This is limited by the USB endpoint buffer size minus
+ * the LSTP header overhead.
+ *
+ * Context: Any context.
+ *
+ * Return: Maximum transfer size in bytes.
+ */
+static size_t lstp_spi_max_xfer_size(struct spi_device *spi)
+{
+	struct lstp_channel *ch;
+
+	if (spi) {
+		ch = spi_controller_get_devdata(spi->controller);
+		return min(ch->max_tx_payload, ch->max_rx_payload);
+	}
+
+	return LSTP_USB_EP_MAX_SIZE - sizeof(struct lstp_header);
+}
+
+/*******************************************************************************
+ * SPI channel initialization and start
+ ******************************************************************************/
+
+/**
+ * lstp_spi_create_spidev() - Create spidev devices for the SPI controller.
+ * @ctrl: SPI controller to create spidev devices for
+ * @ch:   LSTP channel to create spidev devices for
+ *
+ * Creates spidev devices on a SPI controller based on the number of chip selects.
+ * Uses the "spidev" modalias which must be present in spidev's allowlist.
+ */
+static void lstp_spi_create_spidev(struct spi_controller *ctrl, struct lstp_channel *ch)
+{
+	struct lstp_spi_priv *priv = ch->priv;
+	u8 cs;
+	struct spi_board_info info;
+
+	for (cs = 0; cs < ctrl->num_chipselect; cs++) {
+		info = (struct spi_board_info){
+			.max_speed_hz = priv->current_speed_hz,
+			.mode = SPI_MODE_0,
+			.chip_select = cs,
+		};
+		strscpy(info.modalias, "spidev", sizeof(info.modalias));
+
+		if (!spi_new_device(ctrl, &info)) {
+			dev_err(ch->dev, "%s: ch_%d: Could not create spidev for CS%u\n", __func__,
+				ch->ch_id, cs);
+		}
+	}
+}
+
+/**
+ * lstp_spi_init() - Initialize an LSTP SPI channel.
+ * @ch:   LSTP channel to initialize as SPI controller
+ * @info: config blob (struct lstp_spi_config); legacy defaults if absent or short
+ *
+ * Allocates and initializes the SPI controller but does not register it; call
+ * lstp_spi_start() once the RX URB is active to register it and create a spidev
+ * for each chip select.
+ *
+ * Context: Process context. Called during probe before RX URB is active.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_spi_init(struct lstp_channel *ch, const struct lstp_channel_init_info *info)
+{
+	struct lstp_spi_priv *priv;
+	struct spi_controller *ctrl;
+	const struct lstp_spi_config *config = info->config_len >= sizeof(*config) ? info->config :
+										     NULL;
+	u8 num_devices;
+	u32 speed_hz;
+
+	priv = devm_kzalloc(ch->dev, sizeof(*priv), GFP_KERNEL);
+	if (!priv)
+		return -ENOMEM;
+
+	ctrl = devm_spi_alloc_host(ch->dev, 0);
+	if (!ctrl)
+		return -ENOMEM;
+
+	/* Parse SPI config (uses defaults if no config is present) */
+	if (config) {
+		num_devices = config->num_devices;
+		speed_hz = le32_to_cpu(config->speed_hz);
+	} else {
+		/* TODO: Legacy support - remove this at some point */
+		dev_err(ch->dev, "%s: ch_%d: No SPI channel config, using defaults\n", __func__,
+			ch->ch_id);
+		num_devices = LSTP_SPI_DEFAULT_NUM_DEVICES;
+		speed_hz = LSTP_SPI_DEFAULT_SPEED_HZ;
+	}
+
+	if (num_devices == 0 || num_devices > ARRAY_SIZE(lstp_spi_cs_map)) {
+		dev_err(ch->dev, "%s: ch_%d: Invalid num_devices %u (max %zu)\n", __func__,
+			ch->ch_id, num_devices, ARRAY_SIZE(lstp_spi_cs_map));
+		return -EINVAL;
+	}
+
+	if (speed_hz == 0) {
+		dev_err(ch->dev, "%s: ch_%d: Device returned SPI speed of %u Hz\n", __func__,
+			ch->ch_id, speed_hz);
+		return -EINVAL;
+	}
+
+	spi_controller_set_devdata(ctrl, ch);
+	ctrl->bus_num = -1;
+	ctrl->num_chipselect = num_devices;
+	ctrl->transfer_one_message = lstp_spi_transfer_one_message;
+	ctrl->max_transfer_size = lstp_spi_max_xfer_size;
+	ctrl->set_cs_timing = lstp_spi_set_cs_timing;
+
+	/* Set firmware node so SPI core auto-enumerates child devices (DT or ACPI) */
+	device_set_node(&ctrl->dev, ch->fwnode);
+
+	priv->ctrl = ctrl;
+	priv->current_speed_hz = speed_hz;
+
+	ch->priv = priv;
+
+	dev_dbg(ch->dev, "%s: ch_%d: Initialized as %s\n", __func__, ch->ch_id, ch->display_name);
+	return 0;
+}
+
+/**
+ * lstp_spi_start() - Start an LSTP SPI channel.
+ * @ch: LSTP channel to start
+ *
+ * Registers the SPI controller with the Linux SPI subsystem and creates
+ * a spidev device for each chip select so that userspace can access the
+ * bus via /dev/spidevN.CS.
+ *
+ * Context: Process context. Called during probe after RX URB is active.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_spi_start(struct lstp_channel *ch)
+{
+	int ret;
+	struct lstp_spi_priv *priv = ch->priv;
+	struct spi_controller *ctrl;
+
+	if (!priv || !priv->ctrl) {
+		dev_err(ch->dev, "%s: ch_%d: SPI controller not initialized\n", __func__,
+			ch->ch_id);
+		return -EINVAL;
+	}
+
+	ctrl = priv->ctrl;
+
+	ret = devm_spi_register_controller(ch->dev, ctrl);
+	if (ret) {
+		dev_err(ch->dev, "%s: ch_%d: Could not register SPI controller (%pe)\n", __func__,
+			ch->ch_id, ERR_PTR(ret));
+		return ret;
+	}
+
+	if (ch->fwnode) {
+		unsigned int child_count = 0;
+		struct fwnode_handle *child;
+
+		fwnode_for_each_available_child_node(ch->fwnode, child)
+			child_count++;
+
+		if (child_count == 0) {
+			dev_warn(ch->dev,
+				 "%s: ch_%d: Firmware node present but defines no SPI devices\n",
+				 __func__, ch->ch_id);
+		} else {
+			dev_info(ch->dev, "%s: ch_%d: Firmware node present with %u SPI devices\n",
+				 __func__, ch->ch_id, child_count);
+		}
+	} else if (lstp_auto_bind_spidev) {
+		lstp_spi_create_spidev(ctrl, ch);
+	}
+
+	deprecated_lstp_channel_publish_child_dev(ch, &ctrl->dev);
+
+	dev_info(ch->dev, "%s: ch_%d: Started as %s (devices=%u, speed=%u Hz)\n", __func__,
+		 ch->ch_id, ch->display_name, ctrl->num_chipselect, priv->current_speed_hz);
+	return 0;
+}
+
+/* clang-format off */
+LSTP_SUBSYS(spi, LSTP_CHANNEL_TYPE_SPI, lstp_spi_init, lstp_spi_start,
+	    .fwnode_compatible = "nvidia,lstp-spi",
+);
+/* clang-format on */

--- a/drivers/usb/misc/lstp/lstp-spi.c
+++ b/drivers/usb/misc/lstp/lstp-spi.c
@@ -143,6 +143,19 @@ static int lstp_spi_do_transfer(struct lstp_channel *ch, struct spi_transfer *xf
 }
 
 /**
+ * lstp_spi_deassert_cs() - Best-effort chip-select recovery after an error.
+ * @ch:      LSTP channel to recover
+ * @cs_bits: Chip select selection bits (LSTP_SPI_CMD_CS0..CS1)
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_spi_deassert_cs(struct lstp_channel *ch, u8 cs_bits)
+{
+	return lstp_request(ch, LSTP_SPI_CMD_WRITE | cs_bits | LSTP_SPI_CMD_CS_DEASSERT, NULL, 0,
+			    NULL, 0, NULL, NULL);
+}
+
+/**
  * lstp_spi_transfer_one_message() - Execute a complete SPI message.
  * @ctrl: SPI controller performing the transfer
  * @mesg: SPI message containing one or more transfers
@@ -185,21 +198,27 @@ static int lstp_spi_transfer_one_message(struct spi_controller *ctrl, struct spi
 
 	list_for_each_entry(xfer, &mesg->transfers, transfer_list) {
 		u8 cs_flags = 0;
+		bool deassert_after;
 		bool is_last = list_is_last(&xfer->transfer_list, &mesg->transfers);
 
-		if (!cs_active) {
+		if (!cs_active)
 			cs_flags |= LSTP_SPI_CMD_CS_ASSERT;
-			cs_active = true;
-		}
 
-		if ((is_last && !xfer->cs_change) || (!is_last && xfer->cs_change)) {
+		deassert_after = (is_last && !xfer->cs_change) || (!is_last && xfer->cs_change);
+		if (deassert_after)
 			cs_flags |= LSTP_SPI_CMD_CS_DEASSERT;
-			cs_active = false;
-		}
 
 		ret = lstp_spi_do_transfer(ch, xfer, cs_bits, cs_flags);
-		if (ret)
+		if (ret) {
+			int recovery_ret = lstp_spi_deassert_cs(ch, cs_bits);
+
+			if (recovery_ret)
+				dev_err(ch->dev, "%s: ch_%d: Could not deassert CS%u (%pe)\n",
+					__func__, ch->ch_id, chip_select, ERR_PTR(recovery_ret));
 			break;
+		}
+
+		cs_active = !deassert_after;
 
 		mesg->actual_length += xfer->len;
 

--- a/drivers/usb/misc/lstp/lstp-spi.c
+++ b/drivers/usb/misc/lstp/lstp-spi.c
@@ -431,6 +431,7 @@ static int lstp_spi_start(struct lstp_channel *ch)
 {
 	unsigned int child_count = 0;
 	struct fwnode_handle *child;
+	void *devres_group;
 	int ret;
 	struct lstp_spi_priv *priv = ch->priv;
 	struct spi_controller *ctrl;
@@ -442,12 +443,15 @@ static int lstp_spi_start(struct lstp_channel *ch)
 	}
 
 	ctrl = priv->ctrl;
+	devres_group = devres_open_group(ch->dev, NULL, GFP_KERNEL);
+	if (!devres_group)
+		return -ENOMEM;
 
 	ret = devm_spi_register_controller(ch->dev, ctrl);
 	if (ret) {
 		dev_err(ch->dev, "%s: ch_%d: Could not register SPI controller (%pe)\n", __func__,
 			ch->ch_id, ERR_PTR(ret));
-		return ret;
+		goto err_release_group;
 	}
 
 	if (ch->fwnode) {
@@ -467,14 +471,19 @@ static int lstp_spi_start(struct lstp_channel *ch)
 	if (!child_count && lstp_auto_bind_spidev) {
 		ret = lstp_spi_create_spidev(ctrl, ch);
 		if (ret)
-			return ret;
+			goto err_release_group;
 	}
+	devres_close_group(ch->dev, devres_group);
 
 	deprecated_lstp_channel_publish_child_dev(ch, &ctrl->dev);
 
 	dev_info(ch->dev, "%s: ch_%d: Started as %s (devices=%u, speed=%u Hz)\n", __func__,
 		 ch->ch_id, ch->display_name, ctrl->num_chipselect, priv->current_speed_hz);
 	return 0;
+
+err_release_group:
+	devres_release_group(ch->dev, devres_group);
+	return ret;
 }
 
 /* clang-format off */

--- a/drivers/usb/misc/lstp/lstp-spi.c
+++ b/drivers/usb/misc/lstp/lstp-spi.c
@@ -14,8 +14,9 @@
  * more details.
  */
 
-#include <linux/spi/spi.h>
 #include <linux/err.h>
+#include <linux/kmod.h>
+#include <linux/spi/spi.h>
 
 #include "lstp-main.h"
 
@@ -268,27 +269,55 @@ static size_t lstp_spi_max_xfer_size(struct spi_device *spi)
  * @ch:   LSTP channel to create spidev devices for
  *
  * Creates spidev devices on a SPI controller based on the number of chip selects.
- * Uses the "spidev" modalias which must be present in spidev's allowlist.
+ * The generic "spidev" modalias is not in spidev's device ID table, so set a
+ * driver override before registering each device.
+ *
+ * Return: 0 on success, negative errno on failure.
  */
-static void lstp_spi_create_spidev(struct spi_controller *ctrl, struct lstp_channel *ch)
+static int lstp_spi_create_spidev(struct spi_controller *ctrl, struct lstp_channel *ch)
 {
 	struct lstp_spi_priv *priv = ch->priv;
+	struct spi_device *spi;
+	int ret;
 	u8 cs;
-	struct spi_board_info info;
+
+	/* driver_override does not provide a module alias, so load spidev first. */
+	request_module("spidev");
 
 	for (cs = 0; cs < ctrl->num_chipselect; cs++) {
-		info = (struct spi_board_info){
-			.max_speed_hz = priv->current_speed_hz,
-			.mode = SPI_MODE_0,
-			.chip_select = cs,
-		};
-		strscpy(info.modalias, "spidev", sizeof(info.modalias));
+		spi = spi_alloc_device(ctrl);
+		if (!spi)
+			return -ENOMEM;
 
-		if (!spi_new_device(ctrl, &info)) {
-			dev_err(ch->dev, "%s: ch_%d: Could not create spidev for CS%u\n", __func__,
+		spi_set_chipselect(spi, 0, cs);
+		spi->cs_index_mask = BIT(0);
+		spi->max_speed_hz = priv->current_speed_hz;
+		spi->mode = SPI_MODE_0;
+		strscpy(spi->modalias, "spidev", sizeof(spi->modalias));
+
+		ret = device_set_driver_override(&spi->dev, "spidev");
+		if (ret)
+			goto err_put;
+
+		ret = spi_add_device(spi);
+		if (ret)
+			goto err_put;
+
+		if (!device_is_bound(&spi->dev)) {
+			dev_err(ch->dev, "%s: ch_%d: Could not bind spidev for CS%u\n", __func__,
 				ch->ch_id, cs);
+			spi_unregister_device(spi);
+			return -ENODEV;
 		}
 	}
+
+	return 0;
+
+err_put:
+	spi_dev_put(spi);
+	dev_err(ch->dev, "%s: ch_%d: Could not create spidev for CS%u (%pe)\n", __func__,
+		ch->ch_id, cs, ERR_PTR(ret));
+	return ret;
 }
 
 /**
@@ -413,7 +442,9 @@ static int lstp_spi_start(struct lstp_channel *ch)
 				 __func__, ch->ch_id, child_count);
 		}
 	} else if (lstp_auto_bind_spidev) {
-		lstp_spi_create_spidev(ctrl, ch);
+		ret = lstp_spi_create_spidev(ctrl, ch);
+		if (ret)
+			return ret;
 	}
 
 	deprecated_lstp_channel_publish_child_dev(ch, &ctrl->dev);

--- a/drivers/usb/misc/lstp/lstp-spi.c
+++ b/drivers/usb/misc/lstp/lstp-spi.c
@@ -377,6 +377,9 @@ static int lstp_spi_init(struct lstp_channel *ch, const struct lstp_channel_init
 	spi_controller_set_devdata(ctrl, ch);
 	ctrl->bus_num = -1;
 	ctrl->num_chipselect = num_devices;
+	ctrl->bits_per_word_mask = SPI_BPW_MASK(8);
+	ctrl->min_speed_hz = speed_hz;
+	ctrl->max_speed_hz = speed_hz;
 	ctrl->transfer_one_message = lstp_spi_transfer_one_message;
 	ctrl->max_transfer_size = lstp_spi_max_xfer_size;
 	ctrl->set_cs_timing = lstp_spi_set_cs_timing;

--- a/drivers/usb/misc/lstp/lstp-spi.c
+++ b/drivers/usb/misc/lstp/lstp-spi.c
@@ -410,6 +410,8 @@ static int lstp_spi_init(struct lstp_channel *ch, const struct lstp_channel_init
  */
 static int lstp_spi_start(struct lstp_channel *ch)
 {
+	unsigned int child_count = 0;
+	struct fwnode_handle *child;
 	int ret;
 	struct lstp_spi_priv *priv = ch->priv;
 	struct spi_controller *ctrl;
@@ -430,9 +432,6 @@ static int lstp_spi_start(struct lstp_channel *ch)
 	}
 
 	if (ch->fwnode) {
-		unsigned int child_count = 0;
-		struct fwnode_handle *child;
-
 		fwnode_for_each_available_child_node(ch->fwnode, child)
 			child_count++;
 
@@ -444,7 +443,9 @@ static int lstp_spi_start(struct lstp_channel *ch)
 			dev_info(ch->dev, "%s: ch_%d: Firmware node present with %u SPI devices\n",
 				 __func__, ch->ch_id, child_count);
 		}
-	} else if (lstp_auto_bind_spidev) {
+	}
+
+	if (!child_count && lstp_auto_bind_spidev) {
 		ret = lstp_spi_create_spidev(ctrl, ch);
 		if (ret)
 			return ret;

--- a/drivers/usb/misc/lstp/lstp-uart.c
+++ b/drivers/usb/misc/lstp/lstp-uart.c
@@ -1,0 +1,779 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * UART driver for LSTP USB interface.
+ *
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+#include <linux/cleanup.h>
+#include <linux/delay.h>
+#include <linux/err.h>
+#include <linux/init.h>
+#include <linux/serial.h>
+#include <linux/termios.h>
+#include <linux/tty.h>
+#include <linux/tty_buffer.h>
+#include <linux/tty_driver.h>
+#include <linux/tty_flip.h>
+#include <linux/xarray.h>
+
+#include "lstp-main.h"
+
+/*****************************************************************************
+ * Protocol constants
+ *****************************************************************************/
+
+enum lstp_uart_cmd {
+	LSTP_UART_CMD_WRITE = 0x00,
+};
+
+struct lstp_uart_config {
+	__le32 speed;
+	u8 data_bits;
+	u8 stop_bits;
+	u8 parity_flow; /* [3:0] parity, [7:4] flow control */
+} __packed;
+
+#define LSTP_UART_CFG_PARITY(pf) ((pf) & 0x0F)
+#define LSTP_UART_CFG_FLOW(pf) (((pf) >> 4) & 0x0F)
+
+enum lstp_uart_parity {
+	LSTP_UART_PARITY_NONE = 0,
+	LSTP_UART_PARITY_ODD = 1,
+	LSTP_UART_PARITY_EVEN = 2,
+	LSTP_UART_PARITY_MARK = 3,
+	LSTP_UART_PARITY_SPACE = 4,
+};
+
+enum lstp_uart_flow {
+	LSTP_UART_FLOW_NONE = 0,
+	LSTP_UART_FLOW_XONXOFF = 1,
+	LSTP_UART_FLOW_RTSCTS = 2,
+	LSTP_UART_FLOW_DTRDSR = 3,
+};
+
+/* clang-format off */
+
+/* Tag bits OR'd into the WRITE command byte. */
+#define LSTP_UART_TAG_CARRIER_DOWN BIT(6) /* dev→host: carrier lost */
+#define LSTP_UART_TAG_TX_OVERRUN   BIT(5) /* dev→host: TX data dropped */
+#define LSTP_UART_TAG_BREAK_DET    BIT(4) /* dev→host: break detected */
+#define LSTP_UART_TAG_GEN_BREAK    BIT(3) /* host→dev: send break */
+
+/* clang-format on */
+
+/* Bits [1:0] = command; [6:2] = tags; [7] = req/resp flag. */
+#define LSTP_UART_CMD_MASK GENMASK(1, 0)
+
+/*
+ * NACK retry: firmware NACKs when its TX FIFO is full.
+ * 5 × 10 ms covers one drain cycle at 115200 baud (~43 ms / 500 bytes).
+ */
+#define LSTP_UART_NAK_MAX_RETRIES 5
+#define LSTP_UART_NAK_RETRY_DELAY_MS 10
+
+#define LSTP_UART_MINORS 256
+
+/*****************************************************************************
+ * Per-channel context
+ *****************************************************************************/
+
+/*
+ * TX uses two-stage coalescing:
+ *
+ *   write() --> [ coal_buf ] --drain--> [ tx_pkt ] --USB--> device
+ *
+ * write() appends to coal_buf and schedules write_work. The USB
+ * round-trip (~1 ms) acts as the natural coalescing window — while
+ * a TX is in-flight, further writes accumulate for the next batch.
+ */
+struct lstp_uart_ctx {
+	struct tty_port port;
+	struct lstp_channel *ch;
+	int minor;
+	size_t max_payload;
+	tcflag_t hw_cflag;
+	tcflag_t hw_iflag;
+
+	spinlock_t write_lock; /* protects all fields below */
+	u8 *coal_buf;
+	u8 *tx_snapshot; /* stable copy handed to lstp_request() */
+	size_t coal_len;
+	size_t tx_inflight_len;
+	bool tx_in_flight;
+	struct work_struct write_work;
+
+	struct serial_icounter_struct iocount; /* per-field single-writer */
+};
+
+static struct tty_driver *lstp_tty_driver;
+
+static DEFINE_XARRAY_ALLOC(lstp_minors);
+static DEFINE_MUTEX(lstp_minors_lock);
+
+/*****************************************************************************
+ * Minor number management
+ *****************************************************************************/
+
+static int lstp_alloc_minor(struct lstp_channel *ch)
+{
+	u32 minor;
+	int ret;
+
+	guard(mutex)(&lstp_minors_lock);
+	ret = xa_alloc(&lstp_minors, &minor, ch, XA_LIMIT(0, LSTP_UART_MINORS - 1), GFP_KERNEL);
+
+	return ret ? ret : minor;
+}
+
+/*
+ * Look up a live channel by minor and take a tty_port reference.
+ * Returns NULL if the minor is unregistered or the channel disconnected.
+ */
+static struct lstp_channel *lstp_get_by_minor(unsigned int minor)
+{
+	struct lstp_uart_ctx *ctx;
+	struct lstp_channel *ch;
+
+	guard(mutex)(&lstp_minors_lock);
+	ch = xa_load(&lstp_minors, minor);
+	if (!ch)
+		return NULL;
+
+	ctx = ch->priv;
+	if (!ctx || lstp_channel_disconnected(ch))
+		return NULL;
+
+	tty_port_get(&ctx->port);
+	return ch;
+}
+
+/*****************************************************************************
+ * Firmware config → termios helpers
+ *****************************************************************************/
+
+/* clang-format off */
+static speed_t lstp_baud_to_speed(u32 baud)
+{
+	static const struct {
+		u32     baud;
+		speed_t speed;
+	} map[] = {
+		{      50, B50      }, {      75, B75      }, {     110, B110     },
+		{     134, B134     }, {     150, B150     }, {     200, B200     },
+		{     300, B300     }, {     600, B600     }, {    1200, B1200    },
+		{    1800, B1800    }, {    2400, B2400    }, {    4800, B4800    },
+		{    9600, B9600    }, {   19200, B19200   }, {   38400, B38400   },
+		{   57600, B57600   }, {  115200, B115200  }, {  230400, B230400  },
+		{  460800, B460800  }, {  500000, B500000  }, {  576000, B576000  },
+		{  921600, B921600  }, { 1000000, B1000000 }, { 1152000, B1152000 },
+		{ 1500000, B1500000 }, { 2000000, B2000000 }, { 2500000, B2500000 },
+		{ 3000000, B3000000 }, { 3500000, B3500000 }, { 4000000, B4000000 },
+	};
+
+	for (size_t i = 0; i < ARRAY_SIZE(map); i++)
+		if (map[i].baud == baud)
+			return map[i].speed;
+
+	return B0;
+}
+
+/* clang-format on */
+
+static tcflag_t lstp_build_cflag(const struct lstp_uart_config *cfg)
+{
+	tcflag_t cflag = CREAD | HUPCL | CLOCAL;
+	u8 parity = LSTP_UART_CFG_PARITY(cfg->parity_flow);
+	u8 flow = LSTP_UART_CFG_FLOW(cfg->parity_flow);
+
+	cflag |= lstp_baud_to_speed(le32_to_cpu(cfg->speed));
+
+	switch (cfg->data_bits) {
+	case 5:
+		cflag |= CS5;
+		break;
+	case 6:
+		cflag |= CS6;
+		break;
+	case 7:
+		cflag |= CS7;
+		break;
+	default:
+		cflag |= CS8;
+		break;
+	}
+
+	if (cfg->stop_bits == 2)
+		cflag |= CSTOPB;
+
+	switch (parity) {
+	case LSTP_UART_PARITY_ODD:
+		cflag |= PARENB | PARODD;
+		break;
+	case LSTP_UART_PARITY_EVEN:
+		cflag |= PARENB;
+		break;
+	case LSTP_UART_PARITY_MARK:
+		cflag |= PARENB | PARODD | CMSPAR;
+		break;
+	case LSTP_UART_PARITY_SPACE:
+		cflag |= PARENB | CMSPAR;
+		break;
+	}
+
+	if (flow == LSTP_UART_FLOW_RTSCTS)
+		cflag |= CRTSCTS;
+
+	return cflag;
+}
+
+static tcflag_t lstp_build_iflag(const struct lstp_uart_config *cfg)
+{
+	if (LSTP_UART_CFG_FLOW(cfg->parity_flow) == LSTP_UART_FLOW_XONXOFF)
+		return IXON | IXOFF;
+	return 0;
+}
+
+static int lstp_uart_parse_config(struct lstp_uart_ctx *ctx, struct lstp_channel *ch,
+				  const struct lstp_uart_config *cfg)
+{
+	ctx->hw_cflag = lstp_build_cflag(cfg);
+	ctx->hw_iflag = lstp_build_iflag(cfg);
+
+	{
+		static const char parity_ch[] = "NOEMS";
+		u8 p = LSTP_UART_CFG_PARITY(cfg->parity_flow);
+
+		dev_info(ch->dev, "%s: ch_%d: %u baud, %u%c%c, parity %u, flow %u\n", __func__,
+			 ch->ch_id, le32_to_cpu(cfg->speed), cfg->data_bits,
+			 cfg->stop_bits == 2 ? '2' : '1',
+			 p < sizeof(parity_ch) - 1 ? parity_ch[p] : '?', p,
+			 LSTP_UART_CFG_FLOW(cfg->parity_flow));
+	}
+
+	return 0;
+}
+
+/*****************************************************************************
+ * TX path
+ *****************************************************************************/
+
+static int lstp_uart_send_with_retry(struct lstp_uart_ctx *ctx, u8 cmd, const void *payload,
+				     size_t len)
+{
+	struct lstp_channel *ch = ctx->ch;
+	int lstp_status = LSTP_NACK;
+	int ret = 0;
+	int attempt;
+
+	for (attempt = 0; lstp_status == LSTP_NACK && attempt < LSTP_UART_NAK_MAX_RETRIES;
+	     attempt++) {
+		if (attempt)
+			fsleep(LSTP_UART_NAK_RETRY_DELAY_MS * USEC_PER_MSEC);
+
+		ret = lstp_request(ch, cmd, payload, len, NULL, 0, NULL, &lstp_status);
+	}
+
+	if (ret)
+		dev_warn(ch->dev, "%s: ch_%d: Failed to write after %d attempt(s) (%pe)\n",
+			 __func__, ch->ch_id, attempt, ERR_PTR(ret));
+
+	return ret;
+}
+
+/*
+ * Drain coal_buf into one LSTP WRITE, send over USB, reschedule if
+ * new data arrived during the round-trip. tx_snapshot is a private,
+ * single-writer buffer (write_work only) so it stays stable across
+ * the retry loop while lstp_tty_write() keeps appending to coal_buf.
+ */
+static void lstp_uart_write_work(struct work_struct *work)
+{
+	struct lstp_uart_ctx *ctx = container_of(work, struct lstp_uart_ctx, write_work);
+	size_t len;
+	int ret;
+
+	scoped_guard(spinlock_irqsave, &ctx->write_lock) {
+		len = ctx->coal_len;
+		if (len == 0)
+			return;
+		memcpy(ctx->tx_snapshot, ctx->coal_buf, len);
+		ctx->coal_len = 0;
+		ctx->tx_in_flight = true;
+		ctx->tx_inflight_len = len;
+	}
+
+	tty_port_tty_wakeup(&ctx->port);
+
+	ret = lstp_uart_send_with_retry(ctx, LSTP_UART_CMD_WRITE, ctx->tx_snapshot, len);
+
+	scoped_guard(spinlock_irqsave, &ctx->write_lock) {
+		ctx->tx_in_flight = false;
+		if (!ret)
+			ctx->iocount.tx += len;
+		if (ctx->coal_len > 0)
+			schedule_work(&ctx->write_work);
+	}
+
+	tty_port_tty_wakeup(&ctx->port);
+}
+
+/*****************************************************************************
+ * RX path
+ *****************************************************************************/
+
+/**
+ * lstp_uart_irq_callback() - Push unsolicited UART RX bytes into the TTY layer.
+ * @ch:  LSTP channel that received the request.
+ * @pkt: Received LSTP packet (header + payload).
+ *
+ * Push RX bytes into the TTY flip buffer. NACK if the buffer is full
+ * so firmware retries. Serialized by irq_buffer_lock in the USB RX
+ * callback — no local locking needed.
+ */
+static void lstp_uart_irq_callback(struct lstp_channel *ch, struct lstp_packet *pkt)
+{
+	struct lstp_uart_ctx *ctx = ch->priv;
+	u16 rx_len = le16_to_cpu(pkt->hdr.length);
+	u8 cmd = pkt->hdr.cmd;
+	bool have_break = cmd & LSTP_UART_TAG_BREAK_DET;
+	bool carrier_down = cmd & LSTP_UART_TAG_CARRIER_DOWN;
+	bool tx_overrun = cmd & LSTP_UART_TAG_TX_OVERRUN;
+	size_t need_room = rx_len + (have_break ? 1 : 0);
+	u8 status = LSTP_SUCCESS;
+	size_t room;
+
+	if ((cmd & LSTP_UART_CMD_MASK) != LSTP_UART_CMD_WRITE) {
+		dev_warn_ratelimited(ch->dev, "%s: ch_%d: unexpected UART command 0x%02x\n",
+				     __func__, ch->ch_id, cmd);
+		lstp_send_irq_resp(ch, LSTP_NOT_SUPP);
+		return;
+	}
+
+	room = tty_buffer_request_room(&ctx->port, need_room);
+	if (room < need_room) {
+		ctx->iocount.buf_overrun++;
+		status = LSTP_NACK;
+	} else {
+		if (have_break) {
+			ctx->iocount.brk++;
+			tty_insert_flip_char(&ctx->port, 0, TTY_BREAK);
+		}
+		if (rx_len) {
+			tty_insert_flip_string(&ctx->port, pkt->payload, rx_len);
+			ctx->iocount.rx += rx_len;
+		}
+		tty_flip_buffer_push(&ctx->port);
+	}
+
+	if (tx_overrun) {
+		ctx->iocount.overrun++;
+		dev_warn_ratelimited(ch->dev,
+				     "%s: ch_%d: RX overrun on link (firmware dropped bytes)\n",
+				     __func__, ch->ch_id);
+	}
+
+	if (carrier_down) {
+		ctx->iocount.dcd++;
+		/* Honors CLOCAL: no-op when userspace asked to ignore carrier. */
+		tty_port_tty_hangup(&ctx->port, true);
+	}
+
+	lstp_send_irq_resp(ch, status);
+}
+
+/*****************************************************************************
+ * TTY port operations
+ *****************************************************************************/
+
+static int lstp_port_activate(struct tty_port *port, struct tty_struct *tty)
+{
+	struct lstp_uart_ctx *ctx = container_of(port, struct lstp_uart_ctx, port);
+
+	tty->termios.c_cflag = ctx->hw_cflag;
+	tty->termios.c_iflag = ctx->hw_iflag;
+
+	/* Let N_TTY pass large writes through instead of byte-at-a-time. */
+	set_bit(TTY_NO_WRITE_SPLIT, &tty->flags);
+	return 0;
+}
+
+static void lstp_port_shutdown(struct tty_port *port)
+{
+	struct lstp_uart_ctx *ctx = container_of(port, struct lstp_uart_ctx, port);
+
+	cancel_work_sync(&ctx->write_work);
+}
+
+static void lstp_port_destruct(struct tty_port *port)
+{
+	struct lstp_uart_ctx *ctx = container_of(port, struct lstp_uart_ctx, port);
+
+	if (ctx->minor >= 0) {
+		scoped_guard(mutex, &lstp_minors_lock)
+			xa_erase(&lstp_minors, ctx->minor);
+	}
+	kfree(ctx->tx_snapshot);
+	kfree(ctx->coal_buf);
+	kfree(ctx);
+}
+
+static const struct tty_port_operations lstp_port_ops = {
+	.activate = lstp_port_activate,
+	.shutdown = lstp_port_shutdown,
+	.destruct = lstp_port_destruct,
+};
+
+/*****************************************************************************
+ * TTY operations
+ *****************************************************************************/
+
+static int lstp_tty_install(struct tty_driver *driver, struct tty_struct *tty)
+{
+	struct lstp_channel *ch = lstp_get_by_minor(tty->index);
+	struct lstp_uart_ctx *ctx;
+	int ret;
+
+	if (!ch)
+		return -ENODEV;
+
+	ctx = ch->priv;
+	ret = tty_standard_install(driver, tty);
+	if (ret) {
+		tty_port_put(&ctx->port);
+		return ret;
+	}
+
+	tty->driver_data = ch;
+	return 0;
+}
+
+static int lstp_tty_open(struct tty_struct *tty, struct file *filp)
+{
+	return tty_port_open(tty->port, tty, filp);
+}
+
+static void lstp_tty_close(struct tty_struct *tty, struct file *filp)
+{
+	tty_port_close(tty->port, tty, filp);
+}
+
+static void lstp_tty_hangup(struct tty_struct *tty)
+{
+	tty_port_hangup(tty->port);
+}
+
+static void lstp_tty_cleanup(struct tty_struct *tty)
+{
+	tty_port_put(tty->port);
+}
+
+static ssize_t lstp_tty_write(struct tty_struct *tty, const unsigned char *buf, size_t count)
+{
+	struct lstp_channel *ch = tty->driver_data;
+	struct lstp_uart_ctx *ctx = ch->priv;
+	size_t room;
+
+	if (!count)
+		return 0;
+
+	guard(spinlock_irqsave)(&ctx->write_lock);
+
+	if (lstp_channel_disconnected(ch))
+		return -EIO;
+
+	room = ctx->max_payload - ctx->coal_len;
+	if (!room)
+		return 0;
+
+	count = min(count, room);
+	memcpy(ctx->coal_buf + ctx->coal_len, buf, count);
+	ctx->coal_len += count;
+
+	schedule_work(&ctx->write_work);
+
+	return count;
+}
+
+static unsigned int lstp_tty_write_room(struct tty_struct *tty)
+{
+	struct lstp_channel *ch = tty->driver_data;
+	struct lstp_uart_ctx *ctx = ch->priv;
+
+	guard(spinlock_irqsave)(&ctx->write_lock);
+
+	if (lstp_channel_disconnected(ch))
+		return 0;
+	return ctx->max_payload - ctx->coal_len;
+}
+
+static unsigned int lstp_tty_chars_in_buffer(struct tty_struct *tty)
+{
+	struct lstp_channel *ch = tty->driver_data;
+	struct lstp_uart_ctx *ctx = ch->priv;
+	unsigned int count;
+
+	guard(spinlock_irqsave)(&ctx->write_lock);
+
+	if (lstp_channel_disconnected(ch))
+		return 0;
+	count = ctx->coal_len;
+	if (ctx->tx_in_flight)
+		count += ctx->tx_inflight_len;
+	return count;
+}
+
+static void lstp_tty_flush_buffer(struct tty_struct *tty)
+{
+	struct lstp_channel *ch = tty->driver_data;
+	struct lstp_uart_ctx *ctx = ch->priv;
+
+	scoped_guard(spinlock_irqsave, &ctx->write_lock)
+		ctx->coal_len = 0;
+	/* Does not cancel an already in-flight TX. */
+	cancel_work(&ctx->write_work);
+}
+
+/*
+ * Firmware config is fixed; preserve hw-set bits on userspace stty.
+ *
+ * tty_termios_copy_hw() restores c_cflag hardware bits and speeds
+ * but leaves c_iflag untouched — restore flow-control bits manually.
+ */
+static void lstp_tty_set_termios(struct tty_struct *tty, const struct ktermios *old_termios)
+{
+	struct lstp_channel *ch = tty->driver_data;
+	struct lstp_uart_ctx *ctx = ch->priv;
+
+	tty_termios_copy_hw(&tty->termios, old_termios);
+
+	/* XON/XOFF is a hardware property of the link — don't let stty change it. */
+	tty->termios.c_iflag &= ~(IXON | IXOFF | IXANY);
+	tty->termios.c_iflag |= ctx->hw_iflag & (IXON | IXOFF | IXANY);
+}
+
+/*
+ * Firmware fires a fixed-duration break; continuous-break semantics
+ * collapse to "fire on any non-zero state" (matching cdc-acm / ftdi_sio).
+ */
+static int lstp_tty_break_ctl(struct tty_struct *tty, int state)
+{
+	struct lstp_channel *ch = tty->driver_data;
+	struct lstp_uart_ctx *ctx = ch->priv;
+
+	if (!state)
+		return 0;
+
+	return lstp_uart_send_with_retry(ctx, LSTP_UART_CMD_WRITE | LSTP_UART_TAG_GEN_BREAK, NULL,
+					 0);
+}
+
+static int lstp_tty_get_icount(struct tty_struct *tty, struct serial_icounter_struct *icount)
+{
+	struct lstp_channel *ch = tty->driver_data;
+	struct lstp_uart_ctx *ctx = ch->priv;
+
+	*icount = ctx->iocount;
+	return 0;
+}
+
+static const struct tty_operations lstp_ops = {
+	.install = lstp_tty_install,
+	.open = lstp_tty_open,
+	.close = lstp_tty_close,
+	.cleanup = lstp_tty_cleanup,
+	.hangup = lstp_tty_hangup,
+	.write = lstp_tty_write,
+	.write_room = lstp_tty_write_room,
+	.chars_in_buffer = lstp_tty_chars_in_buffer,
+	.flush_buffer = lstp_tty_flush_buffer,
+	.set_termios = lstp_tty_set_termios,
+	.break_ctl = lstp_tty_break_ctl,
+	.get_icount = lstp_tty_get_icount,
+};
+
+/*****************************************************************************
+ * Device lifecycle
+ *****************************************************************************/
+
+static void lstp_uart_port_put(void *data)
+{
+	tty_port_put(data);
+}
+
+/**
+ * lstp_uart_init() - Initialize an LSTP UART channel.
+ * @ch:   LSTP channel to initialize as UART
+ * @info: config blob (struct lstp_uart_config)
+ *
+ * Sets up the tty_port, coalescing buffer, and minor number.
+ *
+ * Context: Process context. Called during probe before RX URB is active.
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_uart_init(struct lstp_channel *ch, const struct lstp_channel_init_info *info)
+{
+	struct lstp_uart_ctx *ctx;
+	int ret;
+
+	if (info->config_len < sizeof(struct lstp_uart_config)) {
+		dev_err(ch->dev, "%s: ch_%d: UART config too short: %zu < %zu\n", __func__,
+			ch->ch_id, info->config_len, sizeof(struct lstp_uart_config));
+		return -EINVAL;
+	}
+
+	ctx = kzalloc_obj(*ctx);
+	if (!ctx)
+		return -ENOMEM;
+
+	tty_port_init(&ctx->port);
+	ctx->port.ops = &lstp_port_ops;
+	ctx->minor = -1;
+	ctx->max_payload = ch->max_tx_payload;
+	spin_lock_init(&ctx->write_lock);
+
+	ret = devm_add_action_or_reset(ch->dev, lstp_uart_port_put, &ctx->port);
+	if (ret)
+		return ret;
+
+	ret = lstp_uart_parse_config(ctx, ch, info->config);
+	if (ret)
+		return ret;
+
+	ctx->coal_buf = kzalloc(ctx->max_payload, GFP_KERNEL);
+	if (!ctx->coal_buf)
+		return -ENOMEM;
+
+	ctx->tx_snapshot = kzalloc(ctx->max_payload, GFP_KERNEL);
+	if (!ctx->tx_snapshot)
+		return -ENOMEM;
+
+	ret = lstp_alloc_minor(ch);
+	if (ret < 0) {
+		dev_err(ch->dev, "%s: ch_%d: Failed to allocate minor (%pe)\n", __func__, ch->ch_id,
+			ERR_PTR(ret));
+		return ret;
+	}
+	ctx->minor = ret;
+
+	INIT_WORK(&ctx->write_work, lstp_uart_write_work);
+	ctx->ch = ch;
+	ch->priv = ctx;
+
+	dev_info(ch->dev, "%s: ch_%d: Initialized\n", __func__, ch->ch_id);
+	return 0;
+}
+
+/**
+ * lstp_uart_start() - Register the TTY device for an LSTP UART channel.
+ * @ch: LSTP channel (must have been successfully initialized)
+ *
+ * Context: Process context. Called during probe after RX URB is active.
+ * Return: 0 on success, negative errno on failure.
+ */
+static int lstp_uart_start(struct lstp_channel *ch)
+{
+	struct lstp_uart_ctx *ctx = ch->priv;
+	struct device *tty_dev;
+
+	tty_dev = tty_port_register_device(&ctx->port, lstp_tty_driver, ctx->minor, ch->dev);
+	if (IS_ERR(tty_dev)) {
+		dev_err(ch->dev, "%s: ch_%d: Failed to register TTY (%pe)\n", __func__, ch->ch_id,
+			tty_dev);
+		return PTR_ERR(tty_dev);
+	}
+
+	if (ch->fwnode)
+		device_set_node(tty_dev, ch->fwnode);
+
+	deprecated_lstp_channel_publish_child_dev(ch, tty_dev);
+
+	dev_info(ch->dev, "%s: ch_%d: Started as %s\n", __func__, ch->ch_id, ch->display_name);
+	return 0;
+}
+
+/**
+ * lstp_uart_stop() - Hang up the tty and unregister the device node.
+ * @ch: LSTP channel previously started by lstp_uart_start()
+ *
+ * ctx/coal_buf/minor are released later via the devres-registered
+ * tty_port_put() once the tty layer drops its last reference.
+ */
+static void lstp_uart_stop(struct lstp_channel *ch)
+{
+	struct lstp_uart_ctx *ctx = ch->priv;
+	struct tty_struct *tty;
+
+	tty = tty_port_tty_get(&ctx->port);
+	if (tty) {
+		/*
+		 * Synchronously quiesces the tty: blocks new userspace writes,
+		 * waits for in-flight ones, and runs lstp_port_shutdown() which
+		 * drains ctx->write_work. After this no further write
+		 * submissions can outrun teardown.
+		 */
+		tty_vhangup(tty);
+		tty_kref_put(tty);
+	}
+
+	tty_unregister_device(lstp_tty_driver, ctx->minor);
+}
+
+/*****************************************************************************
+ * Module-level TTY driver registration
+ *****************************************************************************/
+
+static int __init lstp_uart_driver_init(void)
+{
+	int ret;
+
+	lstp_tty_driver =
+		tty_alloc_driver(LSTP_UART_MINORS, TTY_DRIVER_REAL_RAW | TTY_DRIVER_DYNAMIC_DEV);
+	if (IS_ERR(lstp_tty_driver))
+		return PTR_ERR(lstp_tty_driver);
+
+	lstp_tty_driver->driver_name = "lstp";
+	lstp_tty_driver->name = "ttyLSTP";
+	lstp_tty_driver->major = 0;
+	lstp_tty_driver->minor_start = 0;
+	lstp_tty_driver->type = TTY_DRIVER_TYPE_SERIAL;
+	lstp_tty_driver->subtype = SERIAL_TYPE_NORMAL;
+	lstp_tty_driver->init_termios = tty_std_termios;
+	/* Overridden per-device in port_activate; this is the visible default. */
+	lstp_tty_driver->init_termios.c_cflag = B115200 | CS8 | CREAD | HUPCL | CLOCAL;
+	tty_set_operations(lstp_tty_driver, &lstp_ops);
+
+	ret = tty_register_driver(lstp_tty_driver);
+	if (ret) {
+		tty_driver_kref_put(lstp_tty_driver);
+		return ret;
+	}
+
+	return 0;
+}
+
+static void lstp_uart_driver_exit(void)
+{
+	tty_unregister_driver(lstp_tty_driver);
+	tty_driver_kref_put(lstp_tty_driver);
+	xa_destroy(&lstp_minors);
+}
+
+/* clang-format off */
+LSTP_SUBSYS(uart, LSTP_CHANNEL_TYPE_UART, lstp_uart_init, lstp_uart_start,
+	    .fwnode_compatible = "nvidia,lstp-uart",
+	    .irq_callback = lstp_uart_irq_callback,
+	    .channel_stop = lstp_uart_stop,
+	    .init = lstp_uart_driver_init,
+	    .exit = lstp_uart_driver_exit,
+);
+/* clang-format on */


### PR DESCRIPTION
## Summary

- import the LSTP USB multi-function driver from the public [`NVIDIA/lstp_module`](https://github.com/NVIDIA/lstp_module) source at commit [`a91dee07c285`](https://github.com/NVIDIA/lstp_module/commit/a91dee07c285a22139f17533049b2924c1fbf045)
- adapt the out-of-tree source to the Linux 7.0 in-tree GPIO, I2C, allocation, and xarray APIs
- carry the firmware-provided I2C retry policy and combined SMBus block-read fix included in the public source
- integrate `lstp.ko` under `drivers/usb/misc/`
- enable `CONFIG_USB_LSTP=m` for amd64 and arm64 NVIDIA BOS flavours
- enable automatic spidev creation for SPI channels without firmware-described children
- keep separate IPMI POST-code routing disabled by default

## Motivation

The temporary DKMS delivery works for image enablement, but carrying LSTP in NV-Kernels lets the normal kernel packaging and signing pipeline produce a module that supports Secure Boot.

Platform software requires the LSTP SPI channels to expose spidev children, so `CONFIG_USB_LSTP_SPI_SPIDEV=y` enables this behavior without a separate modprobe configuration file.

This is the `26.04_linux-nvidia-bos` companion to standard-kernel PR [#530](https://github.com/NVIDIA/NV-Kernels/pull/530).

BugLink: https://jirasw.nvidia.com/browse/DGX-17400

## Source and scope

The driver is based on public [`NVIDIA/lstp_module`](https://github.com/NVIDIA/lstp_module) commit [`a91dee07c285a22139f17533049b2924c1fbf045`](https://github.com/NVIDIA/lstp_module/commit/a91dee07c285a22139f17533049b2924c1fbf045). That snapshot includes the firmware-provided I2C retry policy and the combined userspace SMBus block-read fix. The in-tree copy adds the documented Linux 7.0 API adaptations and the follow-up fixes carried as separate commits in this PR.

Out-of-tree packaging, CI, README, specification PDFs, and other repository-local files are not imported.

Device-tree schemas remain omitted because the public copies still need kernel-tree `$id` and `maintainers` normalization. They can follow with the upstream-oriented patch series.

The source exposes USB vendor ID `0x0955`. The previously tested DKMS snapshot also exposed `0x0424`; the LSTP owners should confirm whether that second alias is approved and required before this draft is marked ready.

## Validation

- rebased onto the current `26.04_linux-nvidia-bos` tip
- `git diff --check`: pass
- compared the imported source with public commit `a91dee07c285`; unchanged files match byte-for-byte and the remaining deltas are the documented Linux 7.0 GPIO, I2C, allocation, and xarray API adaptations
- `scripts/checkpatch.pl --strict` for the latest sync: 0 errors, 0 warnings, 0 checks
- amd64 BOS config resolves `CONFIG_USB_LSTP=m` with the required USB, I2C, SPI, GPIO, LED, and TTY dependencies enabled
- x86_64: all seven LSTP objects compile with `W=1` against the PR's Linux 7.0 tree
- arm64: LSTP compiled natively against `7.0.0-2015-nvidia-bos-64k`
- arm64 runtime: temporarily removed the DKMS shadow, confirmed `modinfo -n lstp` selected `/lib/modules/7.0.0-2015-nvidia-bos-64k/kernel/drivers/usb/misc/lstp/lstp.ko`, and ran `modprobe lstp` successfully
- runtime evidence: `lsmod` showed `lstp`; dmesg recorded `usbcore: registered new interface driver lstp`; taint remained unchanged (`12288` before and after)
- config annotations resolve `CONFIG_USB_LSTP=m` and `CONFIG_USB_LSTP_SPI_SPIDEV=y` for amd64, arm64, and arm64-64k BOS flavours

The arm64 runtime test predates the two I2C-only source updates. A refreshed kernel package build and I2C functional test remain required. The BOS configuration already has `CONFIG_MODULE_SIG=y` and `CONFIG_MODULE_SIG_ALL=y`; CI/package output will verify the production signature.
