### PR TITLE
[26.04_linux-nvidia]: Backport: "block: check bio split for unaligned bvec"

### DIFF
--- a/block/blk.h
+++ b/block/blk.h
@@ -407,6 +407,8 @@ static inline bool bio_may_need_split(struct bio *bio,
 	bv = __bvec_iter_bvec(bio->bi_io_vec, bio->bi_iter);
 	if (bio->bi_iter.bi_size > bv->bv_len - bio->bi_iter.bi_bvec_done)
 		return true;
+	if ((bv->bv_offset | bv->bv_len) & lim->dma_alignment)
+		return true;
 	return bv->bv_len + bv->bv_offset > lim->max_fast_segment_size;
 }
 


### PR DESCRIPTION
Clean cherry-pick of mainline 9b0c3673c885 ("block: check bio split for
unaligned bvec", v7.2-rc1) - block/blk.h | 2 ++

Fixes LTP dio04/dio10 on -64k, where a misaligned O_DIRECT buffer returns EIO
instead of EINVAL. Regression from 7eac33186957 / 5ff3f74e145a (v6.18-rc1);
4K kernels are unaffected. No Cc: stable upstream, so it will not reach 7.0.y
on its own.

Verified on 7.0.0-1015-nvidia-64k: dio04/dio10 fail on stock, pass with the
fix, and fail again on a control build with only these two lines reverted.
All 30 LTP dio cases pass.

Target: 26.04_linux-nvidia @ c8ca6b82aeb7c
Topic:  jamien/7.0/block-unaligned-bvec

LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia-bos/+bug/2165055