### PR TITLE
[26.04_linux-nvidia] Backport removal of extra ISBs when using msr_hcr_el2

### DIFF
--- a/arch/arm64/include/asm/el2_setup.h
+++ b/arch/arm64/include/asm/el2_setup.h
@@ -50,7 +50,6 @@
 	 * effectively VHE-only or not.
 	 */
 	msr_hcr_el2 x0		// Setup HCR_EL2 as nVHE
-	isb
 	mov	x1, #1		// Write something to FAR_EL1
 	msr	far_el1, x1
 	isb
@@ -64,7 +63,6 @@
 .LnE2H0_\@:
 	orr	x0, x0, #HCR_E2H
 	msr_hcr_el2 x0
-	isb
 .LnVHE_\@:
 .endm
 

--- a/arch/arm64/include/asm/sysreg.h
+++ b/arch/arm64/include/asm/sysreg.h
@@ -1114,11 +1114,9 @@
 	.macro	msr_hcr_el2, reg
 #if IS_ENABLED(CONFIG_AMPERE_ERRATUM_AC04_CPU_23)
 	dsb	nsh
-	msr	hcr_el2, \reg
-	isb
-#else
-	msr	hcr_el2, \reg
 #endif
+	msr	hcr_el2, \reg
+	isb			// Required by AMPERE_ERRATUM_AC04_CPU_23
 	.endm
 #else
 

--- a/arch/arm64/kernel/hyp-stub.S
+++ b/arch/arm64/kernel/hyp-stub.S
@@ -103,7 +103,6 @@ SYM_CODE_START_LOCAL(__finalise_el2)
 	// Engage the VHE magic!
 	mov_q	x0, HCR_HOST_VHE_FLAGS
 	msr_hcr_el2 x0
-	isb
 
 	// Use the EL1 allocated stack, per-cpu offset
 	mrs	x0, sp_el1

--- a/arch/arm64/kvm/hyp/nvhe/host.S
+++ b/arch/arm64/kvm/hyp/nvhe/host.S
@@ -125,7 +125,6 @@ SYM_FUNC_START(__hyp_do_panic)
 	mrs	x0, hcr_el2
 	bic	x0, x0, #HCR_VM
 	msr_hcr_el2 x0
-	isb
 	tlbi	vmalls12e1
 	dsb	nsh
 #endif


### PR DESCRIPTION
Backport of [54a3cc145456272b10c1452fe89e1dcf933d5c39](https://github.com/torvalds/linux/commit/54a3cc145456272b10c1452fe89e1dcf933d5c39), which removes redundant ISBs after msr_hcr_el2, so HCR_EL2 writes do one barrier instead of two and run a bit faster. Verified that patch is present in kernel using [check-hcr-isb.sh](https://github.com/user-attachments/files/30835475/check-hcr-isb.sh).

Script output:

```
kernel  : 7.0.12+  (running: 7.0.12+)
image   : /boot/vmlinuz-7.0.12+
symbols : /boot/System.map-7.0.12+
erratum : CONFIG_AMPERE_ERRATUM_AC04_CPU_23=y
note    : commit landed in v7.1-rc1; no Cc: stable, so no -stable backport

zstd: /*stdin*\: unsupported format 
image format: compressed Image  (73728000 bytes flat)
_text       : 0xffff800080000000

=== sites generated by the msr_hcr_el2 assembly macro (what the patch touches) ===
vaddr              symbol                                     prev      instr            next      next+1      pattern
--------------------------------------------------------------------------------------------------------------------------------------
0xffff800081a40be0 __kvm_nvhe____kvm_hyp_init+0x18            dsb nsh   msr hcr_el2,x1   isb       0xd2c00082  single-isb
0xffff800081a40cd0 __kvm_nvhe___kvm_hyp_init_cpu+0x40         dsb nsh   msr hcr_el2,x0   isb       0xd2800021  single-isb
0xffff800081a40d04 __kvm_nvhe___kvm_hyp_init_cpu+0x74         dsb nsh   msr hcr_el2,x0   isb       0x97fffead  single-isb
0xffff800081a41ad8 __finalise_el2+0x278                       dsb nsh   msr hcr_el2,x0   isb       0xd53c4100  single-isb
0xffff800082e111a4 init_el2+0x58                              dsb nsh   msr hcr_el2,x0   isb       0xd2800021  single-isb
0xffff800082e111d8 init_el2+0x8c                              dsb nsh   msr hcr_el2,x0   isb       0xd2a00000  single-isb

=== other HCR_EL2 writes: C write_sysreg_hcr(), NOT touched by this patch ===
38 sites (5 of them double-isb) -- expected noise, ignore for the verdict

======================================================================================================================================
CONFIG_AMPERE_ERRATUM_AC04_CPU_23=y -> signature is the double ISB
RESULT: commit 54a3cc145456 IS PRESENT (0/6 macro sites have back-to-back ISBs)
======================================================================================================================================
```

Launchpad: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-bos/+bug/2163052