### PR TITLE
test: validate BaseOS Reviewer progress comment

### DIFF
--- a/Documentation/baseos-reviewer-canary.txt
+++ b/Documentation/baseos-reviewer-canary.txt
@@ -1,0 +1,7 @@
+BaseOS Reviewer progress-comment canary
+=======================================
+
+This temporary draft-PR change validates that BaseOS Reviewer creates its
+maintained GitHub comment as soon as a review is queued, before Boro finishes.
+
+This file is test-only and is not intended to be merged.


### PR DESCRIPTION
Temporary draft canary for BaseOS Reviewer. Do not merge.

Expected behavior:
- The maintained comment appears as soon as the watcher queues this PR.
- It shows the Boro review as in progress before Boro finishes.
- The same comment is updated with final review and build results.