### PR TITLE
BaseOS Reviewer dual-architecture build smoke test

### DIFF
--- a/Documentation/baseos-reviewer-build-smoke-test.txt
+++ b/Documentation/baseos-reviewer-build-smoke-test.txt
@@ -1,0 +1,5 @@
+BaseOS Reviewer dual-architecture build smoke test
+==================================================
+
+This temporary documentation-only change exercises the automated ARM64 and
+amd64 kernel package builders. The pull request is not intended to be merged.


### PR DESCRIPTION
## Purpose

Exercise the production BaseOS Reviewer pipeline and verify native ARM64 and amd64 kernel package builds.

## Change

Adds a documentation-only smoke-test marker. There is no kernel code change.

## Validation

- BaseOS Reviewer Boro review: pending
- ARM64 kernel package build: pending
- amd64 kernel package build: pending

This replaces #545, whose `github-actions` base does not contain kernel build configuration. This PR targets the active `26.04_linux-nvidia-bos` kernel branch.

This is a temporary test PR. **Do not merge.** It will be closed after both build paths are validated.
