### PR TITLE
[26.04_linux-nvidia-bos]: Backport "mm/gup: fix GUP-fast fallback for NULL-mapping order-0 folios"

### DIFF
--- a/mm/gup.c
+++ b/mm/gup.c
@@ -2784,12 +2784,17 @@ static bool gup_fast_folio_allowed(struct folio *folio, unsigned int flags)
 	mapping = READ_ONCE(folio->mapping);
 
 	/*
-	 * The mapping may have been truncated, in any case we cannot determine
-	 * if this mapping is safe - fall back to slow path to determine how to
-	 * proceed.
+	 * If the mapping is NULL (truncated, or never set), we cannot
+	 * determine whether the folio is file-backed, so a long-term writable
+	 * pin must fall back to the slow path.
+	 *
+	 * Otherwise, a NULL mapping proves this is not a secretmem folio
+	 * (secretmem folios always have a valid mapping to the secretmem
+	 * inode's address_space), so in that case, we can continue with the
+	 * fast path.
 	 */
 	if (!mapping)
-		return false;
+		return !reject_file_backed;
 
 	/* Anonymous folios pose no problem. */
 	mapping_flags = (unsigned long)mapping & FOLIO_MAPPING_FLAGS;


### PR DESCRIPTION
Target: `26.04_linux-nvidia-bos` · Topic: `jamien/7.0-bos/gup-fast-null-mapping` · Base: `bc44def90522c`

Clean cherry-pick from linux-next:

```
(cherry picked from commit ae75e88d8c258fd849de594e7d468b5263e7b3e3 linux-next)
```

John Hubbard, Acked-by David Hildenbrand, applied by Andrew Morton.
[Lore thread](https://lore.kernel.org/all/20260708005745.164928-1-jhubbard@nvidia.com/).

`-bos` counterpart of the same pick against `26.04_linux-nvidia`. `mm/gup.c` is
byte-identical on both branches; split only to match the branch layout.

## Problem

`f002882ca369` (present on this branch) made `gup_fast_folio_allowed()` bail to the
slow path for *any* order-0 folio with a NULL `->mapping` when `CONFIG_SECRETMEM=y`.
Pages from `alloc_page()` + `vm_insert_page()` legitimately have a NULL mapping, so
every `pin_user_pages_fast()` over such a range misses the fast path — nvidia-fs
(GPUDirect Storage) allocates its shadow buffers exactly this way.

The NULL check was meant to catch truncated file-backed pages, not secretmem.
Secretmem folios are published via `filemap_add_folio()`, which always sets
`->mapping`, so a NULL mapping proves the folio is *not* secretmem. Returning
`!reject_file_backed` keeps long-term writable pins on the slow path and restores
the fast path otherwise — exactly the pre-`f002882ca369` behaviour.

`CONFIG_SECRETMEM=y` on amd64 and arm64, so this is live on every flavour we ship.

## Measurement (GH200, 288 cores)

A module reproducing the nvidia-fs pattern (`alloc_page` + `vm_insert_page`, then
`pin_user_pages_fast(..., FOLL_WRITE, ...)`), with an anonymous-memory control the
patch cannot affect. `get_user_pages_fast_only()` gives the GUP-fast verdict
directly: **0/N unpatched, N/N patched**.

Median ns/page, 512 pages/thread, 5 reps. All four kernels built from this branch,
differing only by this patch and page size:

| threads | 4K unpatched → patched | 64K unpatched → patched |
|--------:|-----------------------:|------------------------:|
| 1       | 34 → 34 (1.0x)         | 33 → 30 (1.1x)          |
| 8       | 74 → 33 (**2.2x**)     | 1920 → 31 (**62x**)     |
| 32      | 95 → 33 (**2.9x**)     | 4792 → 33 (**145x**)    |
| 128     | 500 → 218 (noisy)      | 16673 → 76 (**219x**)   |

We ship `nvidia-64k`, so the 64K column is the operationally relevant one. The anon
control held at 30-35 ns/page across all four kernels, so only the affected range
moved. Stock `7.0.0-1015-nvidia-64k` independently reproduces the unpatched 64K
numbers (8 threads: 1176 vs 37), so this isn't a test-config artefact.

Single-threaded it's a wash; the win is under concurrency. `perf` on the unpatched
64K kernel shows the slow path is ~90% lock contention (`queued_spin_lock_slowpath`
72%), gone entirely once patched — contention that scales with thread count, not a
fixed per-page cost.

## Risk

Low. One line in a static function with three callers, all in GUP-fast. Only
`reject_file_backed == false && check_secretmem && mapping == NULL` changes
behaviour; long-term writable pins are untouched.

A secretmem folio caught mid-truncate can't happen here: `secretmem_setattr()`
refuses to shrink, there's no `.fallocate` (so no punch-hole), and
`secretmem_migrate_folio()` returns `-EBUSY`. Only inode eviction remains, which
requires every VMA gone — no VMA, no PTE for GUP-fast to walk. Raised by David
Hildenbrand on v1 and resolved before he Acked.

## Testing

Applies cleanly; built arm64 4K/64K and x86_64, no new warnings; verified in the
binary (unpatched `mov w0, #0x0` vs patched `eor w0, w0, #0x1`); benchmarked as
above, booting all four kernels.

## Bugs

nvbug: 6064778
LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-7.0/+bug/2162917