### PR TITLE
ci: enable PR validation for 24.04_linux-nvidia

### DIFF
--- a/.github/workflows/patchscan.yml
+++ b/.github/workflows/patchscan.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, edited]
     branches:
+      - 24.04_linux-nvidia
       - 24.04_linux-nvidia-6.17-next
       - 26.04_linux-nvidia-bos
       - 26.04_linux-nvidia


### PR DESCRIPTION
PRs targeting `24.04_linux-nvidia`, including #581, do not trigger PR Validation because the branch is absent from the workflow's target branch list.

Add `24.04_linux-nvidia` so patchscan and PR lint run for the existing opened, synchronize, reopened, and edited events.

Validation: parsed the YAML and verified that the only semantic change is the added branch; `git diff --check` passed. Automatic triggering on the added branch remains to be verified after merge.
