### PR TITLE
[26.04_linux-nvidia] Backport devlink external flag exposition

### DIFF
--- a/net/devlink/port.c
+++ b/net/devlink/port.c
@@ -266,6 +266,8 @@ static int devlink_nl_port_attrs_put(struct sk_buff *msg,
 		    nla_put_u32(msg, DEVLINK_ATTR_PORT_PCI_SF_NUMBER,
 				attrs->pci_sf.sf))
 			return -EMSGSIZE;
+		if (nla_put_u8(msg, DEVLINK_ATTR_PORT_EXTERNAL, attrs->pci_sf.external))
+			return -EMSGSIZE;
 		break;
 	case DEVLINK_PORT_FLAVOUR_PHYSICAL:
 	case DEVLINK_PORT_FLAVOUR_CPU:


### PR DESCRIPTION
Backport the following change to the linux-nvidia kernel:

cb59bfd419d0c devlink: Expose external flag for PCI SF ports (net-next)

This flag is needed by the mlnx-sf tool that is part of ofed's mlnx-tools package.

NVBug: https://nvbugspro.nvidia.com/bug/6579497
LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia/+bug/2163274