### PR TITLE
[26.04_linux-nvidia] NVIDIA: SAUCE: ASoC: sdw_utils: clear stale device references in exit hooks

### DIFF
--- a/sound/soc/sdw_utils/soc_sdw_rt711.c
+++ b/sound/soc/sdw_utils/soc_sdw_rt711.c
@@ -124,6 +124,7 @@ int asoc_sdw_rt711_exit(struct snd_soc_card *card, struct snd_soc_dai_link *dai_
 
 	device_remove_software_node(ctx->headset_codec_dev);
 	put_device(ctx->headset_codec_dev);
+	ctx->headset_codec_dev = NULL;
 
 	return 0;
 }

--- a/sound/soc/sdw_utils/soc_sdw_rt_amp.c
+++ b/sound/soc/sdw_utils/soc_sdw_rt_amp.c
@@ -252,11 +252,13 @@ int asoc_sdw_rt_amp_exit(struct snd_soc_card *card, struct snd_soc_dai_link *dai
 	if (ctx->amp_dev1) {
 		device_remove_software_node(ctx->amp_dev1);
 		put_device(ctx->amp_dev1);
+		ctx->amp_dev1 = NULL;
 	}
 
 	if (ctx->amp_dev2) {
 		device_remove_software_node(ctx->amp_dev2);
 		put_device(ctx->amp_dev2);
+		ctx->amp_dev2 = NULL;
 	}
 
 	return 0;


### PR DESCRIPTION
asoc_sdw_rt_amp_exit() drops the references held in ctx->amp_dev1 and ctx->amp_dev2, but leaves the pointers populated. If the card cleanup path runs the exit hook more than once, the same device references are dropped again, which can underflow the device refcount and leave stale pointers for later SoundWire bus walks.

In practice this can show up as refcount underflow warnings followed by an oops when later probe, driver bind, or suspend paths walk the SoundWire bus and touch the freed device.

This first part is fixed upstream via change 046173b98de316211b81d9909cde81ca582604a8

Clear the amplifier device pointers after put_device(), matching the idempotent pattern already used by the RT SDCA jack cleanup path. Do the same for the RT711 headset codec device pointer.

This second part is covered through second patch under this PR. 

This makes the exit hooks safe to call after deferred or failed card probe paths and avoids stale device references being reused after cleanup.

This is tracked in internal bug 6290103

LP: https://bugs.launchpad.net/ubuntu/+source/linux-nvidia/+bug/2166188