### PR TITLE
[26.04_linux-nvidia-bos] vfio/cxl: include <linux/bitfield.h> for FIELD_GET

### DIFF
--- a/drivers/vfio/pci/cxl/vfio_cxl_core.c
+++ b/drivers/vfio/pci/cxl/vfio_cxl_core.c
@@ -13,6 +13,7 @@
  * CXL subsystem and require direct DPA region access from the guest.
  */
 
+#include <linux/bitfield.h>
 #include <linux/vfio_pci_core.h>
 #include <linux/pci.h>
 #include <cxl/cxl.h>


### PR DESCRIPTION
## Summary

Fixes an **amd64 build break** in the merged CXL VFIO Type-2 passthrough v2 series:
`drivers/vfio/pci/cxl/vfio_cxl_core.c` uses `FIELD_GET()` without including
`<linux/bitfield.h>`. Adds the missing include.

## The failure

On amd64 (`resolute:linux-nvidia-bos`), the build fails with:

```
drivers/vfio/pci/cxl/vfio_cxl_core.c:267:14: error: implicit declaration of function 'FIELD_GET' [-Wimplicit-function-declaration]
```

## Root cause

`vfio_cxl_core.c` calls `FIELD_GET()` (to decode the CXL DVSEC capability
register) but never includes `<linux/bitfield.h>`, where that macro is defined.
It compiled only because of an **architecture-dependent transitive include**:

- On **arm64**, `<linux/bitfield.h>` is pulled in indirectly via
  `linux/slab.h -> linux/cache.h -> arch/arm64/include/asm/cache.h ->
  asm/cputype.h -> asm/sysreg.h`, and arm64's `asm/sysreg.h` includes
  `<linux/bitfield.h>`.
- On **amd64** that arm64-only header chain does not exist, so `FIELD_GET`
  is undefined and the build fails.

The nvidia-bos kernel is built for both amd64 and arm64
(`CONFIG_VFIO_CXL_CORE=y` on both), so the file must not rely on any one
architecture's transitive include graph.

## Fix

Add `#include <linux/bitfield.h>` directly to `vfio_cxl_core.c`
(include-what-you-use), making the file architecture-independent.

## Scope

- This is only needed for the **v2** posting of the CXL VFIO Type-2 passthrough
  series (commit `3570209d539a`). **v3 and later** of that upstream series
  already include `<linux/bitfield.h>` in this file directly, so the change
  becomes redundant and drops out naturally once the tree moves to v3+.

Fixes: 3570209d539a ("NVIDIA: VR: SAUCE: vfio/cxl: Virtualize CXL DVSEC config writes")

LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-bos/+bug/2163376